### PR TITLE
Replace lodash dependency with lightweight local functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@aws-sdk/client-s3": "^3.800.0",
         "@aws-sdk/client-ssm": "^3.799.0",
         "@redocly/openapi-core": "^1.34.2",
-        "lodash": "^4.17.21",
         "object-hash": "^3.0.0",
         "openapi-typescript": "^7.6.1"
       },
@@ -29,7 +28,6 @@
         "@smithy/util-stream": "^3.2.1",
         "@swc-node/register": "^1.10.9",
         "@swc/core": "^1.11.24",
-        "@types/lodash": "^4.17.13",
         "@types/node": "^22.15.3",
         "@types/object-hash": "^3.0.6",
         "@vitest/coverage-v8": "3.1.2",
@@ -6494,13 +6492,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.16",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
-      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "22.15.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
@@ -11841,12 +11832,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -15238,7 +15223,6 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.800.0",
         "@aws-sdk/client-ssm": "^3.799.0",
-        "lodash": "^4.17.21",
         "oauth-sign": "^0.9.0",
         "object-hash": "^3.0.0",
         "openapi-fetch": "^0.13.5"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@aws-sdk/client-s3": "^3.800.0",
     "@aws-sdk/client-ssm": "^3.799.0",
     "@redocly/openapi-core": "^1.34.2",
-    "lodash": "^4.17.21",
     "object-hash": "^3.0.0",
     "openapi-typescript": "^7.6.1"
   },
@@ -37,7 +36,6 @@
     "@smithy/util-stream": "^3.2.1",
     "@swc-node/register": "^1.10.9",
     "@swc/core": "^1.11.24",
-    "@types/lodash": "^4.17.13",
     "@types/node": "^22.15.3",
     "@types/object-hash": "^3.0.6",
     "@vitest/coverage-v8": "3.1.2",

--- a/packages/microservice-util-lib/package.json
+++ b/packages/microservice-util-lib/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.800.0",
     "@aws-sdk/client-ssm": "^3.799.0",
-    "lodash": "^4.17.21",
     "oauth-sign": "^0.9.0",
     "object-hash": "^3.0.0",
     "openapi-fetch": "^0.13.5"


### PR DESCRIPTION
---

**Description of the proposed changes**
- Remove lodash import used for `get` and `set` functions in `remap`
- Replace with simple analogue functions that just do what is required by `remap`

All of lodash was being bundled by lambda functions using any utility in this library, which isn't optimal. This should prevent that from happening.

- **Other solutions considered (if any)**
- Importing just the get and set methods from lodash. This would handle more edge cases and path types but I don't think it's necessary for this utility.

**Notes to reviewers**

🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
