### PR TITLE
MI-322: Add stack-name to workflows & default env to ApplicationStage

### DIFF
--- a/.nx/version-plans/version-plan-1778817879496.md
+++ b/.nx/version-plans/version-plan-1778817879496.md
@@ -1,0 +1,6 @@
+---
+nx-cdk: patch
+---
+
+- Add `stack-name` to deployment workflow templates
+- Set default CDK environment (account/region) in ApplicationStage

--- a/packages/nx-cdk/src/generators/preset/files/.github/workflows/release.yml.template
+++ b/packages/nx-cdk/src/generators/preset/files/.github/workflows/release.yml.template
@@ -12,6 +12,7 @@ jobs:
     with:
       deploy: true
       deploy-command: yarn nx run application:cdk deploy
+      stack-name: prd/*
       environment-target: prd
       github-environment: production
     secrets: inherit

--- a/packages/nx-cdk/src/generators/preset/files/.github/workflows/stg-deployment.yml.template
+++ b/packages/nx-cdk/src/generators/preset/files/.github/workflows/stg-deployment.yml.template
@@ -12,6 +12,7 @@ jobs:
     with:
       deploy: true
       deploy-command: yarn nx run application:cdk deploy
+      stack-name: stg/*
       environment-target: stg
       github-environment: staging
     secrets: inherit

--- a/packages/nx-cdk/src/generators/preset/files/application/lib/service-stacks.ts.template
+++ b/packages/nx-cdk/src/generators/preset/files/application/lib/service-stacks.ts.template
@@ -14,7 +14,13 @@ import type { Construct } from 'constructs';
  */
 export class ApplicationStage extends Stage {
     constructor(scope: Construct, id: string, props?: StageProps) {
-        super(scope, id, props);
+        super(scope, id, {
+            ...props,
+            env: {
+                account: process.env.CDK_DEFAULT_ACCOUNT,
+                region: process.env.CDK_DEFAULT_REGION || 'ap-southeast-2',
+            },
+        });
 
         const sharedInfra = new SharedInfraStack(this, 'shared-infra', props);
 


### PR DESCRIPTION
**Description of the proposed changes**

- Add `stack-name` parameter (`stg/*`, `prd/*`) to the stg and prd deployment workflow templates
- Set default CDK environment (`CDK_DEFAULT_ACCOUNT` / `CDK_DEFAULT_REGION`) in the `ApplicationStage` constructor

**Notes to reviewers**

- 🛈 Toggl Code: _MI-322: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback