### PR TITLE
MI-198: nx-serverless dependencies generators

### DIFF
--- a/packages/nx-serverless/README.md
+++ b/packages/nx-serverless/README.md
@@ -4,7 +4,7 @@ The `@aligent/nx-serverless` package provides Nx generators and plugin for serve
 
 ## Generators
 
-- We support the following types of generators: `init` and `service`
+- We support the following types of generators: `init`, `service`, `link` and `unlink`
 
 ### Init generator
 
@@ -45,6 +45,23 @@ The `@aligent/nx-serverless` package provides Nx generators and plugin for serve
 - To generate a notification service, run the command:
   ```bash
     nx generate @aligent/nx-serverless:service <service-name> notification
+  ```
+
+### Link generator
+
+- The Link generator is used to establish dependencies between projects in your workspace. It updates the `implicitDependencies` of the target projects to include the specified dependency projects.
+- This ensures that the target projects are aware of their dependencies, which can help in managing build and deployment workflows.
+- To use this generator, run the command and follow the prompt:
+  ```bash
+    nx generate @aligent/nx-serverless:link
+  ```
+
+### Unlink generator
+
+- The Unlink generator is used to remove dependencies between projects in your workspace. It updates the `implicitDependencies` of the target projects by removing the specified dependency projects.
+- To use this generator, run the command and follow the prompt:
+  ```bash
+    nx generate @aligent/nx-serverless:unlink
   ```
 
 ## Plugins

--- a/packages/nx-serverless/generators.json
+++ b/packages/nx-serverless/generators.json
@@ -9,6 +9,16 @@
             "factory": "./src/generators/init/generator",
             "schema": "./src/generators/init/schema.json",
             "description": "init generator"
+        },
+        "link": {
+            "factory": "./src/generators/link/generator",
+            "schema": "./src/generators/link/schema.json",
+            "description": "link generator"
+        },
+        "unlink": {
+            "factory": "./src/generators/unlink/generator",
+            "schema": "./src/generators/unlink/schema.json",
+            "description": "unlink generator"
         }
     }
 }

--- a/packages/nx-serverless/src/generators/link/generator.spec.ts
+++ b/packages/nx-serverless/src/generators/link/generator.spec.ts
@@ -1,0 +1,65 @@
+import { Tree, readProjectConfiguration } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+
+import { linkGenerator } from './generator';
+import { LinkGeneratorSchema } from './schema';
+
+describe('link generator', () => {
+    let tree: Tree;
+    const options: LinkGeneratorSchema = {
+        targets: ['projectA'],
+        dependencies: ['projectB', 'projectC'],
+    };
+
+    beforeEach(() => {
+        tree = createTreeWithEmptyWorkspace();
+
+        tree.write(
+            'projectA/project.json',
+            JSON.stringify({ name: 'projectA', implicitDependencies: [] })
+        );
+        tree.write('projectB/project.json', JSON.stringify({ name: 'projectB' }));
+        tree.write('projectC/project.json', JSON.stringify({ name: 'projectC' }));
+    });
+
+    it('should add dependencies to the target projects', async () => {
+        await linkGenerator(tree, options);
+
+        const projectAConfig = readProjectConfiguration(tree, 'projectA');
+        expect(projectAConfig.implicitDependencies).toEqual(['projectB', 'projectC']);
+    });
+
+    it('should not add circular dependencies', async () => {
+        const circularOptions: LinkGeneratorSchema = {
+            targets: ['projectA'],
+            dependencies: ['projectA', 'projectB'],
+        };
+
+        await linkGenerator(tree, circularOptions);
+
+        const projectAConfig = readProjectConfiguration(tree, 'projectA');
+        expect(projectAConfig.implicitDependencies).toEqual(['projectB']);
+    });
+
+    it('should throw an error if target projects do not exist', async () => {
+        const invalidOptions: LinkGeneratorSchema = {
+            targets: ['nonExistentProject'],
+            dependencies: ['projectB'],
+        };
+
+        await expect(linkGenerator(tree, invalidOptions)).rejects.toThrow(
+            'Projects nonExistentProject do not exist'
+        );
+    });
+
+    it('should throw an error if dependency projects do not exist', async () => {
+        const invalidOptions: LinkGeneratorSchema = {
+            targets: ['projectA'],
+            dependencies: ['nonExistentProject'],
+        };
+
+        await expect(linkGenerator(tree, invalidOptions)).rejects.toThrow(
+            'Projects nonExistentProject do not exist'
+        );
+    });
+});

--- a/packages/nx-serverless/src/generators/link/generator.spec.ts
+++ b/packages/nx-serverless/src/generators/link/generator.spec.ts
@@ -7,8 +7,8 @@ import { LinkGeneratorSchema } from './schema';
 describe('link generator', () => {
     let tree: Tree;
     const options: LinkGeneratorSchema = {
-        targets: ['projectA'],
-        dependencies: ['projectB', 'projectC'],
+        targets: 'projectA',
+        dependencies: 'projectB, projectC',
     };
 
     beforeEach(() => {
@@ -31,8 +31,8 @@ describe('link generator', () => {
 
     it('should not add circular dependencies', async () => {
         const circularOptions: LinkGeneratorSchema = {
-            targets: ['projectA'],
-            dependencies: ['projectA', 'projectB'],
+            targets: 'projectA',
+            dependencies: 'projectA, projectB',
         };
 
         await linkGenerator(tree, circularOptions);
@@ -43,8 +43,8 @@ describe('link generator', () => {
 
     it('should throw an error if target projects do not exist', async () => {
         const invalidOptions: LinkGeneratorSchema = {
-            targets: ['nonExistentProject'],
-            dependencies: ['projectB'],
+            targets: 'nonExistentProject',
+            dependencies: 'projectB',
         };
 
         await expect(linkGenerator(tree, invalidOptions)).rejects.toThrow(
@@ -54,8 +54,8 @@ describe('link generator', () => {
 
     it('should throw an error if dependency projects do not exist', async () => {
         const invalidOptions: LinkGeneratorSchema = {
-            targets: ['projectA'],
-            dependencies: ['nonExistentProject'],
+            targets: 'projectA',
+            dependencies: 'nonExistentProject',
         };
 
         await expect(linkGenerator(tree, invalidOptions)).rejects.toThrow(

--- a/packages/nx-serverless/src/generators/link/generator.ts
+++ b/packages/nx-serverless/src/generators/link/generator.ts
@@ -1,0 +1,54 @@
+import {
+    getProjects,
+    logger,
+    ProjectConfiguration,
+    Tree,
+    updateProjectConfiguration,
+} from '@nx/devkit';
+import { hasNonExistProject } from '../../helpers/projects';
+import { LinkGeneratorSchema } from './schema';
+
+/**
+ * Links the specified targets as dependencies of the given targets.
+ *
+ * This generator will throw errors if any of the specified targets or dependencies do not exist.
+ * It will then add the specified dependencies to the targets implicitDependencies list.
+ *
+ * @param {Tree} tree - The file system tree representing the current project.
+ * @param {LinkGeneratorSchema} options - The options passed to the generator, containing the targets and dependencies.
+ * @returns {Promise<void>} A promise that resolves when the generator has completed its task.
+ */
+export async function linkGenerator(tree: Tree, options: LinkGeneratorSchema): Promise<void> {
+    const { targets, dependencies } = options;
+    const projects = getProjects(tree);
+
+    const nonExistTargets = hasNonExistProject(projects, targets);
+    const nonExistDependencies = hasNonExistProject(projects, dependencies);
+
+    if (nonExistTargets.length || nonExistDependencies.length) {
+        throw new Error(
+            `Projects ${nonExistTargets.concat(nonExistDependencies).join(', ')} do not exist`
+        );
+    }
+
+    for (const target of targets) {
+        // This ensure we do not have circular dependencies
+        const implicitDependencies = dependencies.filter(dep => dep != target);
+
+        // We're 99% sure that target project exist so it's safe to cast type
+        const current = projects.get(target) as ProjectConfiguration;
+
+        updateProjectConfiguration(tree, target, {
+            ...current,
+            implicitDependencies: Array.from(
+                new Set((current.implicitDependencies || []).concat(implicitDependencies))
+            ),
+        });
+    }
+
+    logger.info(
+        `Successfully added ${dependencies.join(', ')} as dependencies of ${targets.join(', ')}`
+    );
+}
+
+export default linkGenerator;

--- a/packages/nx-serverless/src/generators/link/schema.d.ts
+++ b/packages/nx-serverless/src/generators/link/schema.d.ts
@@ -1,0 +1,4 @@
+export interface LinkGeneratorSchema {
+    targets: string[];
+    dependencies: string[];
+}

--- a/packages/nx-serverless/src/generators/link/schema.d.ts
+++ b/packages/nx-serverless/src/generators/link/schema.d.ts
@@ -1,4 +1,4 @@
 export interface LinkGeneratorSchema {
-    targets: string[];
-    dependencies: string[];
+    targets: string;
+    dependencies: string;
 }

--- a/packages/nx-serverless/src/generators/link/schema.json
+++ b/packages/nx-serverless/src/generators/link/schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://json-schema.org/schema",
+    "$id": "Link",
+    "title": "Add projects as implicit dependencies of other projects",
+    "type": "object",
+    "properties": {
+        "targets": {
+            "type": "array",
+            "description": "Names of the target projects",
+            "x-prompt": "What are the names of the targeted projects (comma separated)?"
+        },
+        "dependencies": {
+            "type": "array",
+            "description": "Names of the projects that depend on the target projects",
+            "x-prompt": "What are the names of the projects that depend on the target projects (comma separated)?"
+        }
+    },
+    "required": ["targets", "dependencies"]
+}

--- a/packages/nx-serverless/src/generators/link/schema.json
+++ b/packages/nx-serverless/src/generators/link/schema.json
@@ -5,12 +5,12 @@
     "type": "object",
     "properties": {
         "targets": {
-            "type": "array",
+            "type": "string",
             "description": "Names of the target projects",
             "x-prompt": "What are the names of the targeted projects (comma separated)?"
         },
         "dependencies": {
-            "type": "array",
+            "type": "string",
             "description": "Names of the projects that depend on the target projects",
             "x-prompt": "What are the names of the projects that depend on the target projects (comma separated)?"
         }

--- a/packages/nx-serverless/src/generators/unlink/generator.spec.ts
+++ b/packages/nx-serverless/src/generators/unlink/generator.spec.ts
@@ -7,8 +7,8 @@ import { UnlinkGeneratorSchema } from './schema';
 describe('unlinkGenerator', () => {
     let tree: Tree;
     const options: UnlinkGeneratorSchema = {
-        targets: ['projectA'],
-        dependencies: ['projectB', 'projectC'],
+        targets: 'projectA',
+        dependencies: 'projectB, projectC',
     };
 
     beforeEach(() => {
@@ -36,8 +36,8 @@ describe('unlinkGenerator', () => {
 
     it('should throw an error if target projects do not exist', async () => {
         const invalidOptions: UnlinkGeneratorSchema = {
-            targets: ['nonExistentProject'],
-            dependencies: ['projectB'],
+            targets: 'nonExistentProject',
+            dependencies: 'projectB',
         };
 
         await expect(unlinkGenerator(tree, invalidOptions)).rejects.toThrow(
@@ -47,8 +47,8 @@ describe('unlinkGenerator', () => {
 
     it('should throw an error if dependency projects do not exist', async () => {
         const invalidOptions: UnlinkGeneratorSchema = {
-            targets: ['projectA'],
-            dependencies: ['nonExistentProject'],
+            targets: 'projectA',
+            dependencies: 'nonExistentProject',
         };
 
         await expect(unlinkGenerator(tree, invalidOptions)).rejects.toThrow(
@@ -59,8 +59,8 @@ describe('unlinkGenerator', () => {
     it('should not throw an error if dependencies are not in the implicitDependencies list', async () => {
         tree.write('projectE/project.json', JSON.stringify({ name: 'projectE' }));
         const optionsWithNonExistentDependencies: UnlinkGeneratorSchema = {
-            targets: ['projectA'],
-            dependencies: ['projectE'],
+            targets: 'projectA',
+            dependencies: 'projectE',
         };
 
         await expect(

--- a/packages/nx-serverless/src/generators/unlink/generator.spec.ts
+++ b/packages/nx-serverless/src/generators/unlink/generator.spec.ts
@@ -1,0 +1,73 @@
+import { Tree, readProjectConfiguration } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+
+import { unlinkGenerator } from './generator';
+import { UnlinkGeneratorSchema } from './schema';
+
+describe('unlinkGenerator', () => {
+    let tree: Tree;
+    const options: UnlinkGeneratorSchema = {
+        targets: ['projectA'],
+        dependencies: ['projectB', 'projectC'],
+    };
+
+    beforeEach(() => {
+        tree = createTreeWithEmptyWorkspace();
+
+        // Add mock projects to the workspace
+        tree.write(
+            'projectA/project.json',
+            JSON.stringify({
+                name: 'projectA',
+                implicitDependencies: ['projectB', 'projectC', 'projectD'],
+            })
+        );
+        tree.write('projectB/project.json', JSON.stringify({ name: 'projectB' }));
+        tree.write('projectC/project.json', JSON.stringify({ name: 'projectC' }));
+        tree.write('projectD/project.json', JSON.stringify({ name: 'projectD' }));
+    });
+
+    it('should remove dependencies from the target projects', async () => {
+        await unlinkGenerator(tree, options);
+
+        const projectAConfig = readProjectConfiguration(tree, 'projectA');
+        expect(projectAConfig.implicitDependencies).toEqual(['projectD']);
+    });
+
+    it('should throw an error if target projects do not exist', async () => {
+        const invalidOptions: UnlinkGeneratorSchema = {
+            targets: ['nonExistentProject'],
+            dependencies: ['projectB'],
+        };
+
+        await expect(unlinkGenerator(tree, invalidOptions)).rejects.toThrow(
+            'Projects nonExistentProject do not exist'
+        );
+    });
+
+    it('should throw an error if dependency projects do not exist', async () => {
+        const invalidOptions: UnlinkGeneratorSchema = {
+            targets: ['projectA'],
+            dependencies: ['nonExistentProject'],
+        };
+
+        await expect(unlinkGenerator(tree, invalidOptions)).rejects.toThrow(
+            'Projects nonExistentProject do not exist'
+        );
+    });
+
+    it('should not throw an error if dependencies are not in the implicitDependencies list', async () => {
+        tree.write('projectE/project.json', JSON.stringify({ name: 'projectE' }));
+        const optionsWithNonExistentDependencies: UnlinkGeneratorSchema = {
+            targets: ['projectA'],
+            dependencies: ['projectE'],
+        };
+
+        await expect(
+            unlinkGenerator(tree, optionsWithNonExistentDependencies)
+        ).resolves.not.toThrow();
+
+        const projectAConfig = readProjectConfiguration(tree, 'projectA');
+        expect(projectAConfig.implicitDependencies).toEqual(['projectB', 'projectC', 'projectD']);
+    });
+});

--- a/packages/nx-serverless/src/generators/unlink/generator.ts
+++ b/packages/nx-serverless/src/generators/unlink/generator.ts
@@ -1,0 +1,55 @@
+import {
+    ProjectConfiguration,
+    Tree,
+    getProjects,
+    logger,
+    updateProjectConfiguration,
+} from '@nx/devkit';
+import { hasNonExistProject } from '../../helpers/projects';
+import { UnlinkGeneratorSchema } from './schema';
+
+/**
+ * Unlinks the specified dependencies from the given targets.
+ *
+ * This generator will throw errors if any of the specified targets or dependencies do not exist.
+ * It will then remove the specified dependencies from the specified targets.
+ *
+ * @param {Tree} tree - The file system tree representing the current project.
+ * @param {UnlinkGeneratorSchema} options - The options passed to the generator, containing the targets and dependencies.
+ * @returns {Promise<void>} A promise that resolves when the generator has completed its task.
+ */
+export async function unlinkGenerator(tree: Tree, options: UnlinkGeneratorSchema) {
+    const { targets, dependencies } = options;
+    const projects = getProjects(tree);
+
+    const nonExistTargets = hasNonExistProject(projects, targets);
+    const nonExistDependencies = hasNonExistProject(projects, dependencies);
+
+    if (nonExistTargets.length || nonExistDependencies.length) {
+        throw new Error(
+            `Projects ${nonExistTargets.concat(nonExistDependencies).join(', ')} do not exist`
+        );
+    }
+
+    for (const target of targets) {
+        // We're 99% sure that target project exist so it's safe to cast type
+        const current = projects.get(target) as ProjectConfiguration;
+
+        const implicitDependencies = current.implicitDependencies || [];
+
+        const updatedImplicitDependencies = implicitDependencies.filter(
+            dep => !dependencies.includes(dep)
+        );
+
+        updateProjectConfiguration(tree, target, {
+            ...current,
+            implicitDependencies: updatedImplicitDependencies,
+        });
+    }
+
+    logger.info(
+        `Successfully removed ${dependencies.join(', ')} from dependencies of ${targets.join(', ')}`
+    );
+}
+
+export default unlinkGenerator;

--- a/packages/nx-serverless/src/generators/unlink/schema.d.ts
+++ b/packages/nx-serverless/src/generators/unlink/schema.d.ts
@@ -1,0 +1,4 @@
+export interface UnlinkGeneratorSchema {
+    targets: string[];
+    dependencies: string[];
+}

--- a/packages/nx-serverless/src/generators/unlink/schema.d.ts
+++ b/packages/nx-serverless/src/generators/unlink/schema.d.ts
@@ -1,4 +1,4 @@
 export interface UnlinkGeneratorSchema {
-    targets: string[];
-    dependencies: string[];
+    targets: string;
+    dependencies: string;
 }

--- a/packages/nx-serverless/src/generators/unlink/schema.json
+++ b/packages/nx-serverless/src/generators/unlink/schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://json-schema.org/schema",
+    "$id": "Unlink",
+    "title": "",
+    "type": "object",
+    "properties": {
+        "targets": {
+            "type": "array",
+            "description": "Names of the target projects",
+            "x-prompt": "What are the names of the targeted projects (comma separated)?"
+        },
+        "dependencies": {
+            "type": "array",
+            "description": "Names of the projects to be removed from dependencies of the target projects",
+            "x-prompt": "What are the names of the projects to be removed from dependencies of the target projects (comma separated)?"
+        }
+    },
+    "required": ["targets", "dependencies"]
+}

--- a/packages/nx-serverless/src/generators/unlink/schema.json
+++ b/packages/nx-serverless/src/generators/unlink/schema.json
@@ -5,12 +5,12 @@
     "type": "object",
     "properties": {
         "targets": {
-            "type": "array",
+            "type": "string",
             "description": "Names of the target projects",
             "x-prompt": "What are the names of the targeted projects (comma separated)?"
         },
         "dependencies": {
-            "type": "array",
+            "type": "string",
             "description": "Names of the projects to be removed from dependencies of the target projects",
             "x-prompt": "What are the names of the projects to be removed from dependencies of the target projects (comma separated)?"
         }

--- a/packages/nx-serverless/src/helpers/projects.spec.ts
+++ b/packages/nx-serverless/src/helpers/projects.spec.ts
@@ -1,0 +1,46 @@
+import { ProjectConfiguration } from '@nx/devkit';
+import { hasNonExistProject } from './projects';
+
+describe('hasNonExistProject', () => {
+    let projects: Map<string, ProjectConfiguration>;
+
+    beforeEach(() => {
+        // Mock projects map
+        projects = new Map<string, ProjectConfiguration>([
+            ['projectA', {} as ProjectConfiguration],
+            ['projectB', {} as ProjectConfiguration],
+            ['projectC', {} as ProjectConfiguration],
+        ]);
+    });
+
+    it('should return an empty array if all project names exist', () => {
+        const names = ['projectA', 'projectB'];
+        const result = hasNonExistProject(projects, names);
+        expect(result).toEqual([]);
+    });
+
+    it('should return an array of project names that do not exist', () => {
+        const names = ['projectA', 'projectD', 'projectE'];
+        const result = hasNonExistProject(projects, names);
+        expect(result).toEqual(['projectD', 'projectE']);
+    });
+
+    it('should return all names if none of them exist in the projects map', () => {
+        const names = ['projectX', 'projectY', 'projectZ'];
+        const result = hasNonExistProject(projects, names);
+        expect(result).toEqual(['projectX', 'projectY', 'projectZ']);
+    });
+
+    it('should return an empty array if the names array is empty', () => {
+        const names: string[] = [];
+        const result = hasNonExistProject(projects, names);
+        expect(result).toEqual([]);
+    });
+
+    it('should return all names if the projects map is empty', () => {
+        projects = new Map(); // Empty projects map
+        const names = ['projectA', 'projectB'];
+        const result = hasNonExistProject(projects, names);
+        expect(result).toEqual(['projectA', 'projectB']);
+    });
+});

--- a/packages/nx-serverless/src/helpers/projects.ts
+++ b/packages/nx-serverless/src/helpers/projects.ts
@@ -1,0 +1,16 @@
+import { ProjectConfiguration } from '@nx/devkit';
+
+/**
+ * Checks if any of the given project names do not exist in the provided map of projects.
+ *
+ * @param {Map<string, ProjectConfiguration>} projects - A map of project names to their configurations.
+ * @param {string[]} names - An array of project names to check for existence.
+ * @returns {string[]} An array of project names that do not exist in the provided map.
+ */
+export function hasNonExistProject(
+    projects: Map<string, ProjectConfiguration>,
+    names: string[]
+): string[] {
+    const projectNames = new Set(projects.keys());
+    return names.filter(name => !projectNames.has(name));
+}


### PR DESCRIPTION
This PR added 2 new generators that support "link" and "unlink" services.
- The Link generator is used to establish dependencies between projects in your workspace. It updates the `implicitDependencies` of the target projects to include the specified dependency projects.
- The Unlink generator is used to remove dependencies between projects in your workspace. It removes the specified dependency projects from the `implicitDependencies` of the target projects.