### PR TITLE
MI-316: Fix error throwing in retry middleware

### DIFF
--- a/.nx/version-plans/version-plan-1776386403305.md
+++ b/.nx/version-plans/version-plan-1776386403305.md
@@ -1,0 +1,6 @@
+---
+microservice-util-lib: minor
+---
+
+- Fix HttpResponseError losing request/response bodies by pre-reading them at creation time. 
+- Add `throwOnNotOk` option to retry middleware for controlling error-throwing behavior.

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts
@@ -1,5 +1,5 @@
 import type { Middleware } from 'openapi-fetch';
-
+import { parseBody } from './utils/body-parser';
 /**
  * Logger interface to support various logging implementations
  * (console, winston, pino, bunyan, etc.)
@@ -10,49 +10,6 @@ interface Logger {
 }
 
 type LogLevel = 'INFO' | 'DEBUG';
-
-/**
- * Parse request/response body based on Content-Type header
- */
-async function parseBody(source: Request | Response, contentType: string | null): Promise<unknown> {
-    const normalizedContentType = contentType ? contentType.toLowerCase() : 'application/json';
-
-    try {
-        if (!source.body) {
-            return 'null';
-        }
-
-        // JSON content
-        if (normalizedContentType.includes('application/json')) {
-            return await source.json();
-        }
-
-        // Text content
-        if (
-            normalizedContentType.includes('text/') ||
-            normalizedContentType.includes('application/xml') ||
-            normalizedContentType.includes('application/x-www-form-urlencoded')
-        ) {
-            return await source.text();
-        }
-
-        // Binary or multipart content - don't parse
-        if (
-            normalizedContentType.includes('multipart/form-data') ||
-            normalizedContentType.includes('application/octet-stream') ||
-            normalizedContentType.includes('image/') ||
-            normalizedContentType.includes('video/') ||
-            normalizedContentType.includes('audio/')
-        ) {
-            return `[Binary content: ${contentType}]`;
-        }
-
-        // Unknown content type, try TEXT as default
-        return await source.text();
-    } catch (error) {
-        return `[Unable to parse ${contentType} body: ${error instanceof Error ? error.message : 'Unknown error'}]`;
-    }
-}
 
 /**
  * Creates a logging middleware for openapi-fetch clients.

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.test.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.test.ts
@@ -699,6 +699,140 @@ describe('retry middleware', () => {
         });
     });
 
+    describe('throwOnNotOk behavior', () => {
+        it('should throw on non-OK response by default (throwOnNotOk defaults to true)', async () => {
+            mockFetch.mockResolvedValue(
+                new Response(JSON.stringify({ error: 'Bad Request' }), {
+                    status: 400,
+                    statusText: 'Bad Request',
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+
+            const client = createClient<paths>({
+                baseUrl: 'https://api.example.com',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(retryMiddleware({ retries: 3, baseDelay: 10 }));
+
+            await expect(client.GET('/test')).rejects.toThrow('400: Bad Request');
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not throw on non-OK response when throwOnNotOk is false', async () => {
+            mockFetch.mockResolvedValue(
+                new Response(JSON.stringify({ error: 'Bad Request' }), {
+                    status: 400,
+                    statusText: 'Bad Request',
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+
+            const client = createClient<paths>({
+                baseUrl: 'https://api.example.com',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(retryMiddleware({ retries: 3, baseDelay: 10, throwOnNotOk: false }));
+
+            const result = await client.GET('/test');
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            expect(result.response.status).toBe(400);
+        });
+
+        it('should return non-OK response after exhausting retries when throwOnNotOk is false', async () => {
+            mockFetch.mockResolvedValue(
+                new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+                    status: 500,
+                    statusText: 'Internal Server Error',
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+
+            const client = createClient<paths>({
+                baseUrl: 'https://api.example.com',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(
+                retryMiddleware({
+                    retries: 2,
+                    baseDelay: 10,
+                    throwOnNotOk: false,
+                    fetch: mockFetch as typeof fetch,
+                })
+            );
+
+            const result = await client.GET('/test');
+
+            // Initial request + 2 retries = 3 total calls
+            expect(mockFetch).toHaveBeenCalledTimes(3);
+            expect(result.response.status).toBe(500);
+        });
+
+        it('should return non-OK response when retryOn does not match and throwOnNotOk is false', async () => {
+            mockFetch.mockResolvedValue(
+                new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+                    status: 500,
+                    statusText: 'Internal Server Error',
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+
+            const client = createClient<paths>({
+                baseUrl: 'https://api.example.com',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(
+                retryMiddleware({
+                    retries: 2,
+                    baseDelay: 10,
+                    retryOn: [502, 503],
+                    throwOnNotOk: false,
+                    fetch: mockFetch as typeof fetch,
+                })
+            );
+
+            const result = await client.GET('/test');
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            expect(result.response.status).toBe(500);
+        });
+
+        it('should still retry retryable errors and return final response when throwOnNotOk is false', async () => {
+            mockFetch
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+                        status: 500,
+                        headers: { 'Content-Type': 'application/json' },
+                    })
+                )
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({ message: 'success' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    })
+                );
+
+            const client = createClient<paths>({
+                baseUrl: 'https://api.example.com',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(
+                retryMiddleware({
+                    retries: 3,
+                    baseDelay: 10,
+                    throwOnNotOk: false,
+                    fetch: mockFetch as typeof fetch,
+                })
+            );
+
+            const result = await client.GET('/test');
+
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+            expect(result.response.status).toBe(200);
+        });
+    });
+
     it('should throw error when final response is not ok after exhausting retries', async () => {
         mockFetch.mockResolvedValue(
             new Response(JSON.stringify({ error: 'Internal Server Error' }), {

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts
@@ -2,6 +2,7 @@ import type { Middleware } from 'openapi-fetch';
 import type { NormalisedConfig, RetryConfig, RetryContext, RetryDelayFn } from './types/retry';
 import { HttpResponseError, isHttpResponseError } from './utils/http-response-error';
 import { isNetworkError } from './utils/is-network-error';
+export type { HttpRequestData, HttpResponseData } from './utils/http-response-error';
 
 const IDEMPOTENT_HTTP_METHODS: string[] = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'] as const;
 
@@ -98,15 +99,17 @@ function shouldRetryOnStatus(status: number, retryOn: number[]): boolean {
 }
 
 /**
- * Checks the response status and throws HttpResponseError if it's not "ok".
+ * Checks the response status and throws HttpResponseError if it's not "ok"
+ * and throwOnNotOk is enabled.
  *
  * @param {Response} response - The HTTP response object.
  * @param {Request} request - The HTTP request object.
- * @throws {HttpResponseError} When the response is not an "ok" response.
+ * @param {boolean} throwOnNotOk - Whether to throw on non-ok responses.
+ * @throws {HttpResponseError} When throwOnNotOk is true and the response is not "ok".
  */
-function throwErrorIfNotOkResponse(response: Response, request: Request) {
-    if (!response.ok) {
-        throw new HttpResponseError(response, request);
+async function throwErrorIfNotOkResponse(response: Response, request: Request, throwOnNotOk: boolean) {
+    if (throwOnNotOk && !response.ok) {
+        throw await HttpResponseError.create(response, request);
     }
 }
 
@@ -167,6 +170,7 @@ function retryMiddleware(config?: RetryConfig): Middleware {
         retryDelay: getRetryDelayFn(config),
         idempotentOnly: config?.idempotentOnly ?? true,
         fetch: config?.fetch ?? fetch,
+        throwOnNotOk: config?.throwOnNotOk ?? true,
     };
 
     return {
@@ -176,7 +180,7 @@ function retryMiddleware(config?: RetryConfig): Middleware {
             // If retryOn is specified, only use that list
             if (config?.retryOn && config.retryOn.length > 0) {
                 if (!shouldRetryOnStatus(response.status, config.retryOn)) {
-                    throwErrorIfNotOkResponse(response, request);
+                    await throwErrorIfNotOkResponse(response, request, normalisedConfig.throwOnNotOk);
                     return response;
                 }
 
@@ -189,7 +193,7 @@ function retryMiddleware(config?: RetryConfig): Middleware {
                 normalisedConfig.idempotentOnly
             );
             if (!shouldRetry) {
-                throwErrorIfNotOkResponse(response, request);
+                await throwErrorIfNotOkResponse(response, request, normalisedConfig.throwOnNotOk);
                 return response;
             }
 
@@ -248,13 +252,13 @@ async function performRetries(config: NormalisedConfig, context: RetryContext): 
         }
 
         if (config.retryOn && !shouldRetryOnStatus(response?.status, config.retryOn)) {
-            throwErrorIfNotOkResponse(response, context.request);
+            await throwErrorIfNotOkResponse(response, context.request, config.throwOnNotOk);
             return response;
         }
 
         const shouldRetry = await config.retryCondition(context, config.idempotentOnly);
         if (!shouldRetry) {
-            throwErrorIfNotOkResponse(response, context.request);
+            await throwErrorIfNotOkResponse(response, context.request, config.throwOnNotOk);
             return response;
         }
     } while (attempt <= maxRetries);
@@ -263,7 +267,7 @@ async function performRetries(config: NormalisedConfig, context: RetryContext): 
         throw context.error;
     }
 
-    throwErrorIfNotOkResponse(response, context.request);
+    await throwErrorIfNotOkResponse(response, context.request, config.throwOnNotOk);
     return response;
 }
 

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts
@@ -107,7 +107,11 @@ function shouldRetryOnStatus(status: number, retryOn: number[]): boolean {
  * @param {boolean} throwOnNotOk - Whether to throw on non-ok responses.
  * @throws {HttpResponseError} When throwOnNotOk is true and the response is not "ok".
  */
-async function throwErrorIfNotOkResponse(response: Response, request: Request, throwOnNotOk: boolean) {
+async function throwErrorIfNotOkResponse(
+    response: Response,
+    request: Request,
+    throwOnNotOk: boolean
+) {
     if (throwOnNotOk && !response.ok) {
         throw await HttpResponseError.create(response, request);
     }
@@ -180,7 +184,11 @@ function retryMiddleware(config?: RetryConfig): Middleware {
             // If retryOn is specified, only use that list
             if (config?.retryOn && config.retryOn.length > 0) {
                 if (!shouldRetryOnStatus(response.status, config.retryOn)) {
-                    await throwErrorIfNotOkResponse(response, request, normalisedConfig.throwOnNotOk);
+                    await throwErrorIfNotOkResponse(
+                        response,
+                        request,
+                        normalisedConfig.throwOnNotOk
+                    );
                     return response;
                 }
 

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts
@@ -4,7 +4,7 @@ import { HttpResponseError, isHttpResponseError } from './utils/http-response-er
 import { isNetworkError } from './utils/is-network-error';
 export type { HttpRequestData, HttpResponseData } from './utils/http-response-error';
 
-const IDEMPOTENT_HTTP_METHODS: string[] = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'] as const;
+const IDEMPOTENT_HTTP_METHODS: readonly string[] = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'];
 
 /**
  * Default retry condition function.
@@ -133,7 +133,7 @@ async function throwErrorIfNotOkResponse(response: Response, request: Request, t
  * const middleware = retryMiddleware({
  *     retries: 5,
  *     retryDelay: 'linear',
- *     retryDelayBase: 200,
+ *     baseDelay: 200,
  *     retryOn: [500, 502, 503, 504],
  *     onRetry: (context) => {
  *         console.log(`Retrying request (attempt ${context.attemptNumber})`);

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts
@@ -19,7 +19,7 @@ export interface RetryContext {
  * Returns true if the request should be retried.
  *
  * @param {RetryContext} context - The retry context containing attempt information.
- * @param {boolean} idempotentOnly - Whether to retry only when the HTTP method is an idempotent methods.
+ * @param {boolean} idempotentOnly - Whether to retry only when the HTTP method is idempotent.
  * @returns {boolean | Promise<boolean>} Whether to retry the request.
  */
 export type RetryConditionFn = (
@@ -65,16 +65,21 @@ export type OnRetryFn = (context: RetryContext) => void | Promise<void>;
  *      - 'exponential': Exponential backoff (100ms * 2^attemptNumber)
  *      - 'linear': Linear backoff (100ms * attemptNumber)
  *      - Custom function: Allows custom delay calculation
- * @property {number} [retryDelayBase=100] - Base delay in milliseconds for built-in delay strategies.
- * @property {number} [maxRetryDelay=30000] - Maximum delay in milliseconds between retry attempts.
+ * @property {number} [baseDelay=100] - Base delay in milliseconds for built-in delay strategies.
+ * @property {number} [maxDelay=30000] - Maximum delay in milliseconds between retry attempts.
  * @property {boolean} [shouldResetTimeout=false] - Whether to reset the timeout between retries.
  * @property {OnRetryFn} [onRetry] - Callback function executed before each retry attempt.
  * @property {number[]} [retryOn]
  * - Array of HTTP status codes that should trigger a retry.
- * - If not specified, defaults to 5xx, 429 and 408 errors.
- * @property {boolean} [idempotentOnly]
- * - Whether to retry only when the HTTP method is an idempotent methods.
- * - If not specified, defaults to true and retry only on GET, HEAD, OPTIONS, PUT or DELETE method.
+ * - Defaults to 5xx, 429, and 408 errors.
+ * @property {boolean} [idempotentOnly=true]
+ * - Whether to retry only when the HTTP method is idempotent.
+ * - Defaults to `true`, retrying only on GET, HEAD, OPTIONS, PUT, or DELETE methods.
+ * @property {boolean} [throwOnNotOk=true]
+ * - Whether to throw an `HttpResponseError` when the final response has a non-OK status (i.e. not 2xx).
+ * - Defaults to `true` for backward compatibility.
+ * - Set to `false` to return the response as-is, which allows downstream middlewares
+ *   (e.g. logging middleware) to inspect the response before the caller handles the error.
  * @property {typeof fetch} [fetch]
  * - Custom fetch function to use for retries. Defaults to the global fetch function.
  * - Useful for testing or using a custom fetch implementation.
@@ -89,16 +94,18 @@ export interface RetryConfig {
     onRetry?: OnRetryFn;
     retryOn?: number[];
     idempotentOnly?: boolean;
+    throwOnNotOk?: boolean;
     fetch?: typeof fetch;
 }
 
 export type NormalisedConfig = Omit<
     RetryConfig,
-    'retries' | 'retryCondition' | 'retryDelay' | 'idempotentOnly' | 'fetch'
+    'retries' | 'retryCondition' | 'retryDelay' | 'idempotentOnly' | 'throwOnNotOk' | 'fetch'
 > & {
     retries: number;
     retryCondition: RetryConditionFn;
     retryDelay: RetryDelayFn;
     idempotentOnly: boolean;
+    throwOnNotOk: boolean;
     fetch: typeof fetch;
 };

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/body-parser.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/body-parser.ts
@@ -1,0 +1,45 @@
+/**
+ * Parse request/response body based on Content-Type header
+ */
+export async function parseBody(
+    source: Request | Response,
+    contentType: string | null
+): Promise<unknown> {
+    const normalizedContentType = contentType ? contentType.toLowerCase() : 'application/json';
+
+    try {
+        if (!source.body) {
+            return 'null';
+        }
+
+        // JSON content
+        if (normalizedContentType.includes('application/json')) {
+            return await source.json();
+        }
+
+        // Text content
+        if (
+            normalizedContentType.includes('text/') ||
+            normalizedContentType.includes('application/xml') ||
+            normalizedContentType.includes('application/x-www-form-urlencoded')
+        ) {
+            return await source.text();
+        }
+
+        // Binary or multipart content - don't parse
+        if (
+            normalizedContentType.includes('multipart/form-data') ||
+            normalizedContentType.includes('application/octet-stream') ||
+            normalizedContentType.includes('image/') ||
+            normalizedContentType.includes('video/') ||
+            normalizedContentType.includes('audio/')
+        ) {
+            return `[Binary content: ${contentType}]`;
+        }
+
+        // Unknown content type, try TEXT as default
+        return await source.text();
+    } catch (error) {
+        return `[Unable to parse ${contentType} body: ${error instanceof Error ? error.message : 'Unknown error'}]`;
+    }
+}

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts
@@ -1,26 +1,86 @@
+import { parseBody } from './body-parser';
+
+/**
+ * Serializable snapshot of an HTTP request.
+ * Captures all meaningful data at creation time so it can be
+ * logged, serialized, or inspected without stream-consumption issues.
+ */
+export interface HttpRequestData {
+    readonly method: string;
+    readonly url: string;
+    readonly params: Record<string, string>;
+    readonly headers: Record<string, string>;
+    readonly body: unknown;
+}
+
+/**
+ * Serializable snapshot of an HTTP response.
+ * Captures all meaningful data at creation time so it can be
+ * logged, serialized, or inspected without stream-consumption issues.
+ */
+export interface HttpResponseData {
+    readonly status: number;
+    readonly statusText: string;
+    readonly headers: Record<string, string>;
+    readonly body: unknown;
+}
+
 /**
  * Custom error class for HTTP response errors, similar to Axios Error.
  * Provides detailed information about the failed request and response.
+ *
+ * Stores pre-read, serializable snapshots of the request and response
+ * rather than raw Request/Response objects, ensuring bodies are always
+ * available for logging and debugging.
  */
 export class HttpResponseError extends Error {
     override readonly name = 'HttpResponseError';
     readonly status: number;
     readonly statusText: string;
-    readonly response: Response;
-    readonly request: Request;
+    readonly response: HttpResponseData;
+    readonly request: HttpRequestData;
     readonly isHttpResponseError = true;
 
-    constructor(response: Response, request: Request) {
+    private constructor(request: HttpRequestData, response: HttpResponseData) {
         super(`${response.status}: ${response.statusText}`);
         this.status = response.status;
         this.statusText = response.statusText;
-        this.response = response;
         this.request = request;
+        this.response = response;
 
         // Maintains proper stack trace for where error was thrown (V8 engines)
         if (Error.captureStackTrace) {
             Error.captureStackTrace(this, HttpResponseError);
         }
+    }
+
+    /**
+     * Creates an HttpResponseError with pre-read request and response bodies.
+     * Bodies are read eagerly so they are available for logging/serialization.
+     */
+    static async create(response: Response, request: Request): Promise<HttpResponseError> {
+        const url = new URL(request.url);
+        const [requestBody, responseBody] = await Promise.all([
+            parseBody(request.clone(), request.headers.get('content-type')),
+            parseBody(response.clone(), response.headers.get('content-type')),
+        ]);
+
+        const requestData: HttpRequestData = {
+            method: request.method,
+            url: request.url,
+            params: Object.fromEntries(url.searchParams.entries()),
+            headers: Object.fromEntries(request.headers.entries()),
+            body: requestBody,
+        };
+
+        const responseData: HttpResponseData = {
+            status: response.status,
+            statusText: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: responseBody,
+        };
+
+        return new HttpResponseError(requestData, responseData);
     }
 
     /**
@@ -32,8 +92,8 @@ export class HttpResponseError extends Error {
             message: this.message,
             status: this.status,
             statusText: this.statusText,
-            method: this.request.method,
-            url: this.request.url,
+            request: this.request,
+            response: this.response,
         };
     }
 }


### PR DESCRIPTION
**Description of the proposed changes**

- Fix HttpResponseError losing request/response bodies by pre-reading them at creation time. 
- Add `throwOnNotOk` option to retry middleware for controlling error-throwing behavior.

**Notes to reviewers**

🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
