### PR TITLE
chore: rename release branch prefix to release-pr

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,9 +1,9 @@
-name: Release new version
+name: Create new version release PR
 
 on:
   push:
     branches:
-      - releases/**
+      - release-pr/**
 
 permissions:
   contents: write

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   code-quality:
     name: 🕵️‍♀️ Code Quality Check
-    if: ${{ !startsWith(github.head_ref, 'releases/') }}
+    if: ${{ !startsWith(github.head_ref, 'release-pr/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ To bootstrap a new package:
 
 ## Step-by-Step Guide for subsequence releases
 
-1. Start by creating a new `releases/*` branch from the latest `main` branch.
+1. Start by creating a new `release-pr/*` branch from the latest `main` branch.
 
 2. Check if a version plan exist.
    - The version plan is a `version-plan-*.md` file in `.nx/version-plans` folder.
@@ -178,12 +178,12 @@ To bootstrap a new package:
 
      Follow the prompts to select the type of change (patch, minor, major, etc.) and provide a description for each affected package. This will create a version plan file in the repository.
 
-3. Double check your release plan then commit and push your changes to the newly created `releases/*` branch.
+3. Double check your release plan then commit and push your changes to the newly created `release-pr/*` branch.
    - Ensure your change contains only one version plan file.
    - This will trigger the `release` workflow. The workflow will:
      - Detect the version plan file.
      - Release a new version without publishing to NPM.
-     - Push the necessary changes to your `releases/*` branch.
+     - Push the necessary changes to your `release-pr/*` branch.
      - Remove the version plan file after a successful releasing.
      - Open a "Publish" pull request targeting the `main` branch.
 


### PR DESCRIPTION
**Description of the proposed changes**

- Rename the release branch prefix from `releases/**` to `release-pr/**` to adapt with new branch protection rules
- Rename workflow file from `release.yml` to `create-release-pr.yml` with updated workflow name
- Update README documentation to reflect the new branch prefix

**Other solutions considered**

- Updating branch protection rules to allow `releases/**` — not feasible given the new protection policy

**Notes to reviewers**

- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback