### PR TITLE
MI-204: download schema before generate type

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 max_line_length = 100
 
-[{package.json,*.yml,*.md}]
+[{package.json,*.yaml,*.yml,*.md}]
 indent_size = 2
 indent_style = space
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@aws-sdk/client-ssm": "^3.687.0",
         "@redocly/openapi-core": "^1.34.1",
         "axios": "^1.7.7",
-        "enquirer": "^2.4.1",
         "lodash": "^4.17.21",
         "object-hash": "^3.0.0",
         "openapi-typescript": "^7.6.1"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@aws-sdk/client-ssm": "^3.687.0",
     "@redocly/openapi-core": "^1.34.1",
     "axios": "^1.7.7",
-    "enquirer": "^2.4.1",
     "lodash": "^4.17.21",
     "object-hash": "^3.0.0",
     "openapi-typescript": "^7.6.1"

--- a/packages/nx-openapi/README.md
+++ b/packages/nx-openapi/README.md
@@ -19,16 +19,17 @@ To build with flags (without needing to prompt):
 Run `nx g @aligent/nx-openapi:client` with optional flags:
 
 - `--name` Name of the api client.
-- `--schemaPath` Path to the schema. If using the --remote flag then you must specify a valid remote URL. If not you must specify a local file.
-- `--remote` Specify whether you would like to fetch remotely.
+- `--schemaPath` Absolute path to the schema. This can be a valid HTTP URL or a local file.
+- `--importPath` The package name used to import the client. Defaults to `@clients/{name}` if not supplied
 - `--configPath` path to the redocly config file responsible for authentication when fetching a schema remotely. For more information: https://openapi-ts.dev/cli#auth.
 - `--skipValidate` If passed, this will skip schema pre-validation. Only do this if you have good reason to - not validating the schema beforehand may produce unpredictable results (either things may not generate at all or they may generate something that is incorrect).
+- `--override` Override the schema (and the generated type) of an existing client.
 
 **:rotating_light: Do not edit the files in the `/generated` folder after generating a client. These files are generated using the OpenAPI Schema and editing them may put you at risk of no longer conforming to the specifications of the API you are using! :rotating_light:**
 
 ### Regenerating types for an existing client
 
-To regenerate an existing client run the same generator command again (as above). If the client already exists in the Nx project, after confirmation it will have its types file regenerated from either the existing schema or a newly provided one.
+To regenerate an existing client run the same generator command again (as above) and pass in `--override` flag. If the client already exists, its types file will be regenerated from the provided one.
 
 ## Development
 
@@ -59,7 +60,7 @@ graph LR;
   GR-->G;
   G-->W[Write generated .ts file to tree];
   W-->NX[Nx generator uses tree to build directory];
