### PR TITLE
MI-325: Fix retry and oAuth10a conflict

### DIFF
--- a/.nx/version-plans/version-plan-1780122297898.md
+++ b/.nx/version-plans/version-plan-1780122297898.md
@@ -1,0 +1,32 @@
+---
+microservice-util-lib: minor
+---
+
+### Retry middleware: `onRetry` hook now supports request transformation
+
+The `onRetry` callback can now optionally return a `Request` to replace the current request before retrying. If it returns `void`, the original request is used as-is. This merges the observation and transformation concerns into a single hook.
+
+```ts
+// Logging only (returns void)
+onRetry: (context) => {
+    console.log(`Retrying (attempt ${context.attempt})`);
+},
+
+// Re-sign OAuth 1.0a + logging (returns Request)
+onRetry: async (context) => {
+    console.log(`Retrying (attempt ${context.attempt})`);
+    return resignOauth10aRequest(context.request, oauthConfig);
+},
+```
+
+### New: `resignOauth10aRequest` standalone function
+
+Re-signs a `Request` with fresh OAuth 1.0a credentials (nonce, timestamp, signature) without requiring openapi-fetch middleware context. Designed for use with the `onRetry` hook to regenerate signatures on retried requests.
+
+### Internal: extracted `signOauth10a` core
+
+The shared OAuth 1.0a signing logic is now in a single `signOauth10a` helper, used by both `generateOauthParams` (middleware path) and `resignOauth10aRequest` (standalone path).
+
+### Tests
+
+Added test coverage for `onRetry` request transformation, `resignOauth10aRequest`, `HttpResponseError`, and body parser utilities.

--- a/nx.json
+++ b/nx.json
@@ -2,7 +2,7 @@
     "$schema": "./node_modules/nx/schemas/nx-schema.json",
     "defaultBase": "origin/main",
     "tui": {
-        "enabled": false
+        "enabled": true
     },
     "sync": {
         "applyChanges": true

--- a/packages/microservice-util-lib/src/index.ts
+++ b/packages/microservice-util-lib/src/index.ts
@@ -12,6 +12,7 @@ import {
     basicAuthMiddleware,
     oAuth10aAuthMiddleware,
     oAuth20AuthMiddleware,
+    resignOauth10aRequest,
 } from './openapi-fetch-middlewares/authentications';
 import { LogLevel, Logger, logMiddleware } from './openapi-fetch-middlewares/log';
 import {
@@ -47,6 +48,7 @@ export {
     oAuth10aAuthMiddleware,
     oAuth20AuthMiddleware,
     remap,
+    resignOauth10aRequest,
     retryMiddleware,
     retryWrapper,
 };

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.test.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.test.ts
@@ -133,4 +133,141 @@ describe('authentications middlewares', () => {
         const request = mockFetch.mock.calls?.[0]?.[0] as Request;
         expect(request.headers.get('Authorization')).toBe('Bearer mock-access-token');
     });
+
+    describe('static and sync function values', () => {
+        it('apiKeyAuthMiddleware should accept a static string value', async () => {
+            const config: ApiKey = {
+                header: 'x-api-key',
+                value: 'static-api-key',
+            };
+
+            const client = createClient<paths>({
+                baseUrl: 'https://base.url/api',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(apiKeyAuthMiddleware(config));
+
+            await client.GET('/path');
+
+            const request = mockFetch.mock.calls?.[0]?.[0] as Request;
+            expect(request.headers.get('x-api-key')).toBe('static-api-key');
+        });
+
+        it('apiKeyAuthMiddleware should accept a sync function value', async () => {
+            const config: ApiKey = {
+                header: 'x-api-key',
+                value: () => 'sync-api-key',
+            };
+
+            const client = createClient<paths>({
+                baseUrl: 'https://base.url/api',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(apiKeyAuthMiddleware(config));
+
+            await client.GET('/path');
+
+            const request = mockFetch.mock.calls?.[0]?.[0] as Request;
+            expect(request.headers.get('x-api-key')).toBe('sync-api-key');
+        });
+
+        it('basicAuthMiddleware should accept a static credentials object', async () => {
+            const config: Basic = {
+                credentials: { username: 'user', password: 'pass' },
+            };
+
+            const client = createClient<paths>({
+                baseUrl: 'https://base.url/api',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(basicAuthMiddleware(config));
+
+            await client.GET('/path');
+
+            const request = mockFetch.mock.calls?.[0]?.[0] as Request;
+            expect(request.headers.get('Authorization')).toBe(
+                'Basic ' + Buffer.from('user:pass').toString('base64')
+            );
+        });
+
+        it('basicAuthMiddleware should accept a sync function returning credentials', async () => {
+            const config: Basic = {
+                credentials: () => ({ username: 'user', password: 'pass' }),
+            };
+
+            const client = createClient<paths>({
+                baseUrl: 'https://base.url/api',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(basicAuthMiddleware(config));
+
+            await client.GET('/path');
+
+            const request = mockFetch.mock.calls?.[0]?.[0] as Request;
+            expect(request.headers.get('Authorization')).toBe(
+                'Basic ' + Buffer.from('user:pass').toString('base64')
+            );
+        });
+
+        it('oAuth20AuthMiddleware should accept a static token string', async () => {
+            const config: OAuth20 = {
+                token: 'static-token',
+                tokenType: 'Bearer',
+            };
+
+            const client = createClient<paths>({
+                baseUrl: 'https://base.url/api',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(oAuth20AuthMiddleware(config));
+
+            await client.GET('/path');
+
+            const request = mockFetch.mock.calls?.[0]?.[0] as Request;
+            expect(request.headers.get('Authorization')).toBe('Bearer static-token');
+        });
+
+        it('oAuth20AuthMiddleware should accept a sync function returning a token', async () => {
+            const config: OAuth20 = {
+                token: () => 'sync-token',
+                tokenType: 'Bearer',
+            };
+
+            const client = createClient<paths>({
+                baseUrl: 'https://base.url/api',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(oAuth20AuthMiddleware(config));
+
+            await client.GET('/path');
+
+            const request = mockFetch.mock.calls?.[0]?.[0] as Request;
+            expect(request.headers.get('Authorization')).toBe('Bearer sync-token');
+        });
+
+        it('oAuth10aAuthMiddleware should accept a static credentials object', async () => {
+            vi.spyOn(oauth10aAuth, 'generateOauthParams').mockResolvedValue('mock-oauth-params');
+
+            const config: OAuth10a = {
+                algorithm: 'HMAC-SHA256',
+                credentials: {
+                    consumerKey: 'k',
+                    consumerSecret: 's',
+                    token: 't',
+                    tokenSecret: 'ts',
+                },
+            };
+
+            const client = createClient<paths>({
+                baseUrl: 'https://base.url/api',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(oAuth10aAuthMiddleware(config));
+
+            await client.GET('/path');
+
+            const request = mockFetch.mock.calls?.[0]?.[0] as Request;
+            expect(request.headers.get('Authorization')).toBe('OAuth mock-oauth-params');
+        });
+    });
 });

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts
@@ -1,6 +1,17 @@
 import type { Middleware } from 'openapi-fetch';
 import { generateOauthParams } from './oauth10a/oauth10a';
-import type { ApiKey, Basic, OAuth10a, OAuth20 } from './types/authentications';
+import type { ApiKey, Basic, OAuth10a, OAuth20, Resolvable } from './types/authentications';
+
+/**
+ * Resolves a `Resolvable<T>` value to its underlying type.
+ * If the value is a function, it is called and awaited; otherwise, it is returned as-is.
+ *
+ * @param {Resolvable<T>} value - The resolvable value.
+ * @returns {Promise<T>} The resolved value.
+ */
+async function resolve<T>(value: Resolvable<T>): Promise<T> {
+    return typeof value === 'function' ? await (value as () => T | Promise<T>)() : value;
+}
 
 /**
  * Creates an openapi-fetch middleware for API key authentication.
@@ -10,15 +21,23 @@ import type { ApiKey, Basic, OAuth10a, OAuth20 } from './types/authentications';
  * @returns {Middleware} The middleware for API key authentication.
  *
  * @example
+ * // Static value
  * const middleware = apiKeyAuthMiddleware({
  *     header: 'x-api-key',
- *     value: async () => 'your-api-key',
+ *     value: 'your-api-key',
+ * });
+ *
+ * @example
+ * // Dynamic value (async function)
+ * const middleware = apiKeyAuthMiddleware({
+ *     header: 'x-api-key',
+ *     value: async () => fetchApiKey(),
  * });
  */
 function apiKeyAuthMiddleware(config: ApiKey): Middleware {
     return {
         onRequest: async ({ request }) => {
-            request.headers.set(config.header, await config.value());
+            request.headers.set(config.header, await resolve(config.value));
         },
     };
 }
@@ -32,14 +51,21 @@ function apiKeyAuthMiddleware(config: ApiKey): Middleware {
  * @returns {Middleware} The middleware for Basic authentication.
  *
  * @example
+ * // Static credentials
  * const middleware = basicAuthMiddleware({
- *     credentials: async () => ({ username: 'user', password: 'pass' }),
+ *     credentials: { username: 'user', password: 'pass' },
+ * });
+ *
+ * @example
+ * // Dynamic credentials (async function)
+ * const middleware = basicAuthMiddleware({
+ *     credentials: async () => fetchCredentials(),
  * });
  */
 function basicAuthMiddleware(config: Basic): Middleware {
     return {
         onRequest: async ({ request }) => {
-            const { username, password } = await config.credentials();
+            const { username, password } = await resolve(config.credentials);
 
             request.headers.set(
                 'Authorization',
@@ -58,14 +84,22 @@ function basicAuthMiddleware(config: Basic): Middleware {
  * @returns {Middleware} The middleware for OAuth 1.0a authentication.
  *
  * @example
+ * // Static credentials
  * const middleware = oAuth10aAuthMiddleware({
  *     algorithm: 'HMAC-SHA256',
- *     credentials: async () => ({
+ *     credentials: {
  *         consumerKey: 'key',
  *         consumerSecret: 'secret',
  *         token: 'token',
  *         tokenSecret: 'tokenSecret',
- *     }),
+ *     },
+ * });
+ *
+ * @example
+ * // Dynamic credentials (async function)
+ * const middleware = oAuth10aAuthMiddleware({
+ *     algorithm: 'HMAC-SHA256',
+ *     credentials: async () => fetchOAuthCredentials(),
  * });
  */
 function oAuth10aAuthMiddleware(config: OAuth10a): Middleware {
@@ -86,8 +120,16 @@ function oAuth10aAuthMiddleware(config: OAuth10a): Middleware {
  * @returns {Middleware} The middleware for OAuth 2.0 authentication.
  *
  * @example
+ * // Static token
  * const middleware = oAuth20AuthMiddleware({
- *     token: async () => 'your-access-token',
+ *     token: 'your-access-token',
+ *     tokenType: 'Bearer',
+ * });
+ *
+ * @example
+ * // Dynamic token (async function)
+ * const middleware = oAuth20AuthMiddleware({
+ *     token: async () => fetchAccessToken(),
  *     tokenType: 'Bearer',
  * });
  */
@@ -96,11 +138,12 @@ function oAuth20AuthMiddleware(options: OAuth20): Middleware {
         onRequest: async ({ request }) => {
             const { tokenType = 'Bearer' } = options;
 
-            request.headers.set('Authorization', `${tokenType} ${await options.token()}`);
+            request.headers.set('Authorization', `${tokenType} ${await resolve(options.token)}`);
         },
     };
 }
 
-export type { ApiKey, Basic, OAuth10a, OAuth20 };
+export { resolve };
+export type { ApiKey, Basic, OAuth10a, OAuth20, Resolvable };
 
 export { apiKeyAuthMiddleware, basicAuthMiddleware, oAuth10aAuthMiddleware, oAuth20AuthMiddleware };

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts
@@ -1,5 +1,5 @@
 import type { Middleware } from 'openapi-fetch';
-import { generateOauthParams } from './oauth10a/oauth10a';
+import { generateOauthParams, resignOauth10aRequest } from './oauth10a/oauth10a';
 import type { ApiKey, Basic, OAuth10a, OAuth20, Resolvable } from './types/authentications';
 
 /**
@@ -146,4 +146,10 @@ function oAuth20AuthMiddleware(options: OAuth20): Middleware {
 export { resolve };
 export type { ApiKey, Basic, OAuth10a, OAuth20, Resolvable };
 
-export { apiKeyAuthMiddleware, basicAuthMiddleware, oAuth10aAuthMiddleware, oAuth20AuthMiddleware };
+export {
+    apiKeyAuthMiddleware,
+    basicAuthMiddleware,
+    oAuth10aAuthMiddleware,
+    oAuth20AuthMiddleware,
+    resignOauth10aRequest,
+};

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.test.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.test.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import { MiddlewareCallbackParams } from 'openapi-fetch';
 import { vi } from 'vitest';
 import { OAuth10a } from '../authentications';
-import { generateOauthParams } from './oauth10a';
+import { generateOauthParams, resignOauth10aRequest } from './oauth10a';
 
 describe('generateOauthParams', () => {
     const baseRequest: MiddlewareCallbackParams['request'] = {
@@ -318,5 +318,188 @@ describe('generateOauthParams', () => {
 
         const result = await generateOauthParams(request, options, params, config);
         expect(result).toEqual(expected);
+    });
+});
+
+describe('resignOauth10aRequest', () => {
+    const credentials = {
+        consumerKey: 'k',
+        consumerSecret: 's',
+        token: 't',
+        tokenSecret: 'ts',
+    };
+
+    beforeEach(() => {
+        vi.spyOn(crypto, 'randomUUID').mockReturnValue('123-456-789-0ab-cde');
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2025-04-30T12:00:00Z'));
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('should return a Request with a valid OAuth Authorization header', async () => {
+        const request = new Request('https://base.url/path/with/string');
+        const config: OAuth10a = {
+            algorithm: 'HMAC-SHA256',
+            credentials,
+        };
+
+        const result = await resignOauth10aRequest(request, config);
+
+        expect(result).toBeInstanceOf(Request);
+        const authHeader = result.headers.get('Authorization');
+        expect(authHeader).not.toBeNull();
+        expect(authHeader).toMatch(/^OAuth /);
+        expect(authHeader).toContain('oauth_consumer_key="k"');
+        expect(authHeader).toContain('oauth_nonce="123-456-789-0ab-cde"');
+        expect(authHeader).toContain('oauth_timestamp="1746014400"');
+        expect(authHeader).toContain('oauth_signature_method="HMAC-SHA256"');
+        expect(authHeader).toContain('oauth_version="1.0"');
+        expect(authHeader).toContain('oauth_token="t"');
+        expect(authHeader).toContain('oauth_signature=');
+    });
+
+    it('should generate fresh nonce and timestamp on each invocation', async () => {
+        const config: OAuth10a = {
+            algorithm: 'HMAC-SHA256',
+            credentials,
+        };
+
+        vi.mocked(crypto.randomUUID).mockReturnValueOnce(
+            'nonce-1' as `${string}-${string}-${string}-${string}-${string}`
+        );
+        vi.setSystemTime(new Date('2025-04-30T12:00:00Z'));
+        const result1 = await resignOauth10aRequest(new Request('https://base.url/path'), config);
+
+        vi.mocked(crypto.randomUUID).mockReturnValueOnce(
+            'nonce-2' as `${string}-${string}-${string}-${string}-${string}`
+        );
+        vi.setSystemTime(new Date('2025-04-30T12:01:00Z'));
+        const result2 = await resignOauth10aRequest(new Request('https://base.url/path'), config);
+
+        const auth1 = result1.headers.get('Authorization');
+        const auth2 = result2.headers.get('Authorization');
+
+        expect(auth1).toContain('oauth_nonce="nonce-1"');
+        expect(auth2).toContain('oauth_nonce="nonce-2"');
+        expect(auth1).toContain('oauth_timestamp="1746014400"');
+        expect(auth2).toContain('oauth_timestamp="1746014460"');
+    });
+
+    it('should handle GET request with query parameters', async () => {
+        const request = new Request('https://base.url/path?a=1&b=2');
+        const config: OAuth10a = {
+            algorithm: 'HMAC-SHA256',
+            credentials,
+        };
+
+        const result = await resignOauth10aRequest(request, config);
+
+        const authHeader = result.headers.get('Authorization');
+        expect(authHeader).toContain('oauth_signature=');
+    });
+
+    it('should handle POST with JSON body and generate body hash', async () => {
+        const request = new Request('https://base.url/path', {
+            method: 'POST',
+            body: '{"a":1,"b":2}',
+        });
+        const config: OAuth10a = {
+            algorithm: 'HMAC-SHA256',
+            credentials,
+        };
+
+        const result = await resignOauth10aRequest(request, config);
+
+        const authHeader = result.headers.get('Authorization');
+        expect(authHeader).toContain('oauth_body_hash=');
+        expect(authHeader).toContain('oauth_signature=');
+    });
+
+    it('should handle POST with form-encoded body', async () => {
+        const request = new Request('https://base.url/path', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: 'a=1&b=2',
+        });
+        const config: OAuth10a = {
+            algorithm: 'HMAC-SHA1',
+            credentials,
+        };
+
+        const result = await resignOauth10aRequest(request, config);
+
+        const authHeader = result.headers.get('Authorization');
+        expect(authHeader).not.toContain('oauth_body_hash=');
+        expect(authHeader).toContain('oauth_signature=');
+    });
+
+    it('should handle request with no body', async () => {
+        const request = new Request('https://base.url/path');
+        const config: OAuth10a = {
+            algorithm: 'HMAC-SHA1',
+            credentials,
+        };
+
+        const result = await resignOauth10aRequest(request, config);
+
+        const authHeader = result.headers.get('Authorization');
+        expect(authHeader).not.toContain('oauth_body_hash=');
+        expect(authHeader).toContain('oauth_signature=');
+    });
+
+    it('should produce the same signature as generateOauthParams for equivalent requests', async () => {
+        const config: OAuth10a = {
+            algorithm: 'HMAC-SHA256',
+            credentials: () => Promise.resolve(credentials),
+        };
+
+        // Use generateOauthParams with middleware-style params
+        const middlewareRequest: MiddlewareCallbackParams['request'] = {
+            method: 'get',
+            url: 'path/with/string',
+            cache: 'default',
+            credentials: 'same-origin',
+            headers: new Headers(),
+            integrity: '',
+            keepalive: false,
+            mode: 'cors',
+            redirect: 'follow',
+            referrer: '',
+            referrerPolicy: '',
+            signal: new AbortController().signal,
+            body: null,
+            bodyUsed: false,
+            destination: 'document',
+            duplex: 'half',
+            arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+            blob: () => Promise.resolve(new Blob(Array(new ArrayBuffer(0)))),
+            formData: () => Promise.resolve(new FormData()),
+            json: () => Promise.resolve({}),
+            text: () => Promise.resolve(''),
+            clone: () => ({ ...middlewareRequest }),
+        };
+        const options: MiddlewareCallbackParams['options'] = {
+            baseUrl: 'https://base.url',
+            bodySerializer: () => '',
+            fetch: () => Promise.resolve(new Response()),
+            pathSerializer: () => '',
+            querySerializer: () => '',
+            parseAs: 'json',
+        };
+
+        const middlewareResult = await generateOauthParams(middlewareRequest, options, {}, config);
+
+        // Use generateOauth10aParams with a real Request (fully resolved URL)
+        const standaloneResult = await resignOauth10aRequest(
+            new Request('https://base.url/path/with/string'),
+            config
+        );
+
+        const standaloneAuth = standaloneResult.headers.get('Authorization');
+        expect(standaloneAuth).toBe(`OAuth ${middlewareResult}`);
     });
 });

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.ts
@@ -155,33 +155,25 @@ function shouldGenerateBodyHash(
     return includeBodyHash === true;
 }
 
+interface SignOauth10aInput {
+    method: string;
+    oauthUrl: string;
+    contentType: string | null;
+    body: string;
+    query: URLSearchParams | Record<string, unknown> | undefined;
+}
+
 /**
- * Generates OAuth 1.0a parameters for signing a request.
+ * Core signing logic shared by both the middleware path and the standalone re-sign path.
  *
- * @param {MiddlewareCallbackParams['request']} request - The request object.
- * @param {MiddlewareCallbackParams['options']} options - The options object.
- * @param {MiddlewareCallbackParams['params']} params - The parameters object.
- * @param {OAuth10a} config - The OAuth 1.0a configuration.
- * @returns {Promise<string>} The generated OAuth 1.0a Authorization header.
+ * @param input - The request details needed for signing.
+ * @param config - The OAuth 1.0a configuration.
+ * @returns The OAuth 1.0a Authorization header value (without the "OAuth " prefix).
  */
-export async function generateOauthParams(
-    request: MiddlewareCallbackParams['request'],
-    options: MiddlewareCallbackParams['options'],
-    params: MiddlewareCallbackParams['params'],
-    config: OAuth10a
-): Promise<string> {
+async function signOauth10a(input: SignOauth10aInput, config: OAuth10a): Promise<string> {
     const { algorithm, includeBodyHash = 'auto', realm, callback, verifier } = config;
+    const { method, oauthUrl, body, contentType, query } = input;
     const { consumerKey, consumerSecret, token, tokenSecret } = await resolve(config.credentials);
-
-    // Due to the way that openapi-fetch & fetch API are implemented in NodeJS (undici),
-    // each request only can be used ONCE. We have to clone the request like this to extract information
-    // Otherwise, undici will not be able to create & send the request.
-    const clonedRequest = request.clone();
-
-    const method = (clonedRequest.method || 'GET').toUpperCase();
-    const url = combineUrlAndPathParams(clonedRequest.url, params.path);
-    const contentType = clonedRequest.headers.get('Content-Type');
-    const body = await clonedRequest.text();
 
     const oauthParams: Record<string, string> = {
         oauth_consumer_key: consumerKey,
@@ -209,8 +201,8 @@ export async function generateOauthParams(
 
     addParamsToSign(paramsToSign, oauthParams);
 
-    if (params.query) {
-        addParamsToSign(paramsToSign, params.query);
+    if (query) {
+        addParamsToSign(paramsToSign, query);
     }
 
     // If user submit a form, then include form parameters in the
@@ -227,7 +219,6 @@ export async function generateOauthParams(
         addParamToSign(paramsToSign, 'oauth_body_hash', bodyHash);
     }
 
-    const oauthUrl = getOAuthUrl(options.baseUrl, url);
     oauthParams.oauth_signature = sign(
         algorithm,
         method,
@@ -248,4 +239,73 @@ export async function generateOauthParams(
     return Object.entries(oauthParams)
         .map(e => [e[0], '="', rfc3986(e[1]), '"'].join(''))
         .join(',');
+}
+
+/**
+ * Generates OAuth 1.0a parameters for signing a request.
+ *
+ * @param {MiddlewareCallbackParams['request']} request - The request object.
+ * @param {MiddlewareCallbackParams['options']} options - The options object.
+ * @param {MiddlewareCallbackParams['params']} params - The parameters object.
+ * @param {OAuth10a} config - The OAuth 1.0a configuration.
+ * @returns {Promise<string>} The generated OAuth 1.0a Authorization header.
+ */
+export async function generateOauthParams(
+    request: MiddlewareCallbackParams['request'],
+    options: MiddlewareCallbackParams['options'],
+    params: MiddlewareCallbackParams['params'],
+    config: OAuth10a
+): Promise<string> {
+    const clonedRequest = request.clone();
+    const method = (clonedRequest.method || 'GET').toUpperCase();
+    const url = combineUrlAndPathParams(clonedRequest.url, params.path);
+
+    return signOauth10a(
+        {
+            method,
+            oauthUrl: getOAuthUrl(options.baseUrl, url),
+            contentType: clonedRequest.headers.get('Content-Type'),
+            body: await clonedRequest.text(),
+            query: params.query,
+        },
+        config
+    );
+}
+
+/**
+ * Standalone function that re-signs a `Request` with fresh OAuth 1.0a credentials.
+ * This function derives all information (URL, method, query params, body)
+ * directly from the `Request` object, without requiring openapi-fetch middleware context.
+ *
+ * Designed for use with the retry middleware's `onRetry` hook to regenerate
+ * OAuth 1.0a signatures on retried requests.
+ *
+ * @param {Request} request - The request to re-sign.
+ * @param {OAuth10a} config - The OAuth 1.0a configuration.
+ * @returns {Promise<Request>} The request with a fresh `Authorization` header.
+ *
+ * @example
+ * client.use(retryMiddleware({
+ *     onRetry: ({ request }) => resignOauth10aRequest(request, config),
+ * }));
+ */
+export async function resignOauth10aRequest(request: Request, config: OAuth10a): Promise<Request> {
+    const clonedRequest = request.clone();
+    const method = (clonedRequest.method || 'GET').toUpperCase();
+    const parsedUrl = new URL(clonedRequest.url);
+
+    const oauthParams = await signOauth10a(
+        {
+            method,
+            oauthUrl: getOAuthUrl(parsedUrl.origin, parsedUrl.pathname),
+            contentType: clonedRequest.headers.get('Content-Type'),
+            body: await clonedRequest.text(),
+            query: parsedUrl.search ? parsedUrl.searchParams : undefined,
+        },
+        config
+    );
+
+    request.headers.set('Authorization', `OAuth ${oauthParams}`);
+
+    return request;
 }

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import { rfc3986, sign } from 'oauth-sign';
 import { MiddlewareCallbackParams } from 'openapi-fetch';
-import { OAuth10a } from '../authentications';
+import { OAuth10a, resolve } from '../authentications';
 
 /**
  * Determines whether a given URL is absolute.
@@ -171,7 +171,7 @@ export async function generateOauthParams(
     config: OAuth10a
 ): Promise<string> {
     const { algorithm, includeBodyHash = 'auto', realm, callback, verifier } = config;
-    const { consumerKey, consumerSecret, token, tokenSecret } = await config.credentials();
+    const { consumerKey, consumerSecret, token, tokenSecret } = await resolve(config.credentials);
 
     // Due to the way that openapi-fetch & fetch API are implemented in NodeJS (undici),
     // each request only can be used ONCE. We have to clone the request like this to extract information

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.test.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.test.ts
@@ -833,6 +833,197 @@ describe('retry middleware', () => {
         });
     });
 
+    describe('onRetry request transformation', () => {
+        it('should transform the request when onRetry returns a Request', async () => {
+            const retryFetch = vi.fn();
+
+            // Initial request returns 500, retry succeeds
+            mockFetch.mockResolvedValueOnce(
+                new Response(JSON.stringify({ error: 'Server Error' }), {
+                    status: 500,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+            retryFetch.mockResolvedValueOnce(
+                new Response(JSON.stringify({ message: 'success' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+
+            const client = createClient<paths>({
+                baseUrl: 'https://api.example.com',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(
+                retryMiddleware({
+                    retries: 2,
+                    baseDelay: 10,
+                    fetch: retryFetch as typeof fetch,
+                    onRetry: ({ request }) => {
+                        request.headers.set('X-Retry-Token', 'refreshed');
+                        return request;
+                    },
+                })
+            );
+
+            await client.GET('/test');
+
+            expect(retryFetch).toHaveBeenCalledTimes(1);
+            const firstCall = retryFetch.mock.calls[0];
+            if (!firstCall) throw new Error('Expected retryFetch to have been called');
+            const retriedRequest = firstCall[0] as Request;
+            expect(retriedRequest.headers.get('X-Retry-Token')).toBe('refreshed');
+        });
+
+        it('should keep the original request when onRetry returns void', async () => {
+            const retryFetch = vi.fn();
+            const onRetry = vi.fn();
+
+            mockFetch.mockResolvedValueOnce(
+                new Response(JSON.stringify({ error: 'Server Error' }), {
+                    status: 500,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+            retryFetch.mockResolvedValueOnce(
+                new Response(JSON.stringify({ message: 'success' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+
+            const client = createClient<paths>({
+                baseUrl: 'https://api.example.com',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(
+                retryMiddleware({
+                    retries: 2,
+                    baseDelay: 10,
+                    fetch: retryFetch as typeof fetch,
+                    onRetry,
+                })
+            );
+
+            await client.GET('/test');
+
+            expect(onRetry).toHaveBeenCalledTimes(1);
+            expect(retryFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not be called on the initial request', async () => {
+            const onRetry = vi.fn();
+
+            mockFetch.mockResolvedValueOnce(
+                new Response(JSON.stringify({ message: 'success' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+
+            const client = createClient<paths>({
+                baseUrl: 'https://api.example.com',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(
+                retryMiddleware({
+                    retries: 2,
+                    baseDelay: 10,
+                    onRetry,
+                })
+            );
+
+            await client.GET('/test');
+
+            expect(onRetry).not.toHaveBeenCalled();
+        });
+
+        it('should receive the correct RetryContext', async () => {
+            const retryFetch = vi.fn();
+            const onRetry = vi.fn((ctx: { request: Request }) => ctx.request);
+
+            mockFetch.mockResolvedValueOnce(
+                new Response(JSON.stringify({ error: 'Server Error' }), {
+                    status: 500,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+            retryFetch.mockResolvedValueOnce(
+                new Response(JSON.stringify({ message: 'success' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+
+            const client = createClient<paths>({
+                baseUrl: 'https://api.example.com',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(
+                retryMiddleware({
+                    retries: 2,
+                    baseDelay: 10,
+                    fetch: retryFetch as typeof fetch,
+                    onRetry,
+                })
+            );
+
+            await client.GET('/test');
+
+            expect(onRetry).toHaveBeenCalledTimes(1);
+            expect(onRetry).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    attempt: 1,
+                    request: expect.any(Request),
+                    response: expect.any(Response),
+                    error: null,
+                })
+            );
+        });
+
+        it('should await async onRetry functions that return a Request', async () => {
+            const retryFetch = vi.fn();
+
+            mockFetch.mockResolvedValueOnce(
+                new Response(JSON.stringify({ error: 'Server Error' }), {
+                    status: 500,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+            retryFetch.mockResolvedValueOnce(
+                new Response(JSON.stringify({ message: 'success' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+
+            const client = createClient<paths>({
+                baseUrl: 'https://api.example.com',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(
+                retryMiddleware({
+                    retries: 2,
+                    baseDelay: 10,
+                    fetch: retryFetch as typeof fetch,
+                    onRetry: async ({ request }) => {
+                        await new Promise(resolve => setTimeout(resolve, 10));
+                        request.headers.set('X-Async-Header', 'async-value');
+                        return request;
+                    },
+                })
+            );
+
+            await client.GET('/test');
+
+            const firstCall = retryFetch.mock.calls[0];
+            if (!firstCall) throw new Error('Expected retryFetch to have been called');
+            const retriedRequest = firstCall[0] as Request;
+            expect(retriedRequest.headers.get('X-Async-Header')).toBe('async-value');
+        });
+    });
+
     it('should throw error when final response is not ok after exhausting retries', async () => {
         mockFetch.mockResolvedValue(
             new Response(JSON.stringify({ error: 'Internal Server Error' }), {

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts
@@ -133,14 +133,31 @@ async function throwErrorIfNotOkResponse(
  * const middleware = retryMiddleware();
  *
  * @example
- * // Custom configuration
+ * // Custom configuration with logging
  * const middleware = retryMiddleware({
  *     retries: 5,
  *     retryDelay: 'linear',
  *     baseDelay: 200,
  *     retryOn: [500, 502, 503, 504],
  *     onRetry: (context) => {
- *         console.log(`Retrying request (attempt ${context.attemptNumber})`);
+ *         console.log(`Retrying request (attempt ${context.attempt})`);
+ *     },
+ * });
+ *
+ * @example
+ * // Re-sign OAuth 1.0a requests on retry (returns a Request to replace the original)
+ * const middleware = retryMiddleware({
+ *     retries: 3,
+ *     onRetry: (context) => resignOauth10aRequest(context.request, oauthConfig),
+ * });
+ *
+ * @example
+ * // Combine logging and request transformation in onRetry
+ * const middleware = retryMiddleware({
+ *     retries: 3,
+ *     onRetry: async (context) => {
+ *         console.log(`Retrying request (attempt ${context.attempt})`);
+ *         return resignOauth10aRequest(context.request, oauthConfig);
  *     },
  * });
  *
@@ -150,7 +167,7 @@ async function throwErrorIfNotOkResponse(
  *     retries: 3,
  *     retryCondition: async (context) => {
  *         // Only retry on 503 Service Unavailable
- *         return context.response.status === 503;
+ *         return context.response?.status === 503;
  *     },
  * });
  *
@@ -235,7 +252,10 @@ async function performRetries(config: NormalisedConfig, context: RetryContext): 
         await new Promise(resolve => setTimeout(resolve, delay));
 
         if (config.onRetry) {
-            await config.onRetry({ ...context, attempt, response });
+            const mutatedReq = await config.onRetry({ ...context, attempt, response });
+            if (mutatedReq instanceof Request) {
+                context = { ...context, attempt, request: mutatedReq };
+            }
         }
 
         try {

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts
@@ -1,41 +1,58 @@
 /**
+ * A value that can be provided either statically or as a function (sync or async).
+ * Used by authentication config interfaces to allow both static credentials
+ * and dynamic credential retrieval (e.g., from a secrets manager).
+ *
+ * @example
+ * // Static value
+ * const value: Resolvable<string> = 'my-api-key';
+ *
+ * // Sync function
+ * const value: Resolvable<string> = () => getKey();
+ *
+ * // Async function
+ * const value: Resolvable<string> = async () => await fetchKey();
+ */
+export type Resolvable<T> = T | (() => T | Promise<T>);
+
+/**
  * Represents an API key authentication method.
  *
  * This interface is used for API key-based authentication, where the key is sent
- * in a specific header. The value of the API key is retrieved asynchronously.
+ * in a specific header. The value can be a static string or a function that returns one.
  *
  * @interface ApiKey
  * @property {string} header - The header name where the API key will be set.
- * @property {() => Promise<string>} value - A function that returns a promise resolving to the API key value.
+ * @property {Resolvable<string>} value - The API key value, or a function returning it.
  */
 export interface ApiKey {
     header: string;
-    value: () => Promise<string>;
+    value: Resolvable<string>;
 }
 
 /**
  * Represents basic authentication credentials.
  *
  * This interface is used for basic authentication, where the username and password
- * are retrieved asynchronously.
+ * can be provided statically or retrieved dynamically via a function.
  *
  * @interface Basic
- * @property {() => Promise<{ username: string; password: string }>} credentials - A function that returns a promise resolving to the username and password.
+ * @property {Resolvable<{ username: string; password: string }>} credentials - The credentials, or a function returning them.
  */
 export interface Basic {
-    credentials: () => Promise<{ username: string; password: string }>;
+    credentials: Resolvable<{ username: string; password: string }>;
 }
 
 /**
  * Represents OAuth 1.0a authentication credentials.
  *
  * This interface is used for OAuth 1.0a authentication, where the consumer key, consumer secret,
- * token, and token secret are retrieved asynchronously. It also supports optional parameters
- * like body hash inclusion, realm, callback, and verifier.
+ * token, and token secret can be provided statically or retrieved dynamically via a function.
+ * It also supports optional parameters like body hash inclusion, realm, callback, and verifier.
  *
  * @interface OAuth10a
  * @property {'HMAC-SHA1' | 'HMAC-SHA256'} algorithm - The signing algorithm to use.
- * @property {() => Promise<{ consumerKey: string; consumerSecret: string; token?: string; tokenSecret: string }>} credentials - A function that returns a promise resolving to the OAuth 1.0a credentials.
+ * @property {Resolvable<{ consumerKey: string; consumerSecret: string; token?: string; tokenSecret: string }>} credentials - The OAuth 1.0a credentials, or a function returning them.
  * @property {boolean | 'auto'} [includeBodyHash] - Whether to include a body hash in the signature. Defaults to 'auto'.
  * @property {string} [realm] - The realm parameter for the Authorization header.
  * @property {string} [callback] - The callback URL for OAuth 1.0a.
@@ -43,7 +60,7 @@ export interface Basic {
  */
 export interface OAuth10a {
     algorithm: 'HMAC-SHA1' | 'HMAC-SHA256';
-    credentials: () => Promise<{
+    credentials: Resolvable<{
         consumerKey: string;
         consumerSecret: string;
         token?: string;
@@ -58,14 +75,15 @@ export interface OAuth10a {
 /**
  * Represents OAuth 2.0 authentication credentials.
  *
- * This interface is used for OAuth 2.0 authentication, where an access token is retrieved
- * asynchronously. It also supports an optional token type (e.g., 'Bearer').
+ * This interface is used for OAuth 2.0 authentication, where an access token can be
+ * provided statically or retrieved dynamically via a function.
+ * It also supports an optional token type (e.g., 'Bearer').
  *
  * @interface OAuth20
- * @property {() => Promise<string>} token - A function that returns a promise resolving to the access token.
+ * @property {Resolvable<string>} token - The access token, or a function returning it.
  * @property {string} [tokenType] - The type of the token (e.g., 'Bearer'). Defaults to 'Bearer' if not specified.
  */
 export interface OAuth20 {
-    token: () => Promise<string>;
+    token: Resolvable<string>;
     tokenType?: string;
 }

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts
@@ -41,10 +41,15 @@ export type RetryDelayFn = (attempt: number, context: RetryContext) => number | 
  * Function type for the onRetry callback.
  * Called before each retry attempt.
  *
+ * - If the function returns a `Request` (or `Promise<Request>`), that request replaces
+ *   the current one for the retry attempt. This is useful for regenerating authentication
+ *   headers (e.g., OAuth 1.0a re-signing).
+ * - If the function returns `void`, the original request is used as-is.
+ *
  * @param {RetryContext} context - The retry context containing attempt information.
- * @returns {void | Promise<void>}
+ * @returns {Request | void | Promise<Request | void>}
  */
-export type OnRetryFn = (context: RetryContext) => void | Promise<void>;
+export type OnRetryFn = (context: RetryContext) => Request | void | Promise<Request | void>;
 
 /**
  * Configuration for the retry middleware.
@@ -68,7 +73,11 @@ export type OnRetryFn = (context: RetryContext) => void | Promise<void>;
  * @property {number} [baseDelay=100] - Base delay in milliseconds for built-in delay strategies.
  * @property {number} [maxDelay=30000] - Maximum delay in milliseconds between retry attempts.
  * @property {boolean} [shouldResetTimeout=false] - Whether to reset the timeout between retries.
- * @property {OnRetryFn} [onRetry] - Callback function executed before each retry attempt.
+ * @property {OnRetryFn} [onRetry]
+ * - Callback executed before each retry attempt (not the initial request).
+ * - If it returns a `Request`, that request replaces the current one for the retry.
+ *   Useful for regenerating authentication headers (e.g., OAuth 1.0a re-signing).
+ * - If it returns `void`, the original request is used as-is.
  * @property {number[]} [retryOn]
  * - Array of HTTP status codes that should trigger a retry.
  * - Defaults to 5xx, 429, and 408 errors.

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/body-parser.test.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/body-parser.test.ts
@@ -1,0 +1,181 @@
+import { parseBody } from './body-parser';
+
+describe('parseBody', () => {
+    describe('JSON content', () => {
+        it('should parse application/json body', async () => {
+            const body = { key: 'value' };
+            const response = new Response(JSON.stringify(body), {
+                headers: { 'Content-Type': 'application/json' },
+            });
+
+            const result = await parseBody(response, 'application/json');
+
+            expect(result).toEqual(body);
+        });
+
+        it('should parse application/json with charset', async () => {
+            const body = { key: 'value' };
+            const response = new Response(JSON.stringify(body), {
+                headers: { 'Content-Type': 'application/json; charset=utf-8' },
+            });
+
+            const result = await parseBody(response, 'application/json; charset=utf-8');
+
+            expect(result).toEqual(body);
+        });
+
+        it('should default to application/json when contentType is null', async () => {
+            const body = { key: 'value' };
+            const response = new Response(JSON.stringify(body));
+
+            const result = await parseBody(response, null);
+
+            expect(result).toEqual(body);
+        });
+    });
+
+    describe('text content', () => {
+        it('should parse text/plain body', async () => {
+            const response = new Response('hello world', {
+                headers: { 'Content-Type': 'text/plain' },
+            });
+
+            const result = await parseBody(response, 'text/plain');
+
+            expect(result).toBe('hello world');
+        });
+
+        it('should parse text/html body', async () => {
+            const html = '<html><body>test</body></html>';
+            const response = new Response(html, {
+                headers: { 'Content-Type': 'text/html' },
+            });
+
+            const result = await parseBody(response, 'text/html');
+
+            expect(result).toBe(html);
+        });
+
+        it('should parse application/xml body', async () => {
+            const xml = '<root><item>test</item></root>';
+            const response = new Response(xml, {
+                headers: { 'Content-Type': 'application/xml' },
+            });
+
+            const result = await parseBody(response, 'application/xml');
+
+            expect(result).toBe(xml);
+        });
+
+        it('should parse application/x-www-form-urlencoded body', async () => {
+            const form = 'key=value&foo=bar';
+            const response = new Response(form, {
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            });
+
+            const result = await parseBody(response, 'application/x-www-form-urlencoded');
+
+            expect(result).toBe(form);
+        });
+    });
+
+    describe('binary content', () => {
+        it('should return placeholder for multipart/form-data', async () => {
+            const response = new Response('binary data', {
+                headers: { 'Content-Type': 'multipart/form-data' },
+            });
+
+            const result = await parseBody(response, 'multipart/form-data');
+
+            expect(result).toBe('[Binary content: multipart/form-data]');
+        });
+
+        it('should return placeholder for application/octet-stream', async () => {
+            const response = new Response('binary', {
+                headers: { 'Content-Type': 'application/octet-stream' },
+            });
+
+            const result = await parseBody(response, 'application/octet-stream');
+
+            expect(result).toBe('[Binary content: application/octet-stream]');
+        });
+
+        it('should return placeholder for image content types', async () => {
+            const response = new Response('image data', {
+                headers: { 'Content-Type': 'image/png' },
+            });
+
+            const result = await parseBody(response, 'image/png');
+
+            expect(result).toBe('[Binary content: image/png]');
+        });
+
+        it('should return placeholder for video content types', async () => {
+            const response = new Response('video data', {
+                headers: { 'Content-Type': 'video/mp4' },
+            });
+
+            const result = await parseBody(response, 'video/mp4');
+
+            expect(result).toBe('[Binary content: video/mp4]');
+        });
+
+        it('should return placeholder for audio content types', async () => {
+            const response = new Response('audio data', {
+                headers: { 'Content-Type': 'audio/mpeg' },
+            });
+
+            const result = await parseBody(response, 'audio/mpeg');
+
+            expect(result).toBe('[Binary content: audio/mpeg]');
+        });
+    });
+
+    describe('empty body', () => {
+        it('should return "null" when body is null', async () => {
+            const response = new Response(null);
+
+            const result = await parseBody(response, 'application/json');
+
+            expect(result).toBe('null');
+        });
+    });
+
+    describe('unknown content type', () => {
+        it('should fall back to text for unknown content types', async () => {
+            const content = 'some unknown content';
+            const response = new Response(content, {
+                headers: { 'Content-Type': 'application/vnd.custom' },
+            });
+
+            const result = await parseBody(response, 'application/vnd.custom');
+
+            expect(result).toBe(content);
+        });
+    });
+
+    describe('error handling', () => {
+        it('should return error message when parsing fails', async () => {
+            const response = new Response('not json', {
+                headers: { 'Content-Type': 'application/json' },
+            });
+            // Consume the body so .json() will fail
+            await response.text();
+
+            const result = await parseBody(response, 'application/json');
+
+            expect(result).toMatch(/\[Unable to parse application\/json body:/);
+        });
+    });
+
+    describe('case insensitivity', () => {
+        it('should handle uppercase content-type', async () => {
+            const body = { key: 'value' };
+            const response = new Response(JSON.stringify(body));
+
+            const result = await parseBody(response, 'APPLICATION/JSON');
+
+            expect(result).toEqual(body);
+        });
+    });
+});

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.test.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.test.ts
@@ -53,7 +53,11 @@ describe('HttpResponseError', () => {
         });
 
         it('should capture response data', async () => {
-            const response = createTestResponse(502, 'Bad Gateway', JSON.stringify({ error: 'upstream' }));
+            const response = createTestResponse(
+                502,
+                'Bad Gateway',
+                JSON.stringify({ error: 'upstream' })
+            );
             const request = createTestRequest({ contentType: 'application/json' });
 
             const error = await HttpResponseError.create(response, request);
@@ -116,7 +120,10 @@ describe('HttpResponseError', () => {
 describe('isHttpResponseError', () => {
     it('should return true for HttpResponseError instances', async () => {
         const request = new Request('https://api.example.com/test', { method: 'GET' });
-        const response = new Response('error', { status: 500, statusText: 'Internal Server Error' });
+        const response = new Response('error', {
+            status: 500,
+            statusText: 'Internal Server Error',
+        });
 
         const error = await HttpResponseError.create(response, request);
 

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.test.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.test.ts
@@ -1,0 +1,151 @@
+import { HttpResponseError, isHttpResponseError } from './http-response-error';
+
+describe('HttpResponseError', () => {
+    const createTestRequest = (options?: { body?: string; contentType?: string }): Request => {
+        const headers: Record<string, string> = {};
+        if (options?.contentType) {
+            headers['Content-Type'] = options.contentType;
+        }
+        return new Request('https://api.example.com/test?foo=bar&baz=qux', {
+            method: 'POST',
+            headers,
+            body: options?.body ?? JSON.stringify({ request: 'data' }),
+        });
+    };
+
+    const createTestResponse = (
+        status: number,
+        statusText: string,
+        body?: string,
+        contentType = 'application/json'
+    ): Response => {
+        return new Response(body ?? JSON.stringify({ error: 'something went wrong' }), {
+            status,
+            statusText,
+            headers: { 'Content-Type': contentType },
+        });
+    };
+
+    describe('create', () => {
+        it('should create an error with correct status and message', async () => {
+            const request = createTestRequest({ contentType: 'application/json' });
+            const response = createTestResponse(404, 'Not Found');
+
+            const error = await HttpResponseError.create(response, request);
+
+            expect(error).toBeInstanceOf(HttpResponseError);
+            expect(error).toBeInstanceOf(Error);
+            expect(error.status).toBe(404);
+            expect(error.statusText).toBe('Not Found');
+            expect(error.message).toBe('404: Not Found');
+            expect(error.name).toBe('HttpResponseError');
+        });
+
+        it('should capture request data', async () => {
+            const request = createTestRequest({ contentType: 'application/json' });
+            const response = createTestResponse(500, 'Internal Server Error');
+
+            const error = await HttpResponseError.create(response, request);
+
+            expect(error.request.method).toBe('POST');
+            expect(error.request.url).toBe('https://api.example.com/test?foo=bar&baz=qux');
+            expect(error.request.params).toEqual({ foo: 'bar', baz: 'qux' });
+        });
+
+        it('should capture response data', async () => {
+            const response = createTestResponse(502, 'Bad Gateway', JSON.stringify({ error: 'upstream' }));
+            const request = createTestRequest({ contentType: 'application/json' });
+
+            const error = await HttpResponseError.create(response, request);
+
+            expect(error.response.status).toBe(502);
+            expect(error.response.statusText).toBe('Bad Gateway');
+            expect(error.response.headers['content-type']).toBe('application/json');
+        });
+
+        it('should handle request with already-consumed body', async () => {
+            const request = createTestRequest({ contentType: 'application/json' });
+            await request.text(); // consume the body
+            const response = createTestResponse(400, 'Bad Request');
+
+            const error = await HttpResponseError.create(response, request);
+
+            expect(error.request.body).toBeNull();
+        });
+
+        it('should handle response with already-consumed body', async () => {
+            const response = createTestResponse(400, 'Bad Request');
+            await response.text(); // consume the body
+            const request = createTestRequest({ contentType: 'application/json' });
+
+            const error = await HttpResponseError.create(response, request);
+
+            expect(error.response.body).toBeNull();
+        });
+
+        it('should set isHttpResponseError flag', async () => {
+            const request = createTestRequest({ contentType: 'application/json' });
+            const response = createTestResponse(500, 'Internal Server Error');
+
+            const error = await HttpResponseError.create(response, request);
+
+            expect(error.isHttpResponseError).toBe(true);
+        });
+    });
+
+    describe('toJson', () => {
+        it('should return a serializable representation', async () => {
+            const request = createTestRequest({ contentType: 'application/json' });
+            const response = createTestResponse(422, 'Unprocessable Entity');
+
+            const error = await HttpResponseError.create(response, request);
+            const json = error.toJson();
+
+            expect(json).toEqual({
+                name: 'HttpResponseError',
+                message: '422: Unprocessable Entity',
+                status: 422,
+                statusText: 'Unprocessable Entity',
+                request: error.request,
+                response: error.response,
+            });
+        });
+    });
+});
+
+describe('isHttpResponseError', () => {
+    it('should return true for HttpResponseError instances', async () => {
+        const request = new Request('https://api.example.com/test', { method: 'GET' });
+        const response = new Response('error', { status: 500, statusText: 'Internal Server Error' });
+
+        const error = await HttpResponseError.create(response, request);
+
+        expect(isHttpResponseError(error)).toBe(true);
+    });
+
+    it('should return true for duck-typed objects with isHttpResponseError flag', () => {
+        const fakeLike = { isHttpResponseError: true, message: 'fake' };
+
+        expect(isHttpResponseError(fakeLike)).toBe(true);
+    });
+
+    it('should return false for regular errors', () => {
+        expect(isHttpResponseError(new Error('regular error'))).toBe(false);
+    });
+
+    it('should return false for null', () => {
+        expect(isHttpResponseError(null)).toBe(false);
+    });
+
+    it('should return false for undefined', () => {
+        expect(isHttpResponseError(undefined)).toBe(false);
+    });
+
+    it('should return false for non-error objects', () => {
+        expect(isHttpResponseError({ message: 'not an error' })).toBe(false);
+    });
+
+    it('should return false for objects with isHttpResponseError set to false', () => {
+        expect(isHttpResponseError({ isHttpResponseError: false })).toBe(false);
+    });
+});


### PR DESCRIPTION
**Description of the proposed changes**

- Extends the `onRetry` callback in the retry middleware to optionally return a `Request`, enabling request transformation (e.g. re-signing OAuth 1.0a) before retrying
- Adds a new `resignOauth10aRequest` standalone function for re-signing requests with fresh OAuth 1.0a credentials outside middleware context
- Extracts shared OAuth 1.0a signing logic into a single `signOauth10a` helper used by both the middleware and standalone paths
- Allows auth middlewares (`apiKeyAuthMiddleware`, `bearerAuthMiddleware`, `oauth2ClientCredentialsMiddleware`) to accept static string values alongside functions
- Adds comprehensive test coverage for retry transformation, `resignOauth10aRequest`, `HttpResponseError`, and body parser utilities
- Enables TUI for Nx

**Other solutions considered**

- Separate `transformRequest` hook on retry middleware — rejected in favour of merging observation and transformation into a single `onRetry` hook for simpler API surface

**Notes to reviewers**

- 🛈 Toggl Code: _MI-325: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback