### PR TITLE
MI-251: nx-openapi improvements and dependency fixes

### DIFF
--- a/.nx/version-plans/version-plan-1782434440905.md
+++ b/.nx/version-plans/version-plan-1782434440905.md
@@ -1,6 +1,0 @@
----
-vite-plugin-handler: minor
-nx-cdk: minor
----
-
-Extract Lambda handler bundling into a standalone Vite plugin (`@aligent/vite-plugin-handler`) and update the nx-cdk preset to use it instead of inline vite config.

--- a/.nx/version-plans/version-plan-1782960408802.md
+++ b/.nx/version-plans/version-plan-1782960408802.md
@@ -1,0 +1,10 @@
+---
+appbuilder-util-lib: patch
+nx-openapi: patch
+vite-plugin-handler: minor
+nx-cdk: minor
+---
+
+- Make authMethod optional with interactive prompt fallback in nx-openapi client generator; move mongodb from devDependencies to dependencies in appbuilder-util-lib; add dependency-checks eslint rule to appbuilder-util-lib
+
+- Extract Lambda handler bundling into a standalone Vite plugin (`@aligent/vite-plugin-handler`) and update the nx-cdk preset to use it instead of inline vite config.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4085,7 +4085,6 @@
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
       "integrity": "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
@@ -7124,14 +7123,12 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
       "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
       "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
@@ -15744,7 +15741,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge-descriptors": {
@@ -15934,7 +15930,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.3.0.tgz",
       "integrity": "sha512-WpCqSx7JAU9vcyjm/SU7ydnHls2YrfU3Y3sx4Ml9D7sPe4mXPlaapndiurDXrQ7/VvJkB4/i7b7WovHb8bd8sg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.3.0",
@@ -15981,7 +15976,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
       "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/whatwg-url": "^13.0.0",
@@ -15995,7 +15989,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
       "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -16008,7 +16001,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -16018,7 +16010,6 @@
       "version": "14.2.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
       "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^5.1.0",
@@ -16032,7 +16023,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.0.tgz",
       "integrity": "sha512-WmjjMEwFwZHmGnAb7wn90MhkiT+mTm4x/rLj7dvAPWfwnVWDXhLun2e+UM88MJoDGW624yzZglVX/zTBy9ZZMw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.19.0"
@@ -17802,7 +17792,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18801,7 +18790,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "memory-pager": "^1.0.2"
@@ -21151,9 +21139,7 @@
         "@adobe/aio-lib-db": "^0.1.0-beta.6",
         "@adobe/aio-lib-files": "^4.1.2",
         "@adobe/aio-lib-state": "^5.3.1",
-        "base64url": "^3.0.1"
-      },
-      "devDependencies": {
+        "base64url": "^3.0.1",
         "mongodb": "^7.3.0"
       }
     },
@@ -21365,6 +21351,7 @@
       "dependencies": {
         "@nx/devkit": "22.7.5",
         "@redocly/openapi-core": "^1.34.2",
+        "enquirer": "2.4.1",
         "openapi-typescript": "7.13.0",
         "ts-morph": "^27.0.2",
         "typescript": "^5.9.3"
@@ -21388,12 +21375,37 @@
         "nx": ">= 21 <= 23 || ^22.0.0-0"
       }
     },
+    "packages/nx-openapi/node_modules/@nx/devkit/node_modules/enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "packages/nx-openapi/node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "packages/vite-plugin-handler": {
       "name": "@aligent/vite-plugin-handler",
       "version": "0.1.0",
       "license": "MIT",
       "peerDependencies": {
-        "vite": ">=7.3.1"
+        "vite": ">=8.0.14"
       }
     },
     "tools/generators": {

--- a/packages/appbuilder-util-lib/eslint.config.mjs
+++ b/packages/appbuilder-util-lib/eslint.config.mjs
@@ -1,5 +1,7 @@
 import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
+import nxEslintPlugin from '@nx/eslint-plugin';
+import jsonParser from 'jsonc-eslint-parser';
 import baseConfig from '../../eslint.config.mjs';
 
 const compat = new FlatCompat({
@@ -23,5 +25,13 @@ export default [
         rules: {
             'import/no-extraneous-dependencies': 'off',
         },
+    },
+    {
+        files: ['./package.json'],
+        plugins: { '@nx': nxEslintPlugin },
+        rules: {
+            '@nx/dependency-checks': ['error', { ignoredFiles: ['{projectRoot}/*.{js,cjs,mjs}'] }],
+        },
+        languageOptions: { parser: jsonParser },
     },
 ];

--- a/packages/appbuilder-util-lib/package.json
+++ b/packages/appbuilder-util-lib/package.json
@@ -15,11 +15,9 @@
     "@adobe/aio-lib-db": "^0.1.0-beta.6",
     "@adobe/aio-lib-files": "^4.1.2",
     "@adobe/aio-lib-state": "^5.3.1",
-    "base64url": "^3.0.1"
+    "base64url": "^3.0.1",
+    "mongodb": "^7.3.0"
   },
   "author": "Aligent",
-  "license": "MIT",
-  "devDependencies": {
-    "mongodb": "^7.3.0"
-  }
+  "license": "MIT"
 }

--- a/packages/nx-openapi/package.json
+++ b/packages/nx-openapi/package.json
@@ -14,7 +14,8 @@
     "@redocly/openapi-core": "^1.34.2",
     "openapi-typescript": "7.13.0",
     "ts-morph": "^27.0.2",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "enquirer": "2.4.1"
   },
   "generators": "./generators.json",
   "author": "Aligent",

--- a/packages/nx-openapi/src/generators/client/generator.ts
+++ b/packages/nx-openapi/src/generators/client/generator.ts
@@ -1,4 +1,5 @@
 import { Tree, formatFiles, generateFiles, joinPathFragments, logger } from '@nx/devkit';
+import { prompt } from 'enquirer';
 import {
     copySchema,
     generateOpenApiTypes,
@@ -19,6 +20,21 @@ const VALID_EXTENSIONS = ['yaml', 'yml', 'json'];
 
 // We also use this as the project root for all generated clients
 const PROJECT_NAME = 'clients';
+
+async function promptForAuthMethod(): Promise<string> {
+    const answer = await prompt<{ authMethod: string }>({
+        type: 'select',
+        name: 'authMethod',
+        message: 'Which authentication method should the client use?',
+        choices: [
+            { name: 'api-key', message: 'API Key' },
+            { name: 'oauth1.0a', message: 'OAuth 1.0a' },
+            { name: 'basic', message: 'Basic Auth' },
+            { name: 'oauth2.0', message: 'OAuth 2.0' },
+        ],
+    });
+    return answer.authMethod;
+}
 
 export async function clientGenerator(tree: Tree, options: ClientGeneratorSchema) {
     const {
@@ -47,14 +63,13 @@ export async function clientGenerator(tree: Tree, options: ClientGeneratorSchema
     const schemaDest = `${apiClientDest}/schema.${ext}`;
     const typesDest = `${apiClientDest}/generated-types.ts`;
 
-    const isOverriding = override && tree.exists(apiClientDest);
-
     if (tree.exists(apiClientDest) && !override) {
         throw new Error(
             `Directory "${name}" already exists. If you want to override the current api client in this directory use "--override"`
         );
     }
 
+    const isOverriding = override && tree.exists(apiClientDest);
     if (isOverriding) {
         // Remove stale schema files (extension may have changed)
         const schemaChildren = tree
@@ -66,7 +81,6 @@ export async function clientGenerator(tree: Tree, options: ClientGeneratorSchema
     }
 
     const existingProject = getExistingProject(tree, PROJECT_NAME);
-
     if (!existingProject) {
         logger.warn(`Creating new project ${PROJECT_NAME} at ${projectRoot}`);
 
@@ -88,6 +102,8 @@ export async function clientGenerator(tree: Tree, options: ClientGeneratorSchema
     // Only scaffold client.ts and apply auth config on first generation.
     // On override, preserve the user's customized client.ts.
     if (!isOverriding) {
+        const resolvedAuthMethod = authMethod ?? (await promptForAuthMethod());
+
         const className = toClassName(name);
         generateFiles(
             tree,
@@ -97,7 +113,7 @@ export async function clientGenerator(tree: Tree, options: ClientGeneratorSchema
         );
 
         const clientFilePath = joinPathFragments(apiClientDest, 'client.ts');
-        applyAuthMethodConfiguration(tree, clientFilePath, authMethod, className);
+        applyAuthMethodConfiguration(tree, clientFilePath, resolvedAuthMethod, className);
     }
 
     /**

--- a/packages/nx-openapi/src/generators/client/schema.d.ts
+++ b/packages/nx-openapi/src/generators/client/schema.d.ts
@@ -5,5 +5,5 @@ export interface ClientGeneratorSchema {
     importPath?: string;
     skipValidate: boolean;
     override: boolean;
-    authMethod: string;
+    authMethod?: string;
 }

--- a/packages/nx-openapi/src/generators/client/schema.json
+++ b/packages/nx-openapi/src/generators/client/schema.json
@@ -34,7 +34,8 @@
         "skipValidate": {
             "type": "boolean",
             "description": "Skip validation in the generation process",
-            "default": false
+            "default": false,
+            "x-prompt": "Skip schema validation?"
         },
         "override": {
             "type": "boolean",
@@ -44,18 +45,8 @@
         "authMethod": {
             "type": "string",
             "description": "Authentication method to use for the generated client middleware",
-            "enum": ["api-key", "oauth1.0a", "basic", "oauth2.0"],
-            "x-prompt": {
-                "message": "Which authentication method should the client use?",
-                "type": "list",
-                "items": [
-                    { "value": "api-key", "label": "API Key" },
-                    { "value": "oauth1.0a", "label": "OAuth 1.0a" },
-                    { "value": "basic", "label": "Basic Auth" },
-                    { "value": "oauth2.0", "label": "OAuth 2.0" }
-                ]
-            }
+            "enum": ["api-key", "oauth1.0a", "basic", "oauth2.0"]
         }
     },
-    "required": ["name", "schemaPath", "authMethod"]
+    "required": ["name", "schemaPath"]
 }

--- a/packages/vite-plugin-handler/package.json
+++ b/packages/vite-plugin-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aligent/vite-plugin-handler",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Vite plugin for bundling Lambda handlers",
   "type": "module",
   "main": "./dist/src/index.js",


### PR DESCRIPTION
**Description of the proposed changes**

- Make `authMethod` optional in the nx-openapi client generator with an interactive prompt fallback using `enquirer` (replaces `x-prompt` in schema.json for better UX)
- Move `mongodb` from `devDependencies` to `dependencies` in `appbuilder-util-lib` (it is a runtime dependency)
- Add `@nx/dependency-checks` eslint rule to `appbuilder-util-lib` to catch misplaced dependencies
- Add `skipValidate` x-prompt to nx-openapi schema
- Fix `vite-plugin-handler` initial version to `0.0.1` for proper version plan bumping

**Other solutions considered**

- Kept `x-prompt` for `authMethod` in `schema.json`: Nx's built-in `x-prompt` list type does not render correctly in all environments, so using `enquirer` directly gives more control over the prompt UX

**Notes to reviewers**

- 🛈 Toggl Code: _MI-251: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback