### PR TITLE
MI-207: Manual release pipeline with input

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,9 +36,6 @@ jobs:
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@dbe0650947e5f2c81f59190a38512cf49126fe6b # v4
 
-      - name: Check for version plan
-        uses: npm nx release plan:check
-
       - name: ⚙️ Run Tests
         run: npx nx affected -t lint test --parallel=2
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,12 +25,13 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: git fetch origin ${{ env.BASE_REF }}
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - name: Install
+      - name: Install dependencies
         run: npm ci
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,13 @@
 name: Publish to NPM
 
 on:
-  push:
-    branches: [main]
+  # Run manually using Github UI
+  workflow_dispatch:
+    inputs:
+      publish-flags:
+        description: 'Additional flags to pass to publish command'
+        required: false
+        default: ''
 
 jobs:
   build-and-publish:
@@ -37,16 +42,16 @@ jobs:
         run: npm ci
         shell: bash
 
-      - name: Check version plan exists
-        run: npx nx release plan:check
+      - name: Check for version plan
+        run: npx nx release plan:check --verbose
         shell: bash
 
-      - name: Independently release new package versions
-        run: npx nx release
+      - name: Release new version plan
+        run: npx nx release --verbose
         shell: bash
 
-      - name: Publish new package versions
-        run: npx nx release publish
+      - name: Publish packages
+        run: npx nx release publish --verbose ${{ inputs.publish-flags }}
         shell: bash
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
   # Run manually using Github UI
   workflow_dispatch:
     inputs:
-      publish-flags:
-        description: 'Additional flags to pass to publish command'
+      publish-options:
+        description: 'Additional flags to pass to `nx release publish` command'
         required: false
         default: ''
 
@@ -32,7 +32,8 @@ jobs:
           git config --global user.name "Automated NPM Release"
           git config --global user.email "${{ secrets.DEVOPS_GITHUB_EMAIL }}"
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -46,12 +47,12 @@ jobs:
         run: npx nx release plan:check --verbose
         shell: bash
 
-      - name: Release new version plan
+      - name: Release new version
         run: npx nx release --verbose
         shell: bash
 
-      - name: Publish packages
-        run: npx nx release publish --verbose ${{ inputs.publish-flags }}
+      - name: Publish versioned package
+        run: npx nx release publish --verbose ${{ inputs.publish-options }}
         shell: bash
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,16 +10,36 @@ Aligent's monorepo for Microservice Development Utilities. For more details abou
 
 # Release Process
 
-Each of the packages in the monorepo have seperate versioning and independent npm releases. To perform a release of one or more packages we use [Version Plans](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) to define the type of updates and provide messages. Nx will then detect the version plans and automatically update version numbers appropriately, as well as perform seperate builds and deployments in the pipeline if a version plan is detected.
+Each of the packages in the monorepo have separate versioning and independent npm releases. To perform a release of one or more packages we use [Version Plans](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) to define the type of updates and provide change log. Nx will then detect the version plans and automatically update version numbers appropriately, as well as perform builds and deployments separately in the pipeline if a version plan is detected.
 
-### To create a release:
+### Step-by-Step Guide
 
-- `npm run release-plan` to create a release plan based on the detected changes in one or more services. This will prompt you to provide the type of change for each package (patch, minor, major etc.) and the description of the changes. This generates a version-plan file.
-- Commit the changes to the repository.
-- Upon merge the release pipeline will use the version file to perform the independent releases to npm
+1. Start by creating a new branch from the latest `main` branch.
 
-[!WARNING]
-The pipeline will fail if a version plan is not present as part of your merged changes.
+2. Create a new version plan: Run the following command to generate a version plan based on your changes:
 
-[!NOTE]
-Nx is responsible for removing the version plans after a publish occurs. This is because **having multiple version plan files may produce unpredicible results**. For this reason make sure dont commit more than 1 version file. Its also good practice to create version files via the CLI tool rather than manually, as they will have more unique identifiers attached to their file names.
+   ```bash
+   npm run release-plan
+   ```
+
+   Follow the prompts to select the type of change (patch, minor, major, etc.) and provide a description for each affected package. This will create a version plan file in the repository.
+
+3. Merge to `main`:
+
+   - Commit your changes, including the version plan file.
+   - Open a pull request targeting the `main` branch.
+   - Ensure your PR contains only one version plan file.
+   - Once approved, merge your branch into `main`.
+
+4. Manually run the `release` Pipeline
+   - After merging, trigger the `release` pipeline manually (via Github Action UI).
+   - The pipeline will:
+     - Detect the version plan file.
+     - Build and publish the affected packages to npm.
+     - Remove the version plan file after a successful publish.
+
+### Notes
+
+- The `release` pipeline will fail if a version plan is not present in your merged changes. However, the `pull-request` pipeline does not check for version plan. We do this as there might be situations where we want to commit to main without a release.
+- Nx is responsible for removing the version plans after a release. This is because **having multiple version plan files may produce unpredictable results**. For this reason make sure not to commit more than one version plan file.
+- Always use the provided command to generate version plan files for uniqueness and correctness.

--- a/nx.json
+++ b/nx.json
@@ -37,6 +37,11 @@
         }
     },
     "release": {
+        "changelog": {
+            "workspaceChangelog": {
+                "createRelease": "github"
+            }
+        },
         "versionPlans": true,
         "projects": ["packages/*"],
         "projectsRelationship": "independent",


### PR DESCRIPTION
**Description of the proposed changes**

- Switch to manual triggered release pipeline & remove version plan check from pull request. This fix 2 problems that we have at the moment:
  1. Pull Request pipeline failed in situations where we want to merge to main but do not want to release new versions. Eg: pipeline changes, update `devDependencies`, etc.
  2. Support pipeline input options. Eg: `--first-release` is needed when we add new package which isn't published yet. We haven't been unable to release `@aligent/nx-openapi@1.0.0` & `@aligent/nx-serverless@1.0.0` packages yet for this reason.
- Configure Nx release so `CHANGELOG.md` and Github release are generated automatically when there is a release.
- Added name for some pipeline steps for clarity.

**Other solutions considered (if any)**

- I choose to use manual triggered release instead of using job control condition in release pipeline as it's easier to implement & we have more control over the pipeline inputs. 

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in the [Aligent Contribution Guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md)

**Notes to reviewers**

🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
