### PR TITLE
DO-2008: Adjust publish workflow for NPM trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -43,5 +44,3 @@ jobs:
       - name: 🚀 Publish versioned packages
         run: npx nx release publish --verbose ${{ inputs.publish-options }}
         shell: bash
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
The NPM token that was being used to publish the packages has expired. This has broken the pipeline and prevented recent deployments.

Take this opportunity to switch over to NPM trusted publishing which uses OIDC instead of a long-lived token to authorised publishing.

Fixes DO-2008