### PR TITLE
MI-321: widen aws-wrappers logger option to LoggerInterface

### DIFF
--- a/packages/aws-wrappers/CLAUDE.md
+++ b/packages/aws-wrappers/CLAUDE.md
@@ -31,9 +31,10 @@ These are non-negotiable across every service in the package — change them onl
 ### Constructor
 
 ```ts
-constructor(opts?: { logger?: Logger; client?: <ServiceClient> })
+constructor(opts?: { logger?: LoggerInterface; client?: <ServiceClient> })
 ```
 
+- `logger` is typed as `LoggerInterface` (from `@aws-lambda-powertools/logger/types`), **not** the concrete `Logger` class. This avoids the dual-package hazard for ESM consumers — TS treats the ESM and CJS builds of the `Logger` class as nominally distinct (each has its own `#private` field), but `LoggerInterface` is a structural type alias so both builds are mutually assignable. The wrapper still defaults to `new Logger()` internally; only the public type widens.
 - `logger` defaults to `new Logger()`, which picks up `POWERTOOLS_SERVICE_NAME` from the environment. Do **not** pass `serviceName` in the default — env-driven service naming is the Powertools convention.
 - `client` defaults to `captureAWSv3Client(new <ServiceClient>())`. When the caller supplies a client, the wrapper does **not** apply X-Ray instrumentation — that's the caller's call.
 - No `clientConfig` / `region` / `endpoint` options. Callers needing those construct their own client and pass it via `client`.

--- a/packages/aws-wrappers/src/dynamodb/dynamodb.ts
+++ b/packages/aws-wrappers/src/dynamodb/dynamodb.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@aws-lambda-powertools/logger';
+import type { LoggerInterface } from '@aws-lambda-powertools/logger/types';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import {
     BatchGetCommand,
@@ -153,7 +154,7 @@ type WithTypedKey<TInput, K extends Record<string, unknown>> = Omit<TInput, 'Key
  */
 export class DynamoDBService {
     private readonly client: DynamoDBDocumentClient;
-    private readonly logger: Logger;
+    private readonly logger: LoggerInterface;
 
     /**
      * @param opts.logger - Optional Powertools logger. Defaults to `new Logger()`,
@@ -164,7 +165,7 @@ export class DynamoDBService {
      * *before* being passed to `DynamoDBDocumentClient.from`, so X-Ray
      * tracing captures every DynamoDB call.
      */
-    constructor(opts?: { logger?: Logger; client?: DynamoDBDocumentClient }) {
+    constructor(opts?: { logger?: LoggerInterface; client?: DynamoDBDocumentClient }) {
         this.client =
             opts?.client ??
             DynamoDBDocumentClient.from(captureAWSv3Client(new DynamoDBClient({})), {

--- a/packages/aws-wrappers/src/s3/s3.ts
+++ b/packages/aws-wrappers/src/s3/s3.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@aws-lambda-powertools/logger';
+import type { LoggerInterface } from '@aws-lambda-powertools/logger/types';
 import {
     CopyObjectCommand,
     CopyObjectCommandInput,
@@ -66,7 +67,7 @@ const PUT_JSON_OBJECT_SAFE_FIELDS: ReadonlyArray<keyof PutJsonObjectInput<unknow
  */
 export class S3Service {
     private readonly client: S3Client;
-    private readonly logger: Logger;
+    private readonly logger: LoggerInterface;
 
     /**
      * @param opts.logger - Optional Powertools logger. Defaults to `new Logger()`,
@@ -74,7 +75,7 @@ export class S3Service {
      * @param opts.client - Optional pre-configured `S3Client`. When supplied,
      * the wrapper does not apply X-Ray instrumentation.
      */
-    constructor(opts?: { logger?: Logger; client?: S3Client }) {
+    constructor(opts?: { logger?: LoggerInterface; client?: S3Client }) {
         this.client = opts?.client ?? captureAWSv3Client(new S3Client());
         this.logger = opts?.logger ?? new Logger();
     }

--- a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts
+++ b/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@aws-lambda-powertools/logger';
+import type { LoggerInterface } from '@aws-lambda-powertools/logger/types';
 import {
     CreateSecretCommand,
     CreateSecretCommandInput,
@@ -70,7 +71,7 @@ const DELETE_SECRET_SAFE_FIELDS: ReadonlyArray<keyof DeleteSecretCommandInput> =
  */
 export class SecretsManagerService {
     private readonly client: SecretsManagerClient;
-    private readonly logger: Logger;
+    private readonly logger: LoggerInterface;
 
     /**
      * @param opts.logger - Optional Powertools logger. Defaults to `new Logger()`,
@@ -79,7 +80,7 @@ export class SecretsManagerService {
      * supplied, the wrapper does not apply X-Ray instrumentation — the caller
      * owns that decision.
      */
-    constructor(opts?: { logger?: Logger; client?: SecretsManagerClient }) {
+    constructor(opts?: { logger?: LoggerInterface; client?: SecretsManagerClient }) {
         this.client = opts?.client ?? captureAWSv3Client(new SecretsManagerClient());
         this.logger = opts?.logger ?? new Logger();
     }

--- a/packages/aws-wrappers/src/sfn/sfn.ts
+++ b/packages/aws-wrappers/src/sfn/sfn.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@aws-lambda-powertools/logger';
+import type { LoggerInterface } from '@aws-lambda-powertools/logger/types';
 import {
     DescribeExecutionCommand,
     DescribeExecutionCommandInput,
@@ -34,7 +35,7 @@ const START_EXECUTION_SAFE_FIELDS: ReadonlyArray<keyof StartExecutionCommandInpu
  */
 export class StepFunctionsService {
     private readonly client: SFNClient;
-    private readonly logger: Logger;
+    private readonly logger: LoggerInterface;
 
     /**
      * @param opts.logger - Optional Powertools logger. Defaults to `new Logger()`,
@@ -42,7 +43,7 @@ export class StepFunctionsService {
      * @param opts.client - Optional pre-configured `SFNClient`. When supplied,
      * the wrapper does not apply X-Ray instrumentation.
      */
-    constructor(opts?: { logger?: Logger; client?: SFNClient }) {
+    constructor(opts?: { logger?: LoggerInterface; client?: SFNClient }) {
         this.client = opts?.client ?? captureAWSv3Client(new SFNClient());
         this.logger = opts?.logger ?? new Logger();
     }

--- a/packages/aws-wrappers/src/sns/sns.ts
+++ b/packages/aws-wrappers/src/sns/sns.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@aws-lambda-powertools/logger';
+import type { LoggerInterface } from '@aws-lambda-powertools/logger/types';
 import {
     PublishBatchCommand,
     PublishBatchCommandInput,
@@ -37,7 +38,7 @@ const PUBLISH_SAFE_FIELDS: ReadonlyArray<keyof PublishCommandInput> = [
  */
 export class SNSService {
     private readonly client: SNSClient;
-    private readonly logger: Logger;
+    private readonly logger: LoggerInterface;
     private readonly truncate: boolean;
 
     /**
@@ -51,7 +52,7 @@ export class SNSService {
      * usually the right failure mode. Each `publish` call can override via
      * its own `truncate` option.
      */
-    constructor(opts?: { logger?: Logger; client?: SNSClient; truncate?: boolean }) {
+    constructor(opts?: { logger?: LoggerInterface; client?: SNSClient; truncate?: boolean }) {
         this.client = opts?.client ?? captureAWSv3Client(new SNSClient());
         this.logger = opts?.logger ?? new Logger();
         this.truncate = opts?.truncate ?? false;

--- a/packages/aws-wrappers/src/sqs/sqs.ts
+++ b/packages/aws-wrappers/src/sqs/sqs.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@aws-lambda-powertools/logger';
+import type { LoggerInterface } from '@aws-lambda-powertools/logger/types';
 import {
     DeleteMessageBatchCommand,
     DeleteMessageBatchCommandInput,
@@ -44,7 +45,7 @@ const SEND_MESSAGE_SAFE_FIELDS: ReadonlyArray<keyof SendMessageCommandInput> = [
  */
 export class SQSService {
     private readonly client: SQSClient;
-    private readonly logger: Logger;
+    private readonly logger: LoggerInterface;
     private readonly truncate: boolean;
 
     /**
@@ -57,7 +58,7 @@ export class SQSService {
      * `false`. Each `sendMessage` call can override via its own `truncate`
      * option.
      */
-    constructor(opts?: { logger?: Logger; client?: SQSClient; truncate?: boolean }) {
+    constructor(opts?: { logger?: LoggerInterface; client?: SQSClient; truncate?: boolean }) {
         this.client = opts?.client ?? captureAWSv3Client(new SQSClient());
         this.logger = opts?.logger ?? new Logger();
         this.truncate = opts?.truncate ?? false;

--- a/packages/aws-wrappers/src/ssm/ssm.ts
+++ b/packages/aws-wrappers/src/ssm/ssm.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@aws-lambda-powertools/logger';
+import type { LoggerInterface } from '@aws-lambda-powertools/logger/types';
 import {
     DeleteParameterCommand,
     GetParameterCommand,
@@ -45,7 +46,7 @@ const PUT_PARAMETER_SAFE_FIELDS: ReadonlyArray<keyof PutParameterCommandInput> =
  */
 export class SSMService {
     private readonly client: SSMClient;
-    private readonly logger: Logger;
+    private readonly logger: LoggerInterface;
 
     /**
      * @param opts.logger - Optional Powertools logger. Defaults to `new Logger()`,
@@ -53,7 +54,7 @@ export class SSMService {
      * @param opts.client - Optional pre-configured `SSMClient`. When supplied,
      * the wrapper does not apply X-Ray instrumentation.
      */
-    constructor(opts?: { logger?: Logger; client?: SSMClient }) {
+    constructor(opts?: { logger?: LoggerInterface; client?: SSMClient }) {
         this.client = opts?.client ?? captureAWSv3Client(new SSMClient());
         this.logger = opts?.logger ?? new Logger();
     }

--- a/packages/aws-wrappers/src/util/redact.ts
+++ b/packages/aws-wrappers/src/util/redact.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@aws-lambda-powertools/logger';
+import type { LoggerInterface } from '@aws-lambda-powertools/logger/types';
 
 /**
  * Return a log-safe projection of `input` based on the logger's configured level.
@@ -17,7 +17,7 @@ import { Logger } from '@aws-lambda-powertools/logger';
  * the design rationale and conventions on building the safe-field lists.
  */
 export function filterFieldsForLogLevel<T extends object, K extends keyof T>(
-    logger: Logger,
+    logger: LoggerInterface,
     input: T,
     safeFields: readonly K[]
 ): T | Pick<T, K> {


### PR DESCRIPTION
**Description of the proposed changes**

- Widen the `logger` constructor option (and the internal `filterFieldsForLogLevel` helper) across every `*Service` in `@aligent/aws-wrappers` from the concrete `Logger` class to the structural `LoggerInterface` type from `@aws-lambda-powertools/logger/types`.
- Update the package's `CLAUDE.md` to reflect the new locked-in constructor convention, with rationale.

**Why**

The wrappers ship as CommonJS, but `@aws-lambda-powertools/logger` ships dual ESM/CJS builds via conditional exports. An ESM consumer's `import { Logger }` resolves to the ESM `Logger.d.ts`; the wrapper's published `.d.ts` was emitted in CJS context, so it references the CJS `Logger.d.ts`. Each class has its own ECMAScript `#private` field, so TypeScript treats them as nominally distinct — passing `new Logger()` from an ESM consumer to `new S3Service({ logger })` produced TS2322 (`Property '#private' refers to a different member...`).

`LoggerInterface` is a structural type alias with no `#private` brand, and Powertools exports structurally-identical definitions from both builds. A `Logger` instance from either build now satisfies the wrapper's parameter type from either build.

**Other solutions considered**

- **Dual ESM/CJS publish.** A proper fix for the broader hazard, but a significant change to the build and publish pipeline (two tsc passes, conditional `exports` map, per-format `package.json` shims, explicit `.js` extensions on every relative import). It also diverges from the rest of the monorepo, where every package is CJS-only — keeping `aws-wrappers` aligned with that pattern is preferable until there's a broader reason to dual-publish.
- **Document the workaround** (omit the `logger` option, let each wrapper instantiate its own). Loses shared per-request context (`logger.addContext(ctx)` from the handler doesn't propagate) — real ergonomic regression for consumers.

Going with `LoggerInterface` keeps the package consistent with the rest of the monorepo and gives consumers more flexibility: any logger satisfying the structural shape is accepted, not just a `Logger` instance.

**Notes to reviewers**

- 🛈 Toggl Code: _MI-321: Code Review_
- No runtime change — `new Logger()` is still the default. Only the public type widens.
- All four logger methods used by the package (`getLevelName`, `info`, `setLogLevel`, `warn`) are present on `LoggerInterface`.
- `npx nx run aws-wrappers:typecheck`, `test` (113 passing), and `lint --fix` all green.
- Version plan deliberately omitted from this branch — will land on a separate `release-pr/*` branch per the repo's release process docs.
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback