### PR TITLE
MI-185: Fixed incorrect schema extension

### DIFF
--- a/packages/nx-openapi/src/generators/client/generator.ts
+++ b/packages/nx-openapi/src/generators/client/generator.ts
@@ -24,6 +24,11 @@ export async function clientGenerator(tree: Tree, options: ClientGeneratorSchema
         skipValidate = false,
     } = options;
 
+    const ext = schemaPath.split('.').pop();
+    if (ext !== 'yaml' && ext !== 'yml' && ext !== 'json') {
+        throw new Error(`Invalid schema file extension: ${ext}`);
+    }
+
     const projectRoot = `clients/${name}`;
 
     let existingProject = false;
@@ -39,7 +44,7 @@ export async function clientGenerator(tree: Tree, options: ClientGeneratorSchema
                     executor: 'nx:run-commands',
                     options: {
                         cwd: projectRoot,
-                        command: 'npx @redocly/cli lint schema' + schemaPath.slice(-5),
+                        command: `npx @redocly/cli lint schema.${ext}`,
                     },
                 },
             },

--- a/packages/nx-openapi/src/generators/client/generator.ts
+++ b/packages/nx-openapi/src/generators/client/generator.ts
@@ -24,8 +24,13 @@ export async function clientGenerator(tree: Tree, options: ClientGeneratorSchema
         skipValidate = false,
     } = options;
 
+    // Up the top of the file
+    const validExtensions = ['yaml', 'yml', 'json'];
+    
+    // ...
+   
     const ext = schemaPath.split('.').pop();
-    if (ext !== 'yaml' && ext !== 'yml' && ext !== 'json') {
+    if (!validExtensions.includes(ext)) {
         throw new Error(`Invalid schema file extension: ${ext}`);
     }
 

--- a/packages/nx-openapi/src/generators/client/generator.ts
+++ b/packages/nx-openapi/src/generators/client/generator.ts
@@ -14,6 +14,8 @@ import {
 } from '../../helpers/generate-openapi-types';
 import { ClientGeneratorSchema } from './schema';
 
+const VALID_EXTENSIONS = ['yaml', 'yml', 'json'];
+
 export async function clientGenerator(tree: Tree, options: ClientGeneratorSchema) {
     const {
         name,
@@ -24,13 +26,8 @@ export async function clientGenerator(tree: Tree, options: ClientGeneratorSchema
         skipValidate = false,
     } = options;
 
-    // Up the top of the file
-    const validExtensions = ['yaml', 'yml', 'json'];
-    
-    // ...
-   
-    const ext = schemaPath.split('.').pop();
-    if (!validExtensions.includes(ext)) {
+    const ext = schemaPath.split('.').pop() || '';
+    if (!VALID_EXTENSIONS.includes(ext)) {
         throw new Error(`Invalid schema file extension: ${ext}`);
     }
 

--- a/packages/nx-openapi/src/helpers/generate-openapi-types.ts
+++ b/packages/nx-openapi/src/helpers/generate-openapi-types.ts
@@ -92,12 +92,17 @@ export async function copySchema(tree: Tree, name: string, schemaPath: string, r
     } else {
         schemaBuffer = tree.read(schemaPath);
     }
-    if (schemaBuffer) {
-        tree.write(
-            `clients/${name}/schema` + schemaPath.slice(-5), // Use last 5 characters to determine file type
-            schemaBuffer
-        );
+
+    if (!schemaBuffer) {
+        throw new Error(`Failed to read schema at ${schemaPath}`);
     }
+
+    const ext = schemaPath.split('.').pop() || 'yaml';
+    const destination = `clients/${name}/schema.${ext}`;
+
+    tree.write(destination, schemaBuffer);
+
+    return destination;
 }
 
 // This is ignored by coverage because its relying on a third party package to do the validation step


### PR DESCRIPTION
This PR fix the incorrect schema extension when user pass in a `yml` file.

Along with this, I also add some improvements:
- Throw an error when the file extension is not `yml`, `yaml` or `json`.
- Throw an error when we failed to read/download the schema.