-  NX-->C[Cleanup];
+  NX-->C[Clean up];
 ```
 
 ## What gets generated?

--- a/packages/nx-openapi/package.json
+++ b/packages/nx-openapi/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "@nx/devkit": "20.7.0",
     "@redocly/openapi-core": "^1.34.1",
-    "openapi-typescript": "^7.6.1",
-    "enquirer": "^2.3.6"
+    "openapi-typescript": "^7.6.1"
   },
   "generators": "./generators.json",
   "author": "Aligent",

--- a/packages/nx-openapi/src/generators/client/generator.spec.ts
+++ b/packages/nx-openapi/src/generators/client/generator.spec.ts
@@ -1,4 +1,4 @@
-import { Tree, readProjectConfiguration } from '@nx/devkit';
+import { Tree, addProjectConfiguration, readProjectConfiguration } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { clientGenerator } from './generator';
 import { ClientGeneratorSchema } from './schema';
@@ -7,7 +7,6 @@ describe('client generator', () => {
     let tree: Tree;
     beforeEach(() => {
         tree = createTreeWithEmptyWorkspace();
-        tree.root = ''; // Trees root is automatically /virtual/ but that breaks the unit tests
     });
 
     it('should generate a client successfully', async () => {
@@ -15,18 +14,52 @@ describe('client generator', () => {
             name: 'test',
             schemaPath: `${__dirname}/unit-test-schemas/valid.yaml`,
             skipValidate: true, // Validation breaks this unit test for some reason (TODO: figure out wtf is going on here)
+            override: false,
         };
         await clientGenerator(tree, options);
         const config = readProjectConfiguration(tree, 'test');
         expect(config).toBeDefined();
-    }, 10000);
+    });
 
-    it('should error if schema file is not found', async () => {
+    it('should throw an error if schemaPath does point to a supported file type', async () => {
         const options: ClientGeneratorSchema = {
             name: 'test',
-            schemaPath: './unit-test-schemas/missing.yaml',
-            skipValidate: true,
+            schemaPath: `${__dirname}/unit-test-schemas/random.xml`,
+            skipValidate: false,
+            override: false,
         };
-        expect(clientGenerator(tree, options)).rejects.toThrowError();
+        await expect(clientGenerator(tree, options)).rejects.toThrowError();
+    });
+
+    it('should throw an error if schema file is not found', async () => {
+        const options: ClientGeneratorSchema = {
+            name: 'test',
+            schemaPath: `${__dirname}/unit-test-schemas/missing.yaml`,
+            skipValidate: true,
+            override: false,
+        };
+        await expect(clientGenerator(tree, options)).rejects.toThrowError();
+    });
+
+    it('should not write schema to disk if the project exists and override is false', async () => {
+        addProjectConfiguration(tree, 'test', {
+            root: 'clients/test',
+            projectType: 'library',
+            sourceRoot: 'clients/test/src',
+            targets: {},
+            tags: ['client', 'test'],
+        });
+
+        const options: ClientGeneratorSchema = {
+            name: 'test',
+            schemaPath: `${__dirname}/unit-test-schemas/valid.yaml`,
+            skipValidate: true,
+            override: false,
+        };
+
+        await clientGenerator(tree, options);
+
+        expect(tree.exists('clients/test/schema.yaml')).toBe(false);
+        expect(tree.exists('clients/test/generated/index.ts')).toBe(false);
     });
 });

--- a/packages/nx-openapi/src/generators/client/generator.spec.ts
+++ b/packages/nx-openapi/src/generators/client/generator.spec.ts
@@ -13,7 +13,7 @@ describe('client generator', () => {
         const options: ClientGeneratorSchema = {
             name: 'test',
             schemaPath: `${__dirname}/unit-test-schemas/valid.yaml`,
-            skipValidate: true, // Validation breaks this unit test for some reason (TODO: figure out wtf is going on here)
+            skipValidate: false,
             override: false,
         };
         await clientGenerator(tree, options);
@@ -61,5 +61,16 @@ describe('client generator', () => {
 
         expect(tree.exists('clients/test/schema.yaml')).toBe(false);
         expect(tree.exists('clients/test/generated/index.ts')).toBe(false);
+    });
+
+    it('should throw error when validation failed (has problem with severity `error`)', async () => {
+        const options: ClientGeneratorSchema = {
+            name: 'test',
+            schemaPath: `${__dirname}/unit-test-schemas/invalid.yaml`,
+            skipValidate: false,
+            override: false,
+        };
+
+        await expect(clientGenerator(tree, options)).rejects.toThrowError();
     });
 });

--- a/packages/nx-openapi/src/generators/client/generator.spec.ts
+++ b/packages/nx-openapi/src/generators/client/generator.spec.ts
@@ -76,7 +76,7 @@ describe('client generator', () => {
         await expect(clientGenerator(tree, options)).rejects.toThrowError();
     });
 
-    it('should not throw error when validation failed due to unsupported specification', async () => {
+    it('should throw error when validation failed due to unsupported specification', async () => {
         const options: ClientGeneratorSchema = {
             name: 'test',
             schemaPath: `${__dirname}/unit-test-schemas/unsupported.yaml`,

--- a/packages/nx-openapi/src/generators/client/generator.spec.ts
+++ b/packages/nx-openapi/src/generators/client/generator.spec.ts
@@ -17,8 +17,10 @@ describe('client generator', () => {
             override: false,
         };
         await clientGenerator(tree, options);
-        const config = readProjectConfiguration(tree, 'test');
-        expect(config).toBeDefined();
+
+        expect(readProjectConfiguration(tree, 'test')).toBeDefined();
+        expect(tree.exists('clients/test/schema.yaml')).toBe(true);
+        expect(tree.exists('clients/test/generated/index.ts')).toBe(true);
     });
 
     it('should throw an error if schemaPath does point to a supported file type', async () => {

--- a/packages/nx-openapi/src/generators/client/generator.spec.ts
+++ b/packages/nx-openapi/src/generators/client/generator.spec.ts
@@ -75,4 +75,15 @@ describe('client generator', () => {
 
         await expect(clientGenerator(tree, options)).rejects.toThrowError();
     });
+
+    it('should not throw error when validation failed due to unsupported specification', async () => {
+        const options: ClientGeneratorSchema = {
+            name: 'test',
+            schemaPath: `${__dirname}/unit-test-schemas/unsupported.yaml`,
+            skipValidate: false,
+            override: false,
+        };
+
+        await expect(clientGenerator(tree, options)).rejects.toThrowError();
+    });
 });

--- a/packages/nx-openapi/src/generators/client/schema.d.ts
+++ b/packages/nx-openapi/src/generators/client/schema.d.ts
@@ -1,6 +1,7 @@
 export interface ClientGeneratorSchema {
     name: string;
     schemaPath: string;
+    configPath?: string;
     importPath?: string;
     skipValidate: boolean;
     override: boolean;

--- a/packages/nx-openapi/src/generators/client/schema.d.ts
+++ b/packages/nx-openapi/src/generators/client/schema.d.ts
@@ -1,8 +1,7 @@
 export interface ClientGeneratorSchema {
     name: string;
     schemaPath: string;
-    remote?: boolean;
-    configPath?: string;
     importPath?: string;
-    skipValidate?: boolean;
+    skipValidate: boolean;
+    override: boolean;
 }

--- a/packages/nx-openapi/src/generators/client/schema.json
+++ b/packages/nx-openapi/src/generators/client/schema.json
@@ -22,6 +22,10 @@
             },
             "x-prompt": "Absolute schema path (a valid HTTP url or a local file): "
         },
+        "configPath": {
+            "type": "string",
+            "description": "Path to the redocly config file responsible for auth. For more information: https://openapi-ts.dev/cli#auth."
+        },
         "importPath": {
             "type": "string",
             "description": "The package name used to import the client, like @myorg/my-awesome-client. Defaults to @clients/{name} if not supplied"

--- a/packages/nx-openapi/src/generators/client/schema.json
+++ b/packages/nx-openapi/src/generators/client/schema.json
@@ -15,20 +15,12 @@
         },
         "schemaPath": {
             "type": "string",
-            "description": "Path to the schema. If using the --remote flag then you must specify a valid remote URL. If not you must specify a local file.",
+            "description": "Absolute path to the schema. Specify a valid HTTP url or a local file.",
             "$default": {
                 "$source": "argv",
                 "index": 1
             },
-            "x-prompt": "Schema path (URL to schema if using --remote): "
-        },
-        "remote": {
-            "type": "boolean",
-            "description": "Specify whether you would like to fetch remotely."
-        },
-        "configPath": {
-            "type": "string",
-            "description": "path to the redocly config file responsible for auth. For more information: https://openapi-ts.dev/cli#auth."
+            "x-prompt": "Absolute schema path (a valid HTTP url or a local file): "
         },
         "importPath": {
             "type": "string",
@@ -36,7 +28,13 @@
         },
         "skipValidate": {
             "type": "boolean",
-            "description": "Skip validation in the generation process"
+            "description": "Skip validation in the generation process",
+            "default": false
+        },
+        "override": {
+            "type": "boolean",
+            "description": "Override existing project schema",
+            "default": false
         }
     },
     "required": ["name", "schemaPath"]

--- a/packages/nx-openapi/src/generators/client/unit-test-schemas/invalid.yaml
+++ b/packages/nx-openapi/src/generators/client/unit-test-schemas/invalid.yaml
@@ -1,4 +1,4 @@
-# openapi: 3.0.0 <- no version specification makes this invalid
+openapi: 3.0.0
 info:
   title: Sample API
   description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
@@ -16,7 +16,7 @@ paths:
       summary: Returns a list of users.
       description: Optional extended description in CommonMark or HTML.
       responses:
-        "200": # status code
+        '200': # status code
           description: A JSON array of user names
           content:
             application/json:

--- a/packages/nx-openapi/src/generators/client/unit-test-schemas/unsupported.yaml
+++ b/packages/nx-openapi/src/generators/client/unit-test-schemas/unsupported.yaml
@@ -1,0 +1,26 @@
+# openapi: 3.0.0
+info:
+  title: Sample API
+  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
+  version: 0.1.9
+
+servers:
+  - url: http://api.example.com/v1
+    description: Optional server description, e.g. Main (production) server
+  - url: http://staging-api.example.com
+    description: Optional server description, e.g. Internal staging server for testing
+
+paths:
+  /users:
+    get:
+      summary: Returns a list of users.
+      description: Optional extended description in CommonMark or HTML.
+      responses:
+        '200': # status code
+          description: A JSON array of user names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/packages/nx-openapi/src/generators/client/unit-test-schemas/valid.yaml
+++ b/packages/nx-openapi/src/generators/client/unit-test-schemas/valid.yaml
@@ -18,7 +18,7 @@ paths:
       summary: Returns a list of users.
       description: Optional extended description in CommonMark or HTML.
       responses:
-        "200": # status code
+        '200': # status code
           description: A JSON array of user names
           content:
             application/json:

--- a/packages/nx-openapi/src/helpers/generate-openapi-types.ts
+++ b/packages/nx-openapi/src/helpers/generate-openapi-types.ts
@@ -18,14 +18,16 @@ export async function generateOpenApiTypes(
     schemaPath: string,
     typeDest: string
 ): Promise<void> {
-    try {
-        logger.info(`Generating types from ${schemaPath}`);
-        const ast = await openapiTS(tree.read(schemaPath));
+    logger.info(`Generating types from ${schemaPath}`);
+    const schema = tree.read(schemaPath);
 
-        tree.write(typeDest, astToString(ast));
-    } catch (e) {
-        throw new Error(`Failed to generate types for path ${schemaPath}` + e);
+    if (!schema) {
+        throw new Error(`Failed to read schema at ${schemaPath}`);
     }
+
+    const ast = await openapiTS(schema);
+
+    tree.write(typeDest, astToString(ast));
 }
 
 // We do not want to test this function.

--- a/packages/nx-openapi/src/helpers/generate-openapi-types.ts
+++ b/packages/nx-openapi/src/helpers/generate-openapi-types.ts
@@ -65,8 +65,6 @@ export async function copySchema(
     }
 
     tree.write(destination, schema);
-
-    console.log(`Schema copied to ${destination}, length: ${schema.length}`);
 }
 /* v8 ignore end */
 

--- a/packages/nx-openapi/src/helpers/generate-openapi-types.ts
+++ b/packages/nx-openapi/src/helpers/generate-openapi-types.ts
@@ -4,14 +4,20 @@ import { readFileSync } from 'fs';
 import openapiTS, { astToString } from 'openapi-typescript';
 
 /**
- * Grabs schema data from local directory. The schemaPath is evaluated relative to the root of the template project,
- * not the root of the generator.
- * @param rootDir Root directory of the project tree
- * @param schemaPath Path of the schema relative to the root of the entire project.
- * @param typeDest Destination of the generated types.
- * @returns Promise<void>
+ * Generates TypeScript types from an OpenAPI schema
+ * and writes the generated types to a specified destination.
+ *
+ * @param {Tree} tree - The file system tree representing the current project.
+ * @param {string} schemaPath - The path to the OpenAPI schema file.
+ * @param {string} typeDest - The destination path for the generated TypeScript types.
+ * @returns {Promise<void>} A promise that resolves when the types are successfully generated.
+ * @throws {Error} If the schema cannot be read or the types cannot be generated.
  */
-export async function generateOpenApiTypes(tree: Tree, schemaPath: string, typeDest: string) {
+export async function generateOpenApiTypes(
+    tree: Tree,
+    schemaPath: string,
+    typeDest: string
+): Promise<void> {
     try {
         logger.info(`Generating types from ${schemaPath}`);
         const ast = await openapiTS(tree.read(schemaPath));
@@ -26,9 +32,22 @@ export async function generateOpenApiTypes(tree: Tree, schemaPath: string, typeD
 // It only download/copy the schema to a specified destination.
 /* v8 ignore start */
 /**
- * Copies the original schema from the source to newly generated client
+ * Copies the OpenAPI schema from the source to a specified destination.
+ *
+ * This function supports both local and remote schemas. If the schema is remote (HTTP/HTTPS),
+ * it fetches the schema from the URL. If the schema is local, it reads the schema from the file system.
+ *
+ * @param {Tree} tree - The file system tree representing the current project.
+ * @param {string} destination - The destination path where the schema will be copied.
+ * @param {string} schemaPath - The path to the schema file (local or remote).
+ * @returns {Promise<void>} A promise that resolves when the schema is successfully copied.
+ * @throws {Error} If the schema cannot be read or is empty.
  */
-export async function copySchema(tree: Tree, destination: string, schemaPath: string) {
+export async function copySchema(
+    tree: Tree,
+    destination: string,
+    schemaPath: string
+): Promise<void> {
     const isRemoteSchema = schemaPath.startsWith('http://') || schemaPath.startsWith('https://');
 
     let schema: Buffer | null;
@@ -50,7 +69,16 @@ export async function copySchema(tree: Tree, destination: string, schemaPath: st
 }
 /* v8 ignore end */
 
-export async function validateSchema(path: string) {
+/**
+ * Validates an OpenAPI schema using the Redocly OpenAPI linter.
+ *
+ * This function uses the `@redocly/openapi-core` library to lint the schema at the specified path.
+ * It logs warnings and errors based on the severity of the issues found in the schema.
+ *
+ * @param {string} path - The path to the OpenAPI schema file.
+ * @returns {Promise<boolean>} A promise that resolves to `true` if validation errors are found, otherwise `false`.
+ */
+export async function validateSchema(path: string): Promise<boolean> {
     let hasError = false;
     try {
         const config = await loadConfig();

--- a/packages/nx-openapi/src/helpers/generate-openapi-types.ts
+++ b/packages/nx-openapi/src/helpers/generate-openapi-types.ts
@@ -52,6 +52,7 @@ export async function copySchema(
 
     let schema: Buffer | null;
 
+    // TODO: MI-203 - Support private schema endpoint
     if (isRemoteSchema) {
         const response = await fetch(schemaPath);
         schema = Buffer.from(await response.arrayBuffer());
@@ -81,6 +82,7 @@ export async function copySchema(
 export async function validateSchema(path: string): Promise<boolean> {
     let hasError = false;
     try {
+        // TODO: MI-203 - Support private schema endpoint
         const config = await loadConfig();
         const results = await lint({ ref: path, config });
 

--- a/packages/nx-openapi/src/helpers/utilities.ts
+++ b/packages/nx-openapi/src/helpers/utilities.ts
@@ -1,0 +1,76 @@
+import { addProjectConfiguration, Tree, updateJson } from '@nx/devkit';
+
+/**
+ * Attempts to add a new project configuration to the workspace.
+ *
+ * This function adds a new project configuration to the workspace. If a project with the same name
+ * already exists, it returns `false`. If an error occurs for any other reason, the error is re-thrown.
+ *
+ * @param {Tree} tree - The file system tree representing the current project.
+ * @param {string} name - The name of the project to add.
+ * @param {string} projectRoot - The root directory of the project.
+ * @returns {boolean} `true` if the project configuration was added successfully, `false` if the project already exists.
+ * @throws {Error} If an error occurs that is not related to the project already existing.
+ */
+export function attemptToAddProjectConfiguration(tree: Tree, name: string, projectRoot: string) {
+    try {
+        addProjectConfiguration(tree, name, {
+            root: projectRoot,
+            projectType: 'library',
+            sourceRoot: `${projectRoot}/src`,
+            targets: {},
+            tags: ['client', name],
+        });
+        return true;
+    } catch (err) {
+        if (err instanceof Error && err.message.includes('already exists')) {
+            return false;
+        }
+
+        throw err;
+    }
+}
+
+/**
+ * The utility functions below are only exported by '@nx/js', not '@nx/devkit'
+ * They're simple so we recreate them here instead of adding '@nx/js' as a dependency
+ * Source: {@link https://github.com/nrwl/nx/blob/master/packages/js/src/utils/typescript/ts-config.ts}
+ */
+function getRootTsConfigPathInTree(tree: Tree): string {
+    for (const path of ['tsconfig.base.json', 'tsconfig.json']) {
+        if (tree.exists(path)) {
+            return path;
+        }
+    }
+
+    return 'tsconfig.base.json';
+}
+
+/**
+ * Adds a new path mapping to the `paths` property in the root TypeScript configuration file.
+ *
+ * This function updates the `tsconfig.base.json` or `tsconfig.json` file to include a new path mapping
+ * for the specified import path. If the import path already exists, an error is thrown.
+ *
+ * @param {Tree} tree - The file system tree representing the current project.
+ * @param {string} importPath - The import path to add to the `paths` property.
+ * @param {string[]} lookupPaths - The array of paths to associate with the import path.
+ * @throws {Error} If the import path already exists in the `paths` property.
+ */
+export function addTsConfigPath(tree: Tree, importPath: string, lookupPaths: string[]) {
+    updateJson(tree, getRootTsConfigPathInTree(tree), json => {
+        json.compilerOptions ??= {};
+        const c = json.compilerOptions;
+        c.paths ??= {};
+
+        if (c.paths[importPath]) {
+            throw new Error(
+                `You already have a library using the import path "${importPath}". Make sure to specify a unique one.`
+            );
+        }
+
+        c.paths[importPath] = lookupPaths;
+
+        return json;
+    });
+}

--- a/packages/nx-openapi/src/types/openapi-typescript.d.ts
+++ b/packages/nx-openapi/src/types/openapi-typescript.d.ts
@@ -1,1 +1,12 @@
-declare module 'openapi-typescript';
+declare module 'openapi-typescript' {
+    import type { Readable } from 'node:stream';
+    import { astToString, OpenAPI3, OpenAPITSOptions } from 'openapi-typescript/dist/index.js';
+    import ts from 'typescript';
+
+    export default function openapiTS(
+        source: string | URL | OpenAPI3 | Buffer | Readable,
+        options?: OpenAPITSOptions
+    ): Promise<ts.Node[]>;
+
+    export { astToString };
+}

--- a/packages/nx-openapi/src/types/openapi-typescript.d.ts
+++ b/packages/nx-openapi/src/types/openapi-typescript.d.ts
@@ -1,0 +1,1 @@
+declare module 'openapi-typescript';


### PR DESCRIPTION
I first started wanting to fix MI-204 only. However, while trying to fix this issue, I bumped into few other issues. As a result, I end up fixed the following issues:
1. [MI-204](https://aligent.atlassian.net/browse/MI-204) File management issue in this generator as we now want to copy the file into `${projectRoot}/schema.yml` first before generating type.
2. [MI-205](https://aligent.atlassian.net/browse/MI-205) Fixed all issue with unit test. I have to fix this as it blocks me from committing code 😭 
3. [MI-201](https://aligent.atlassian.net/browse/MI-201) Use `@redocly/openapi-core` exposed api to validate schema instead of spawning a child process.
4. Also related to unit testing, I decided to add `--override` flag to:
    - Reduce unit test complexity. We do not need to mock the user input for testing purpose.
    - Remove `enquirer` from dependencies list.
5. Remove `--remote` flag. If `--schemaPath` is a HTTP url, we consider that it's a remote file and will download before generate type.
6. Added `packages/nx-openapi/src/types/openapi-typescript.d.ts` because `openapi-typescript` does not expose types for CJS projects.
7. Switch from pure `console` log to Nx provided `logger`.

Happy Easter 🥚 