### PR TITLE
MI-316: Fixes issues where it attempts to reuse a consumed request

### DIFF
--- a/.nx/version-plans/version-plan-1777531695235.md
+++ b/.nx/version-plans/version-plan-1777531695235.md
@@ -1,0 +1,5 @@
+---
+microservice-util-lib: patch
+---
+
+Fixes type errors caused by consumed requests being reused for retries

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts
@@ -239,9 +239,10 @@ async function performRetries(config: NormalisedConfig, context: RetryContext): 
         }
 
         try {
+            const clonedRequest = context.request.clone();
             const request = config.shouldResetTimeout
-                ? new Request(context.request)
-                : new Request(context.request, { signal: context.request.signal });
+                ? clonedRequest
+                : new Request(clonedRequest, { signal: context.request.signal });
             response = await config.fetch(request);
 
             context = { ...context, attempt: attempt + 1, response, error: null };

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts
@@ -60,10 +60,14 @@ export class HttpResponseError extends Error {
      */
     static async create(response: Response, request: Request): Promise<HttpResponseError> {
         const url = new URL(request.url);
-        const [requestBody, responseBody] = await Promise.all([
-            parseBody(request.clone(), request.headers.get('content-type')),
-            parseBody(response.clone(), response.headers.get('content-type')),
-        ]);
+
+        // If request.bodyUsed is true then it can't be cloned and will throw a type error
+        const requestBody = request.bodyUsed
+            ? null
+            : parseBody(request.clone(), request.headers.get('content-type'));
+        const responseBody = response.bodyUsed
+            ? null
+            : parseBody(response.clone(), response.headers.get('content-type'));
 
         const requestData: HttpRequestData = {
             method: request.method,


### PR DESCRIPTION
**Description of the proposed changes**

- the retry was using a request after it had already been consumed in some instances, which causes a type error `VM741:1 Uncaught TypeError: Failed to execute 'clone' on 'Request': Request body is already used`
- adds another defensive guard for if a consumed request is also used in the error handling

- **Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in the [Aligent Contribution Guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md)

**Notes to reviewers**

🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
