### PR TITLE
MI-314: Remove asset resolver helpers

### DIFF
--- a/.nx/version-plans/version-plan-1776314350563.md
+++ b/.nx/version-plans/version-plan-1776314350563.md
@@ -1,0 +1,6 @@
+---
+nx-cdk: minor
+---
+
+- Remove asset resolver helpers from service template in favor of Aligent CDK constructs
+- Add example flag to preset generator for conditional sample code generation

--- a/packages/nx-cdk/src/generators/preset/files/libs/infra/src/index.ts.template
+++ b/packages/nx-cdk/src/generators/preset/files/libs/infra/src/index.ts.template
@@ -1,20 +1,16 @@
 import { Stack, Stage, StackProps, Tags } from 'aws-cdk-lib';
-import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
-import { IStringParameter, StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
+<% if (example) { %>import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+import { IStringParameter, StringParameter } from 'aws-cdk-lib/aws-ssm';<% } %>
 
-// EXAMPLE ONLY: The following interface, class, and all related resource references
-// (eCommerceBaseUrl, eCommerceCredentials, etc.) are illustrative examples.
-// Replace them with your own resources and props that match your actual infrastructure.
 export interface SharedInfraProps {
-    // eCommerceBaseUrl: IStringParameter;
-    // eCommerceCredentials: Secret;
+    <% if (example) { %>paramExample: IStringParameter;
+    secretExample: Secret;<% } %>
 }
 
 export class SharedInfraStack extends Stack {
-    // EXAMPLE: Replace these properties with your own shared resources
-    // readonly eCommerceBaseUrl: IStringParameter;
-    // readonly eCommerceCredentials: Secret;
+    <% if (example) { %>readonly paramExample: IStringParameter;
+    readonly secretExample: Secret;<% } %>
 
     constructor(scope: Construct, id: string, props?: StackProps) {
         super(scope, id, props);
@@ -24,25 +20,24 @@ export class SharedInfraStack extends Stack {
         }
 
         Tags.of(this).add('SERVICE', id);
+        <% if (example) { %>
+        this.paramExample = StringParameter.fromStringParameterName(
+            this,
+            'ParamExample',
+            `/example/param`
+        );
 
-        // EXAMPLE: Replace with your own SSM parameter lookup
-        // this.eCommerceBaseUrl = StringParameter.fromStringParameterName(
-        //     this,
-        //     'ECommerceBaseUrl',
-        //     `/e-commerce/base-url`
-        // );
-
-        // EXAMPLE: Replace with your own secrets/resources
-        // this.eCommerceCredentials = new Secret(this, 'ECommerceCredentials', {
-        //     description: 'E-Commerce API credentials shared across services',
-        // });
+        this.secretExample = new Secret(this, 'SecretExample', {
+            description: 'Example secret shared across services',
+        });
+        <% } %>
     }
 
-    // EXAMPLE: Update getProps() to return your own resource props
     getProps(): SharedInfraProps {
         return {
-            // eCommerceBaseUrl: this.eCommerceBaseUrl,
-            // eCommerceCredentials: this.eCommerceCredentials,
+            <% if (example) { %>paramExample: this.paramExample,
+            secretExample: this.secretExample,
+            <% } %>
         };
     }
 }

--- a/packages/nx-cdk/src/generators/preset/preset.spec.ts
+++ b/packages/nx-cdk/src/generators/preset/preset.spec.ts
@@ -17,4 +17,22 @@ describe('preset generator', () => {
         const config = readNxJson(tree);
         expect(config).toBeDefined();
     });
+
+    it('should generate example code when example is true', async () => {
+        await presetGenerator(tree, options);
+
+        const infraIndex = tree.read('libs/infra/src/index.ts', 'utf-8');
+        expect(infraIndex).toBeDefined();
+        expect(infraIndex).toContain('paramExample');
+        expect(infraIndex).toContain('secretExample');
+    });
+
+    it('should generate without example code when example is false', async () => {
+        await presetGenerator(tree, { ...options, example: false });
+
+        const infraIndex = tree.read('libs/infra/src/index.ts', 'utf-8');
+        expect(infraIndex).toBeDefined();
+        expect(infraIndex).not.toContain('paramExample');
+        expect(infraIndex).not.toContain('secretExample');
+    });
 });

