### PR TITLE
MI-251: Allow custom shim and externals for vite-plugin-handler

### DIFF
--- a/packages/vite-plugin-handler/README.md
+++ b/packages/vite-plugin-handler/README.md
@@ -31,14 +31,36 @@ export default defineConfig({
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `concurrency` | `number` | `Infinity` | Max concurrent environment builds. Useful for resource-constrained CI. |
-| `shims` | `boolean` | `true` | Inject CJS `__dirname`/`__filename` shim banner into each bundle. |
+| `shims` | `boolean \| string` | `true` | Inject CJS `__dirname`/`__filename` shim banner into each bundle. Pass a string to use a custom banner instead. |
+| `external` | `(string \| RegExp)[]` | `[]` | Additional modules to exclude from the bundle, appended to Node.js built-ins. |
 | `moduleTypes` | `Record<string, string>` | `{}` | Extra Rolldown module type overrides (e.g. `{ '.graphql': 'text' }`). |
 
 ```js
 handlerBundle('src/runtime/handlers', {
     concurrency: 2,
     shims: false,
+    external: ['@aws-sdk/client-s3', /^@smithy\//],
     moduleTypes: { '.graphql': 'text' },
+});
+```
+
+### Custom shims
+
+Pass a string to `shims` to replace the built-in banner with your own:
+
+```js
+handlerBundle('src/runtime/handlers', {
+    shims: 'const MY_VAR = "value";',
+});
+```
+
+To compose with the built-in shim, import `shimBanner` and concatenate:
+
+```js
+import { handlerBundle, shimBanner } from '@aligent/vite-plugin-handler';
+
+handlerBundle('src/runtime/handlers', {
+    shims: `${shimBanner}\nconst MY_VAR = "value";`,
 });
 ```
 

--- a/packages/vite-plugin-handler/src/index.ts
+++ b/packages/vite-plugin-handler/src/index.ts
@@ -1,2 +1,3 @@
 export { handlerBundle } from './lib/handler-bundle.js';
 export type { HandlerBundleOptions } from './lib/handler-bundle.js';
+export { shimBanner } from './lib/shim-banner.js';

--- a/packages/vite-plugin-handler/src/lib/handler-bundle.spec.ts
+++ b/packages/vite-plugin-handler/src/lib/handler-bundle.spec.ts
@@ -180,6 +180,68 @@ describe('handlerBundle', () => {
         expect(output['banner']).toBeUndefined();
     });
 
+    it('uses custom shim string when shims is a string', () => {
+        const customShim = 'const __custom = "shim";';
+        const plugin = handlerBundle('src/handlers', { shims: customShim });
+        const result = callConfigHook(plugin) as Record<string, unknown>;
+
+        const environments = result['environments'] as Record<string, Record<string, unknown>>;
+        const env = Object.values(environments)[0] as Record<string, unknown>;
+        const build = env['build'] as Record<string, unknown>;
+        const rolldownOptions = build['rolldownOptions'] as Record<string, unknown>;
+        const output = rolldownOptions['output'] as Record<string, unknown>;
+
+        expect(output['banner']).toBe(customShim);
+        expect(output['banner']).not.toContain('__dirname');
+    });
+
+    it('uses empty string as banner when shims is an empty string', () => {
+        const plugin = handlerBundle('src/handlers', { shims: '' });
+        const result = callConfigHook(plugin) as Record<string, unknown>;
+
+        const environments = result['environments'] as Record<string, Record<string, unknown>>;
+        const env = Object.values(environments)[0] as Record<string, unknown>;
+        const build = env['build'] as Record<string, unknown>;
+        const rolldownOptions = build['rolldownOptions'] as Record<string, unknown>;
+        const output = rolldownOptions['output'] as Record<string, unknown>;
+
+        expect(output['banner']).toBe('');
+    });
+
+    it('appends custom external entries to built-in modules', () => {
+        const plugin = handlerBundle('src/handlers', {
+            external: ['@aws-sdk/client-s3', /^@smithy\//],
+        });
+        const result = callConfigHook(plugin) as Record<string, unknown>;
+
+        const environments = result['environments'] as Record<string, Record<string, unknown>>;
+        const env = Object.values(environments)[0] as Record<string, unknown>;
+        const build = env['build'] as Record<string, unknown>;
+        const rolldownOptions = build['rolldownOptions'] as Record<string, unknown>;
+        const external = rolldownOptions['external'] as Array<string | RegExp>;
+
+        // Still includes built-ins
+        expect(external).toContain('fs');
+        expect(external).toContain('node:fs');
+        // Includes custom entries
+        expect(external).toContain('@aws-sdk/client-s3');
+        expect(external).toContainEqual(/^@smithy\//);
+    });
+
+    it('does not add extra externals when external is not provided', () => {
+        const plugin = handlerBundle(HANDLERS_PATH);
+        const result = callConfigHook(plugin) as Record<string, unknown>;
+
+        const environments = result['environments'] as Record<string, Record<string, unknown>>;
+        const env = Object.values(environments)[0] as Record<string, unknown>;
+        const build = env['build'] as Record<string, unknown>;
+        const rolldownOptions = build['rolldownOptions'] as Record<string, unknown>;
+        const external = rolldownOptions['external'] as string[];
+
+        // Only built-in modules (bare + node: prefixed)
+        expect(external.every(e => typeof e === 'string')).toBe(true);
+    });
+
     it('merges moduleTypes into rolldown config', () => {
         const plugin = handlerBundle('src/handlers', {
             moduleTypes: { '.graphql': 'text' },

--- a/packages/vite-plugin-handler/src/lib/handler-bundle.ts
+++ b/packages/vite-plugin-handler/src/lib/handler-bundle.ts
@@ -8,14 +8,25 @@ import { stripUnneededPlugins } from './strip-unneeded-plugins.js';
 export interface HandlerBundleOptions {
     /** Max concurrent environment builds (default: Infinity) */
     concurrency?: number;
-    /** Inject CJS __dirname/__filename shim banner (default: true) */
-    shims?: boolean;
+    /** Inject CJS __dirname/__filename shim banner (default: true).
+     *  Pass a string to use a custom banner instead of the built-in shim. */
+    shims?: boolean | string;
+    /** Additional modules to exclude from the bundle, appended to Node.js built-ins (default: []) */
+    external?: Array<string | RegExp>;
     /** Extra Rolldown module type overrides (default: {}) */
     // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     moduleTypes?: {};
 }
 
 const ENV_PREFIX = 'handler';
+
+function decideShimBanner(shim?: boolean | string) {
+    if (shim === false) return undefined;
+
+    if (typeof shim === 'string') return shim;
+
+    return shimBanner;
+}
 
 /**
  * Creates a Vite environment configuration for each handler file, producing
@@ -26,7 +37,13 @@ function buildHandlerEnvironments(
     mode: string | undefined,
     options: HandlerBundleOptions
 ): Record<string, EnvironmentOptions> {
-    const banner = options.shims === false ? undefined : shimBanner;
+    const banner = decideShimBanner(options.shims);
+    const external = [
+        ...builtinModules,
+        ...builtinModules.map(m => `node:${m}`),
+        ...(options.external ?? []),
+    ];
+
     const environments: Record<string, EnvironmentOptions> = {};
     const handlers = globSync(`${handlersDir}/**/*.ts`);
 
@@ -45,11 +62,11 @@ function buildHandlerEnvironments(
                 rolldownOptions: {
                     input: { index: handler },
                     moduleTypes: { ...options.moduleTypes },
-                    external: [...builtinModules, ...builtinModules.map(m => `node:${m}`)],
+                    external,
                     output: {
                         entryFileNames: 'index.mjs',
                         format: 'esm',
-                        ...(banner ? { banner } : {}),
+                        ...(banner !== undefined ? { banner } : {}),
                     },
                 },
             },


### PR DESCRIPTION
**Description of the proposed changes**

- Add support for custom shim banners in `vite-plugin-handler` (accepts `boolean | string` for full control)
- Add `externals` option to allow specifying additional external dependencies beyond the defaults
- Export `DEFAULT_SHIM` constant so consumers can extend it in custom shims

**Other solutions considered**

- Hardcoding all shim/external variations in the plugin — rejected in favour of a flexible API that lets consumers compose their own

**Notes to reviewers**

- 🛈 Toggl Code: _MI-251: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback