### PR TITLE
APP-50 - Add missing webpack-config.cjs to generated appbuilder apps

### DIFF
--- a/.nx/version-plans/version-plan-1779426934482.md
+++ b/.nx/version-plans/version-plan-1779426934482.md
@@ -1,0 +1,5 @@
+---
+nx-appbuilder: patch
+---
+
+Add missing webpack-config.cjs to generated appbuilder apps

--- a/packages/nx-appbuilder/README.md
+++ b/packages/nx-appbuilder/README.md
@@ -103,6 +103,7 @@ The app generator always renders a **base** subtree into `<app-name>/`:
 
 - **Action and test scaffolding**:
   - `src/actions/tsconfig.json` - TypeScript config for the App Builder actions
+  - `src/actions/webpack-config.cjs` - Webpack config used by the `aio` CLI to compile actions via `babel-loader`
   - `tests/tsconfig.json` - TypeScript config for the test suite
   - `hooks/check-action-types.sh` - `pre-app-build` hook that type-checks actions before deploy
   - `global-types/@adobe/aio-sdk/*.d.ts` - Local type augmentations for the Adobe AIO SDK

--- a/packages/nx-appbuilder/src/generators/app/files/base/src/actions/webpack-config.cjs.template
+++ b/packages/nx-appbuilder/src/generators/app/files/base/src/actions/webpack-config.cjs.template
@@ -1,0 +1,34 @@
+// Webpack configuration required to compile typescript action and web source code
+// using the Adobe aio CLI. Adapted from https://github.com/adobe/aio-cli-plugin-app-dev, then switched to babel-loader
+// Appbuilder documentation: https://developer.adobe.com/app-builder/docs/guides/configuration/webpack-configuration/
+
+const path = require('path');
+
+module.exports = {
+    devtool: 'inline-source-map',
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, '..'),
+        },
+        extensions: ['.ts'],
+        extensionAlias: {
+            '.js': ['.ts', '.js'],
+        },
+    },
+    module: {
+        rules: [
+            {
+                // Test for .ts - in theory actions should never use .tsx
+                test: /\.ts$/,
+                exclude: /node_modules/,
+                loader: 'babel-loader',
+                options: {
+                    // Point to the babel config for actions
+                    // This is done to avoid Parcel reading the config file
+                    // while building web code
+                    configFile: './babel.actions.config.js',
+                },
+            },
+        ],
+    },
+};

--- a/packages/nx-appbuilder/src/generators/app/generator.spec.ts
+++ b/packages/nx-appbuilder/src/generators/app/generator.spec.ts
@@ -80,6 +80,10 @@ describe('app generator', () => {
             expect(tree.exists('my-app/tests/tsconfig.json')).toBe(true);
         });
 
+        it('writes the webpack config for actions', () => {
+            expect(tree.exists('my-app/src/actions/webpack-config.cjs')).toBe(true);
+        });
+
         it('writes the pre-build action type-check hook', () => {
             expect(tree.exists('my-app/hooks/check-action-types.sh')).toBe(true);
         });


### PR DESCRIPTION
**Description of the proposed changes**
When aio actions are deployed, TS files are compiled to JS. The `webpack-config.cjs` files is required for this, so it's needed for all apps.

**Screenshots**
N/A

**Other solutions considered (if any)**
N/A

**Notes to reviewers**

- 🛈 Toggl Code: _APP-50: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