--- a/packages/nx-cdk/src/generators/preset/preset.spec.ts
+++ b/packages/nx-cdk/src/generators/preset/preset.spec.ts
@@ -6,7 +6,7 @@ import { PresetGeneratorSchema } from './schema';
 
 describe('preset generator', () => {
     let tree: Tree;
-    const options: PresetGeneratorSchema = { name: 'test', nodeVersion: '24.11.0' };
+    const options: PresetGeneratorSchema = { name: 'test', nodeVersion: '24.11.0', example: true };
 
     beforeEach(() => {
         tree = createTreeWithEmptyWorkspace();

--- a/packages/nx-cdk/src/generators/preset/schema.d.ts
+++ b/packages/nx-cdk/src/generators/preset/schema.d.ts
@@ -2,6 +2,6 @@
 export interface PresetGeneratorSchema {
     name: string;
     nodeVersion: string;
-    // FIXME: [MI-281] Add this into schema.json once we move to our own cli tool
     destination?: string;
+    example?: boolean;
 }

--- a/packages/nx-cdk/src/generators/preset/schema.json
+++ b/packages/nx-cdk/src/generators/preset/schema.json
@@ -26,6 +26,17 @@
             "x-prompt": "What is the target Node.js version the project?",
             "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
             "patternErrorMessage": "Node.js version must be a valid semantic version (semver), e.g. 22.10.0 or 24.10.0"
+        },
+        "destination": {
+            "type": "string",
+            "description": "The destination directory for the generated workspace",
+            "pattern": "^[a-zA-Z0-9_./-]+$",
+            "patternErrorMessage": "Destination must be a valid path containing only alphanumeric characters, dashes, underscores, dots, and slashes"
+        },
+        "example": {
+            "type": "boolean",
+            "description": "Generate example code with sample resources",
+            "default": false
         }
     },
     "required": ["name"]

--- a/packages/nx-cdk/src/generators/service/files/src/index.ts.template
+++ b/packages/nx-cdk/src/generators/service/files/src/index.ts.template
@@ -24,7 +24,20 @@ interface Props extends StackProps, SharedInfraProps {
  *
  * Instantiate in a CDK Application Stage to deploy to AWS.
  *
- * Use 'resolve' helpers below when referencing lambda handlers, step function files etc.
+ * @note Aligent provides the following standard CDK constructs:
+ * - {@link NodejsFunctionFromEntry} from '@aligent/cdk-nodejs-function-from-entry'
+ * - {@link StepFunctionFromFile} from '@aligent/cdk-step-function-from-file'
+ *
+ * @example
+ * new NodejsFunctionFromEntry(this, 'ExampleLambda', {
+ *     baseDir: import.meta.dirname,
+ *     entry: 'runtime/handlers/example.ts',
+ * });
+ *
+ * new StepFunctionFromFile(this, 'ExampleStepFunction', {
+ *     baseDir: import.meta.dirname,
+ *     filepath: 'infra/stepfunctions/example.json',
+ * });
  */
 export class <%= stack %> extends Stack {
     constructor(scope: Construct, id: Id, props: Props) {
@@ -36,40 +49,4 @@ export class <%= stack %> extends Stack {
 
         Tags.of(this).add('SERVICE', id);
     }
-}
-
-/**
- * Resolves a path to infra assets relative to this stack
- *
- * @param assetPath - The path to the asset.
- * @returns The resolved path.
- */
-export function resolveAssetPath(assetPath: `${'infra/'}${string}`) {
-    return path.resolve(import.meta.dirname, assetPath);
-}
-
-/**
- * Return an object with the default bundled code asset and
- * handler property for use with the NodejsFunction construct.
- *
- * @example
- * ```ts
- * new NodejsFunction(this, 'FetchData', {
- *     ...resolveLambdaHandler('runtime/handlers/fetch-data.ts'),
- * });
- * ```
- *
- * @param assetPath - The path to the typescript handler file.
- * @returns The resolved bundled code path and handler name.
- */
-export function resolveLambdaHandler(assetPath: `${'runtime/handlers/'}${string}${'.ts'}`) {
-    // Replace 'runtime/handlers/' with '..dist/' and remove the file extension
-    const bundledPath = assetPath.replace(
-        /^runtime\/handlers\/(?<path>.*)\.ts$/,
-        '../dist/$<path>'
-    );
-    return {
-        code: Code.fromAsset(path.resolve(import.meta.dirname, bundledPath)),
-        handler: 'index.handler',
-    };
 }

--- a/packages/nx-cdk/src/generators/service/files/src/index.ts.template
+++ b/packages/nx-cdk/src/generators/service/files/src/index.ts.template
@@ -1,8 +1,6 @@
 import { SharedInfraProps } from '@libs/infra';
 import { Stack, StackProps, Stage, Tags } from 'aws-cdk-lib';
-import { Code } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
-import path from 'node:path';
 
 /**
 * @important

--- a/packages/nx-cdk/src/generators/service/generator.spec.ts
+++ b/packages/nx-cdk/src/generators/service/generator.spec.ts
@@ -45,4 +45,23 @@ describe('service generator', () => {
 
         expect(references).toEqual([{ path: './services/test' }]);
     });
+
+    it('should throw when a duplicate reference path already exists', async () => {
+        const options: ServiceGeneratorSchema = { name: 'test' };
+
+        await serviceGenerator(tree, options);
+
+        await expect(serviceGenerator(tree, options)).rejects.toThrow(
+            'You already have a library using the import path'
+        );
+    });
+
+    it('should not recreate the services folder if it already exists', async () => {
+        tree.write('services/.gitkeep', '');
+
+        const options: ServiceGeneratorSchema = { name: 'test' };
+        await serviceGenerator(tree, options);
+
+        expect(tree.exists('services/.gitkeep')).toBe(true);
+    });
 });


### PR DESCRIPTION
**Description of the proposed changes**

- Remove resolveAssetPath and resolveLambdaHandler from the service template, replacing them with JSDoc pointing users to Aligent's standard CDK constructs (NodejsFunctionFromEntry, StepFunctionFromFile).
- Add an example boolean flag to the preset generator, gating sample resource code (SSM parameter, Secret) behind <% if (example) { %> EJS conditionals.

**Notes to reviewers**

🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
