### PR TITLE
MI-330: Add EventBridge Scheduler client to aws-wrappers

### DIFF
--- a/.nx/version-plans/version-plan-MI-330.md
+++ b/.nx/version-plans/version-plan-MI-330.md
@@ -1,0 +1,5 @@
+---
+aws-wrappers: minor
+---
+
+- Add `SchedulerService` wrapping the AWS EventBridge Scheduler client (`@aws-sdk/client-scheduler`) with CRUD over schedules and schedule groups, following the package's Powertools-logging + X-Ray conventions. `Target.Input` is redacted from INFO-level logs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -534,6 +534,338 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-scheduler": {
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-scheduler/-/client-scheduler-3.1077.0.tgz",
+      "integrity": "sha512-MJgdoCMdC/n5TAkuKZT5+xSzMeEyrrBgC12fuVJSxGRG74PDNQW8KyWbxpRkHaShBsABm6/nD3DodsxmDrC9eQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-node": "^3.972.60",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/core": {
+      "version": "3.974.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.25.tgz",
+      "integrity": "sha512-fJFkx6u6wCqGMV/v6EAxiwa2UzEukbvr1hNPv4MrD3yj4IFz011jZg42/eSTOP/u5kJ0tlILqEjCWtT8GiKZvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.14",
+        "@aws-sdk/xml-builder": "^3.972.32",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.28.0",
+        "@smithy/signature-v4": "^5.6.0",
+        "@smithy/types": "^4.15.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.51.tgz",
+      "integrity": "sha512-Xo+/zf5k5pZdo53X8aVXN4MJGfU/M1P7yMM/GbNY/x9fyRZGEzjhKqW38GA0FSQQ9TYKs+bfPyz5ja4bi6pjTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.53.tgz",
+      "integrity": "sha512-7E9oFUcf9YWe+ttGiWhe/cCSI+pswwelzgQMoKXgPJi1AIfS27TK6et5ZULqEqHu30zbN+jh1RqlwcXqY/aXyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.58.tgz",
+      "integrity": "sha512-MPr0hD8pyDGfF3dWXvFOILhcKTB9ptqJOJK9JEuDQzpc2HgKisY16eR7IrKUXxSbz8LZj+LHz/CS8Y5G1ai7yw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/credential-provider-env": "^3.972.51",
+        "@aws-sdk/credential-provider-http": "^3.972.53",
+        "@aws-sdk/credential-provider-login": "^3.972.57",
+        "@aws-sdk/credential-provider-process": "^3.972.51",
+        "@aws-sdk/credential-provider-sso": "^3.972.57",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.57",
+        "@aws-sdk/nested-clients": "^3.997.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/credential-provider-imds": "^4.4.4",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.57.tgz",
+      "integrity": "sha512-kPWc/SCrl9agKeywxKwPEoQHanWag0LcNQrcZpEQpjNifkxq6tQENhgrrS9al317CF6yytyihlX+FhPHlk0QjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/nested-clients": "^3.997.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.60.tgz",
+      "integrity": "sha512-hE2hIBJQjCDRx8TbSqpVQ+/o2mIrJZQZbQ3LlwE2bJf7z47x5GmhcvGwZPqJH7Oq//SzTXEBGSZ4qSpK3yPbhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.51",
+        "@aws-sdk/credential-provider-http": "^3.972.53",
+        "@aws-sdk/credential-provider-ini": "^3.972.58",
+        "@aws-sdk/credential-provider-process": "^3.972.51",
+        "@aws-sdk/credential-provider-sso": "^3.972.57",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.57",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/credential-provider-imds": "^4.4.4",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.51.tgz",
+      "integrity": "sha512-081dD2RlnmY+G05v6E73KfACvDjPjnttrLjGHE2SSglbID25UcuijbWpL4g+XR5T2Kl4oIJoVBXi64s+2f009Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.57.tgz",
+      "integrity": "sha512-dC7ZyX3EHKHLOeVUEDzzGvk0L1s6N06YDrau7P0rGXL/j1cO+DzN2w1x9vcEh7zljVCR3019f5mi1Th+GGTURw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/nested-clients": "^3.997.25",
+        "@aws-sdk/token-providers": "3.1077.0",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.57.tgz",
+      "integrity": "sha512-HtWM3FV2o7NJFJSUqFLBlxmV9RxQRHpzCvQaP1n1Qo4CxQSvwpJ8ERWHiLqXMFDgDXyELt+EZNFcpG6XQRcJbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/nested-clients": "^3.997.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.25.tgz",
+      "integrity": "sha512-VpRQ3wR6l+fwRHV5veJL2ehtyQFrGyH/2CJG9DVtb8H3xyqqnZWSTSrq/CJJ7DvDlDgrPRiW2SkYA8pN6VWCFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.37",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/fetch-http-handler": "^5.6.1",
+        "@smithy/node-http-handler": "^4.9.1",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.37.tgz",
+      "integrity": "sha512-u8qd064XsHzM0Mk+yH4IPKn/ZC9rdniEKs+neBHNlsPZirw3rcLvmrH4ImoKC4yF7A0I/MbcC3dseARnJLiAhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/signature-v4": "^5.6.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1077.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1077.0.tgz",
+      "integrity": "sha512-sRUkfZ3fpOco95jZHsQUQiXvuIVLvCmWVclFg6dRFDyfsYs6Pdr/NuZ2+yJxeHN+6WAfDh2aZ8nlZntnvuhZUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.25",
+        "@aws-sdk/nested-clients": "^3.997.25",
+        "@aws-sdk/types": "^3.973.14",
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/types": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.14.tgz",
+      "integrity": "sha512-vH4pEu9YBEwr67yT+GVcmKX0GzfIrIYUn+MF5vXg9OspouVnAekuyVyawFvZHEK7WlcwVDwNrqI3ZBDUAiyu9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.32.tgz",
+      "integrity": "sha512-2loKuOMRFDg1nwdni5AtJ9S5juVbRNPNsPC7tWTfkHyycPwACMhxepspUHi8GhvfNlL2cQo3sPMod1uib+KZ0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@smithy/core": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.28.0.tgz",
+      "integrity": "sha512-N/LoLG8pZ1zv5cIWpdF6vmSjtZtXKK9G0OqT5yYCOZU+CzPq1+nYA95VoKJBGWRScs7YbMugZ7lZx8Fj1vdHoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.4.tgz",
+      "integrity": "sha512-jT0WrDaM88L5na9FX1xRNywCS3B1n75wPY5Ksasjo0PHUtuI7d8FclksN1BbOSYTiaiKxUDqU23nUymH/V+AaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.1.tgz",
+      "integrity": "sha512-fW6l9rWoyk1iyzfuZaERnZLNjB6WIojgGm6Bo9Hpfpy3RUpltjLikNlxTsS/YtxVobcfbCGBuAncREYqT4hvqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@smithy/node-http-handler": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.1.tgz",
+      "integrity": "sha512-m/f15di58P6NtLQ7eVEb5N19NdJWn+4c7zfkFHMT/i3JH7U8UtknpPoy8o2tm2R3OdliYvsvQhZHIfACQDqT+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-scheduler/node_modules/@smithy/signature-v4": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.0.tgz",
+      "integrity": "sha512-IkPHQdbyoebSwBCuMTzJ/2oIhKVqiZZAZxQYSlpDZqq/WhJUpmdgbHvP7ItddxsPzcDUJeI0V4PNMSNtlZ0aqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.28.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-secrets-manager": {
       "version": "3.1075.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1075.0.tgz",
@@ -3258,6 +3590,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
       "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emnapi/wasi-threads": "1.0.4",
@@ -3268,6 +3601,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
       "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -3277,6 +3611,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
       "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -4094,6 +4429,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
       "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emnapi/core": "^1.1.0",
@@ -4300,6 +4636,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4313,6 +4650,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4326,6 +4664,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4339,6 +4678,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4352,6 +4692,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -4368,6 +4709,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -4384,6 +4726,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -4400,6 +4743,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -4416,6 +4760,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4429,6 +4774,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5170,6 +5516,7 @@
       "version": "0.137.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
       "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -5182,6 +5529,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5195,6 +5543,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5208,6 +5557,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5221,6 +5571,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5234,6 +5585,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5247,6 +5599,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5260,6 +5613,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5273,6 +5627,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -5289,6 +5644,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -5305,6 +5661,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -5321,6 +5678,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -5337,6 +5695,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -5353,6 +5712,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -5369,6 +5729,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -5385,6 +5746,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -5401,6 +5763,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5414,6 +5777,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5429,6 +5793,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
       "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5440,6 +5805,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
       "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5450,6 +5816,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5460,6 +5827,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
       "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5478,6 +5846,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5491,6 +5860,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5504,6 +5874,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5639,6 +6010,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5655,6 +6027,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5671,6 +6044,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5687,6 +6061,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5703,6 +6078,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5719,6 +6095,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -5738,6 +6115,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -5757,6 +6135,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -5776,6 +6155,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -5795,6 +6175,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -5814,6 +6195,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -5833,6 +6215,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5849,6 +6232,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5864,6 +6248,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5875,6 +6260,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5885,6 +6271,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5895,6 +6282,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
       "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5913,6 +6301,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5926,6 +6315,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5942,6 +6332,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5955,6 +6346,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-babel": {
@@ -7113,7 +7505,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@swc-node/core/-/core-1.14.1.tgz",
       "integrity": "sha512-jrt5GUaZUU6cmMS+WTJEvGvaB6j1YNKPHPzC2PUi2BjaFbtxURHj6641Az6xN7b665hNniAIdvjxWcRml5yCnw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -7131,7 +7523,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@swc-node/register/-/register-1.11.1.tgz",
       "integrity": "sha512-VQ0hJ5jX31TVv/fhZx4xJRzd8pwn6VvzYd2tGOHHr2TfXGCBixZoqdPDXTiEoJLCTS2MmvBf6zyQZZ0M8aGQCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@swc-node/core": "^1.14.1",
@@ -7155,14 +7547,14 @@
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc-node/sourcemap-support": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@swc-node/sourcemap-support/-/sourcemap-support-0.6.1.tgz",
       "integrity": "sha512-ovltDVH5QpdHXZkW138vG4+dgcNsxfwxHVoV6BtmTbz2KKl1A8ZSlbdtxzzfNjCjbpayda8Us9eMtcHobm38dA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "source-map-support": "^0.5.21",
@@ -7173,7 +7565,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -7184,7 +7576,7 @@
       "version": "1.15.41",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.41.tgz",
       "integrity": "sha512-03nQq/082QRJJiOvp3FGbgxTGyyxMxohPTjhk/W9bD2J0tk4ukITI7goOhOO2WbaHn/lsPmo/zf8+DIXhwpgYQ==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7228,6 +7620,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7244,6 +7637,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7260,6 +7654,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7276,6 +7671,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -7295,6 +7691,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -7314,6 +7711,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -7333,6 +7731,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -7352,6 +7751,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -7371,6 +7771,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -7390,6 +7791,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7406,6 +7808,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7422,6 +7825,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7435,14 +7839,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
       "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -7480,6 +7884,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
       "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -9119,6 +9524,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/@zkochan/js-yaml": {
@@ -10258,7 +10664,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bytes": {
@@ -11348,6 +11754,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -11420,6 +11827,7 @@
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
       "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -11432,6 +11840,7 @@
       "version": "12.0.3",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
       "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "dotenv": "^16.4.5"
@@ -11606,6 +12015,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -12973,6 +13383,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
@@ -12988,6 +13399,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -13273,6 +13685,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -13301,6 +13714,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14094,6 +14508,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -15377,7 +15792,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -15488,6 +15903,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -15537,6 +15953,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -15736,6 +16153,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -15768,6 +16186,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15788,6 +16207,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15808,6 +16228,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15828,6 +16249,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15848,6 +16270,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15868,6 +16291,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -15891,6 +16315,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -15914,6 +16339,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -15937,6 +16363,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -15960,6 +16387,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15980,6 +16408,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15997,6 +16426,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
       "integrity": "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -16489,6 +16919,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -16648,6 +17079,7 @@
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16808,6 +17240,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -16820,6 +17253,7 @@
       "version": "22.7.6",
       "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.6.tgz",
       "integrity": "sha512-cT2iX6NAtuNT/yaMTtwpIuNQBrW2Zhg4X8zdTEo/h27bz/JYnFm7B9MAKbAXNWK6k0Yxz+jv7zJoMBHutd1Dww==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16967,6 +17401,7 @@
       "version": "30.0.1",
       "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
       "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -16976,6 +17411,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
       "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "20 || >=22"
@@ -16985,12 +17421,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nx/node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -17003,6 +17441,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -17012,6 +17451,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -17032,6 +17472,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -17044,12 +17485,14 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/nx/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -17064,6 +17507,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -17073,6 +17517,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
       "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json5": "^2.2.2",
@@ -17087,6 +17532,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -17104,6 +17550,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -17316,6 +17763,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -17510,7 +17958,7 @@
       "version": "11.21.3",
       "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.21.3.tgz",
       "integrity": "sha512-2Mx3fKQz7+xgrBONjsxOgCGtMHOn38/HxMzW1I5efwXB5a4lRN0Vp40gYUJFBWJslcrvwoofTrqoTnLbwTd3pA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -17710,6 +18158,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17945,7 +18394,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -18001,6 +18450,7 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -18724,6 +19174,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
       "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -18776,6 +19227,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.2.tgz",
       "integrity": "sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.137.0",
@@ -19338,6 +19790,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
       "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -19360,7 +19813,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -19370,6 +19823,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -19886,6 +20340,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
@@ -20175,6 +20630,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
@@ -20971,6 +21427,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
@@ -21476,6 +21933,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -21549,6 +22007,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -21751,6 +22210,7 @@
         "@aws-lambda-powertools/logger": "^2.33.1",
         "@aws-sdk/client-dynamodb": "^3.1068.0",
         "@aws-sdk/client-s3": "^3.1068.0",
+        "@aws-sdk/client-scheduler": "^3.1077.0",
         "@aws-sdk/client-secrets-manager": "^3.1068.0",
         "@aws-sdk/client-sfn": "^3.1068.0",
         "@aws-sdk/client-sns": "^3.1068.0",
@@ -22002,7 +22462,7 @@
     },
     "packages/vite-plugin-handler": {
       "name": "@aligent/vite-plugin-handler",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "license": "MIT",
       "peerDependencies": {
         "vite": ">=8.0.14"

--- a/packages/aws-wrappers/README.md
+++ b/packages/aws-wrappers/README.md
@@ -187,6 +187,62 @@ const description = await sfn.describeExecution({ executionArn });
 await sfn.stopExecution({ executionArn });
 ```
 
+## EventBridge Scheduler
+
+```ts
+import { SchedulerService } from '@aligent/aws-wrappers';
+
+const scheduler = new SchedulerService();
+
+// FlexibleTimeWindow is required — pass { Mode: 'OFF' } for a fixed-time
+// schedule. The wrapper bakes in no default.
+await scheduler.createSchedule({
+    Name: 'nightly-sync',
+    GroupName: 'default',
+    ScheduleExpression: 'rate(1 day)',
+    FlexibleTimeWindow: { Mode: 'OFF' },
+    Target: {
+        Arn: 'arn:aws:lambda:us-east-1:0:function:my-fn',
+        RoleArn: 'arn:aws:iam::0:role/scheduler-invoke',
+        Input: JSON.stringify({ job: 'sync' }),
+    },
+});
+
+const schedule = await scheduler.getSchedule({ Name: 'nightly-sync' });
+
+// UpdateSchedule is a FULL REPLACEMENT, not a patch. Any omitted field is
+// reset to its default, so resend the complete configuration and override
+// only what changes. GetSchedule types every field as optional, so the
+// required fields (Name, ScheduleExpression, FlexibleTimeWindow, Target) must
+// be re-asserted after the spread.
+await scheduler.updateSchedule({
+    ...schedule,
+    Name: 'nightly-sync',
+    ScheduleExpression: 'rate(12 hours)', // the change
+    FlexibleTimeWindow: schedule.FlexibleTimeWindow ?? { Mode: 'OFF' },
+    Target: schedule.Target ?? {
+        Arn: 'arn:aws:lambda:us-east-1:0:function:my-fn',
+        RoleArn: 'arn:aws:iam::0:role/scheduler-invoke',
+    },
+});
+
+// Auto-paginated — returns every summary across all pages.
+const schedules = await scheduler.listSchedules({ GroupName: 'default' });
+
+await scheduler.deleteSchedule({ Name: 'nightly-sync' });
+```
+
+`Target.Input` is the payload handed to the target and is omitted from INFO logs (it routinely carries PII); `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full input.
+
+```ts
+// Schedule groups. Groups have no update operation — only create, get,
+// delete, and list. Deleting a group deletes every schedule it contains.
+await scheduler.createScheduleGroup({ Name: 'integrations' });
+const group = await scheduler.getScheduleGroup({ Name: 'integrations' });
+const groups = await scheduler.listScheduleGroups();
+await scheduler.deleteScheduleGroup({ Name: 'integrations' });
+```
+
 ## SSM Parameter Store
 
 ```ts

--- a/packages/aws-wrappers/docs/classes/DynamoDBService.md
+++ b/packages/aws-wrappers/docs/classes/DynamoDBService.md
@@ -6,7 +6,7 @@
 
 # Class: DynamoDBService
 
-Defined in: [dynamodb/dynamodb.ts:49](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L49)
+Defined in: [dynamodb/dynamodb.ts:155](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L155)
 
 Wrapper around the AWS DynamoDB Document client providing structured
 Powertools logging and X-Ray tracing by default.
@@ -22,7 +22,7 @@ callers work with plain TypeScript objects in both directions.
 
 > **new DynamoDBService**(`opts?`): `DynamoDBService`
 
-Defined in: [dynamodb/dynamodb.ts:62](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L62)
+Defined in: [dynamodb/dynamodb.ts:168](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L168)
 
 #### Parameters
 
@@ -40,10 +40,10 @@ tracing captures every DynamoDB call.
 
 ###### logger?
 
-`Logger`
+`LoggerInterface`
 
-Optional Powertools logger. Defaults to a logger with
-`serviceName: 'DynamoDBService'`.
+Optional Powertools logger. Defaults to `new Logger()`,
+which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 #### Returns
 
@@ -57,7 +57,7 @@ Optional Powertools logger. Defaults to a logger with
 
 > **batchGet**(`input`): `Promise`\<`BatchGetCommandOutput`\>
 
-Defined in: [dynamodb/dynamodb.ts:159](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L159)
+Defined in: [dynamodb/dynamodb.ts:319](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L319)
 
 Batch-get items from one or more DynamoDB tables.
 
@@ -84,7 +84,7 @@ Callers should narrow the result type at the call site.
 
 > **batchWrite**(`input`): `Promise`\<`BatchWriteCommandOutput`\>
 
-Defined in: [dynamodb/dynamodb.ts:169](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L169)
+Defined in: [dynamodb/dynamodb.ts:336](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L336)
 
 Batch-write items to DynamoDB, retrying `UnprocessedItems` with jittered
 exponential backoff. Up to 5 attempts (200ms base delay). Throws when
@@ -106,18 +106,24 @@ items remain unprocessed after the final attempt.
 
 ### deleteItem()
 
-> **deleteItem**\<`T`\>(`input`): `Promise`\<`Omit`\<`DeleteCommandOutput`, `"Attributes"`\> & `object`\>
+> **deleteItem**\<`K`, `R`\>(`input`): `Promise`\<`Omit`\<`DeleteCommandOutput`, `"Attributes"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:116](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L116)
+Defined in: [dynamodb/dynamodb.ts:249](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L249)
 
 Delete an item from DynamoDB. The `Attributes` field on the response is
-typed as `T` — relevant when `ReturnValues: 'ALL_OLD'` is set.
+typed as `R` — relevant when `ReturnValues: 'ALL_OLD'` is set.
 
 #### Type Parameters
 
-##### T
+##### K
 
-`T` = `Record`\<`string`, `unknown`\>
+`K` *extends* `Record`\<`string`, `unknown`\> = `Record`\<`string`, `unknown`\>
+
+Shape of the partition / sort key.
+
+##### R
+
+`R` *extends* `Record`\<`string`, `unknown`\> = `Record`\<`string`, `unknown`\>
 
 Expected shape of the returned `Attributes`.
 
@@ -125,7 +131,7 @@ Expected shape of the returned `Attributes`.
 
 ##### input
 
-`DeleteCommandInput`
+`WithTypedKey`\<`DeleteCommandInput`, `K`\>
 
 #### Returns
 
@@ -137,17 +143,23 @@ Expected shape of the returned `Attributes`.
 
 ### getItem()
 
-> **getItem**\<`T`\>(`input`): `Promise`\<`T` \| `undefined`\>
+> **getItem**\<`K`, `R`\>(`input`): `Promise`\<`R` \| `undefined`\>
 
-Defined in: [dynamodb/dynamodb.ts:76](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L76)
+Defined in: [dynamodb/dynamodb.ts:183](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L183)
 
 Get an item from DynamoDB.
 
 #### Type Parameters
 
-##### T
+##### K
 
-`T` = `Record`\<`string`, `unknown`\>
+`K` *extends* `Record`\<`string`, `unknown`\> = `Record`\<`string`, `unknown`\>
+
+Shape of the partition / sort key.
+
+##### R
+
+`R` *extends* `Record`\<`string`, `unknown`\> = `Record`\<`string`, `unknown`\>
 
 Expected unmarshalled item shape.
 
@@ -155,11 +167,11 @@ Expected unmarshalled item shape.
 
 ##### input
 
-`GetCommandInput`
+`WithTypedKey`\<`GetCommandInput`, `K`\>
 
 #### Returns
 
-`Promise`\<`T` \| `undefined`\>
+`Promise`\<`R` \| `undefined`\>
 
 The item, or `undefined` if not found.
 
@@ -171,7 +183,7 @@ The item, or `undefined` if not found.
 
 > **paginateItems**\<`T`\>(`input`): `AsyncGenerator`\<`T`\>
 
-Defined in: [dynamodb/dynamodb.ts:190](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L190)
+Defined in: [dynamodb/dynamodb.ts:364](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L364)
 
 Paginate over Query results, yielding one unmarshalled item at a time.
 
@@ -179,7 +191,7 @@ Paginate over Query results, yielding one unmarshalled item at a time.
 
 ##### T
 
-`T` = `Record`\<`string`, `unknown`\>
+`T` *extends* `Record`\<`string`, `unknown`\> = `Record`\<`string`, `unknown`\>
 
 Expected shape of each yielded item.
 
@@ -201,7 +213,7 @@ Expected shape of each yielded item.
 
 > **paginateScan**\<`T`\>(`input`): `AsyncGenerator`\<`T`\>
 
-Defined in: [dynamodb/dynamodb.ts:203](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L203)
+Defined in: [dynamodb/dynamodb.ts:381](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L381)
 
 Paginate over Scan results, yielding one unmarshalled item at a time.
 
@@ -209,7 +221,7 @@ Paginate over Scan results, yielding one unmarshalled item at a time.
 
 ##### T
 
-`T` = `Record`\<`string`, `unknown`\>
+`T` *extends* `Record`\<`string`, `unknown`\> = `Record`\<`string`, `unknown`\>
 
 Expected shape of each yielded item.
 
@@ -231,7 +243,7 @@ Expected shape of each yielded item.
 
 > **putItem**\<`T`\>(`input`): `Promise`\<`PutCommandOutput`\>
 
-Defined in: [dynamodb/dynamodb.ts:87](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L87)
+Defined in: [dynamodb/dynamodb.ts:203](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L203)
 
 Put an item into DynamoDB. The caller's `Item` is typed as `T`, which
 the document client marshalls automatically.
@@ -262,7 +274,7 @@ Type of the item being stored.
 
 > **query**\<`T`\>(`input`): `Promise`\<`Omit`\<`QueryCommandOutput`, `"Items"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:130](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L130)
+Defined in: [dynamodb/dynamodb.ts:272](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L272)
 
 Execute a DynamoDB Query. The full `QueryCommandOutput` is returned with
 `Items` typed as `T[]` so callers retain pagination metadata
@@ -272,7 +284,7 @@ Execute a DynamoDB Query. The full `QueryCommandOutput` is returned with
 
 ##### T
 
-`T` = `Record`\<`string`, `unknown`\>
+`T` *extends* `Record`\<`string`, `unknown`\> = `Record`\<`string`, `unknown`\>
 
 Expected shape of each unmarshalled item.
 
@@ -294,16 +306,29 @@ Expected shape of each unmarshalled item.
 
 > **scan**\<`T`\>(`input`): `Promise`\<`Omit`\<`ScanCommandOutput`, `"Items"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:143](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L143)
+Defined in: [dynamodb/dynamodb.ts:301](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L301)
 
 Scan a DynamoDB table. The full `ScanCommandOutput` is returned with
 `Items` typed as `T[]` so callers retain pagination metadata.
+
+Scan reads every item in the table, so cost and latency grow linearly
+with table size; it is rarely the right tool in a runtime service.
+Prefer, in order:
+
+  1. `query` with the table's partition key.
+  2. `query` against a GSI or LSI whose key matches your access pattern.
+  3. A sparse GSI populated only for the items you need to enumerate.
+  4. A denormalised lookup item or table maintained on write.
+
+Legitimate scan use cases are mostly one-off admin work (export,
+migration, audit). For those, prefer the AWS CLI or Console rather than
+embedding a scan in a Lambda.
 
 #### Type Parameters
 
 ##### T
 
-`T` = `Record`\<`string`, `unknown`\>
+`T` *extends* `Record`\<`string`, `unknown`\> = `Record`\<`string`, `unknown`\>
 
 Expected shape of each unmarshalled item.
 
@@ -323,12 +348,12 @@ Expected shape of each unmarshalled item.
 
 ### updateItem()
 
-> **updateItem**\<`T`\>(`input`): `Promise`\<`Omit`\<`UpdateCommandOutput`, `"Attributes"`\> & `object`\>
+> **updateItem**\<`K`, `R`\>(`input`): `Promise`\<`Omit`\<`UpdateCommandOutput`, `"Attributes"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:103](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L103)
+Defined in: [dynamodb/dynamodb.ts:226](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L226)
 
 Update an item in DynamoDB. The `Attributes` field on the response is
-typed as `T` — the caller should choose `T` to match their
+typed as `R` — the caller should choose `R` to match their
 `ReturnValues` setting:
 - `NONE` (default): no `Attributes` returned.
 - `ALL_OLD` / `ALL_NEW`: full item.
@@ -336,9 +361,15 @@ typed as `T` — the caller should choose `T` to match their
 
 #### Type Parameters
 
-##### T
+##### K
 
-`T` = `Record`\<`string`, `unknown`\>
+`K` *extends* `Record`\<`string`, `unknown`\> = `Record`\<`string`, `unknown`\>
+
+Shape of the partition / sort key.
+
+##### R
+
+`R` *extends* `Record`\<`string`, `unknown`\> = `Record`\<`string`, `unknown`\>
 
 Expected shape of the returned `Attributes`.
 
@@ -346,7 +377,7 @@ Expected shape of the returned `Attributes`.
 
 ##### input
 
-`UpdateCommandInput`
+`WithTypedKey`\<`UpdateCommandInput`, `K`\>
 
 #### Returns
 

--- a/packages/aws-wrappers/docs/classes/S3Service.md
+++ b/packages/aws-wrappers/docs/classes/S3Service.md
@@ -6,7 +6,7 @@
 
 # Class: S3Service
 
-Defined in: [s3/s3.ts:35](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L35)
+Defined in: [s3/s3.ts:68](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L68)
 
 Wrapper around the AWS S3 client providing structured Powertools logging
 and X-Ray tracing by default.
@@ -23,7 +23,7 @@ tagging, version IDs) should use `S3Client` directly.
 
 > **new S3Service**(`opts?`): `S3Service`
 
-Defined in: [s3/s3.ts:45](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L45)
+Defined in: [s3/s3.ts:78](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L78)
 
 #### Parameters
 
@@ -38,10 +38,10 @@ the wrapper does not apply X-Ray instrumentation.
 
 ###### logger?
 
-`Logger`
+`LoggerInterface`
 
-Optional Powertools logger. Defaults to a logger with
-`serviceName: 'S3Service'`.
+Optional Powertools logger. Defaults to `new Logger()`,
+which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 #### Returns
 
@@ -55,7 +55,7 @@ Optional Powertools logger. Defaults to a logger with
 
 > **copyObject**(`input`): `Promise`\<`CopyObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:145](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L145)
+Defined in: [s3/s3.ts:173](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L173)
 
 Copy an object within S3.
 
@@ -77,7 +77,7 @@ Copy an object within S3.
 
 > **deleteObject**(`input`): `Promise`\<`DeleteObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:199](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L199)
+Defined in: [s3/s3.ts:266](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L266)
 
 Delete a single object from S3.
 
@@ -99,7 +99,7 @@ Delete a single object from S3.
 
 > **deleteObjects**(`bucket`, `keys`): `Promise`\<`DeleteObjectsCommandOutput`[]\>
 
-Defined in: [s3/s3.ts:211](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L211)
+Defined in: [s3/s3.ts:278](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L278)
 
 Delete multiple objects from S3, auto-chunking the request into batches
 of 1000 keys (the S3-enforced DeleteObjects limit). Returns one output
@@ -127,7 +127,7 @@ per chunk.
 
 > **emptyBucket**(`bucket`): `Promise`\<`string`[]\>
 
-Defined in: [s3/s3.ts:234](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L234)
+Defined in: [s3/s3.ts:307](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L307)
 
 Delete every object in a bucket. Streams the listing page-by-page and
 delegates each page's deletion to `deleteObjects`, so peak memory stays
@@ -153,7 +153,7 @@ The keys of every deleted object.
 
 > **getAllObjects**\<`T`\>(`bucket`, `prefix?`): `Promise`\<`T`[]\>
 
-Defined in: [s3/s3.ts:176](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L176)
+Defined in: [s3/s3.ts:204](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L204)
 
 List and JSON-parse every object under a bucket and optional prefix.
 Auto-paginated. Objects without a body are skipped.
@@ -188,7 +188,7 @@ Expected type of each parsed object.
 
 > **getJsonObject**\<`T`\>(`input`): `Promise`\<`T` \| `undefined`\>
 
-Defined in: [s3/s3.ts:123](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L123)
+Defined in: [s3/s3.ts:151](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L151)
 
 Get an object from S3 and parse it as JSON.
 
@@ -224,7 +224,7 @@ If the body is non-empty and not valid JSON.
 
 > **getObject**(`input`): `Promise`\<`GetObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:97](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L97)
+Defined in: [s3/s3.ts:125](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L125)
 
 Get an object from S3.
 
@@ -246,7 +246,7 @@ Get an object from S3.
 
 > **getObjectBody**(`input`): `Promise`\<`string` \| `undefined`\>
 
-Defined in: [s3/s3.ts:109](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L109)
+Defined in: [s3/s3.ts:137](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L137)
 
 Get an object from S3 and return its body as a string.
 
@@ -265,13 +265,67 @@ has no body.
 
 ***
 
+<a id="getpresignedurl"></a>
+
+### getPresignedUrl()
+
+> **getPresignedUrl**(`input`): `Promise`\<`string`\>
+
+Defined in: [s3/s3.ts:242](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L242)
+
+Generate a presigned URL that callers can use to GET or PUT an S3 object
+directly, without going through the wrapper. The signing happens against
+the wrapper's `S3Client`, so callers do not need their own client.
+
+GET URLs are signed with `ResponseContentDisposition: 'attachment'` so
+browsers download the object rather than rendering it in-place.
+
+The input shape is an inline object (rather than the `Required<Pick<...>>`
+pattern used by other S3 methods) because this method wraps two SDK
+commands rather than one, and `action` / `expiresIn` are wrapper-level
+concerns with no SDK-input equivalent.
+
+#### Parameters
+
+##### input
+
+###### action
+
+`"get"` \| `"put"`
+
+`'get'` to download, `'put'` to upload.
+
+###### Bucket
+
+`string`
+
+The S3 bucket name.
+
+###### expiresIn?
+
+`number`
+
+URL lifetime in seconds. Defaults to 3600 (1 hour).
+
+###### Key
+
+`string`
+
+The S3 object key.
+
+#### Returns
+
+`Promise`\<`string`\>
+
+***
+
 <a id="headobject"></a>
 
 ### headObject()
 
 > **headObject**(`input`): `Promise`\<`HeadObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:135](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L135)
+Defined in: [s3/s3.ts:163](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L163)
 
 Fetch the metadata for an S3 object without downloading its body.
 
@@ -293,7 +347,7 @@ Fetch the metadata for an S3 object without downloading its body.
 
 > **listObjects**(`bucket`, `prefix?`): `Promise`\<`string`[]\>
 
-Defined in: [s3/s3.ts:156](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L156)
+Defined in: [s3/s3.ts:184](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L184)
 
 List object keys under a bucket and optional prefix, auto-paginating
 across all pages.
@@ -320,7 +374,7 @@ across all pages.
 
 > **putJsonObject**\<`T`\>(`input`): `Promise`\<`PutObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:75](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L75)
+Defined in: [s3/s3.ts:108](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L108)
 
 Serialise a value to JSON and store it as an S3 object.
 
@@ -340,21 +394,7 @@ Type of the value being stored.
 
 ##### input
 
-###### Body
-
-`T`
-
-###### Bucket
-
-`string`
-
-###### Key
-
-`string`
-
-###### Metadata?
-
-`Record`\<`string`, `string`\>
+`PutJsonObjectInput`\<`T`\>
 
 #### Returns
 
@@ -368,7 +408,7 @@ Type of the value being stored.
 
 > **putObject**(`input`): `Promise`\<`PutObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:59](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/s3/s3.ts#L59)
+Defined in: [s3/s3.ts:92](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L92)
 
 Put an object into S3.
 
@@ -380,7 +420,7 @@ content into CloudWatch.
 
 ##### input
 
-`Required`\<`Pick`\<`PutObjectCommandInput`, `"Bucket"` \| `"Key"` \| `"Body"`\>\>
+`PutObjectInput`
 
 Bucket, Key, and Body of the object to store.
 

--- a/packages/aws-wrappers/docs/classes/SNSService.md
+++ b/packages/aws-wrappers/docs/classes/SNSService.md
@@ -6,7 +6,7 @@
 
 # Class: SNSService
 
-Defined in: [sns/sns.ts:20](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sns/sns.ts#L20)
+Defined in: [sns/sns.ts:39](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sns/sns.ts#L39)
 
 Wrapper around the AWS SNS client providing structured Powertools logging
 and X-Ray tracing by default.
@@ -19,7 +19,7 @@ and X-Ray tracing by default.
 
 > **new SNSService**(`opts?`): `SNSService`
 
-Defined in: [sns/sns.ts:30](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sns/sns.ts#L30)
+Defined in: [sns/sns.ts:55](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sns/sns.ts#L55)
 
 #### Parameters
 
@@ -34,10 +34,20 @@ the wrapper does not apply X-Ray instrumentation.
 
 ###### logger?
 
-`Logger`
+`LoggerInterface`
 
-Optional Powertools logger. Defaults to a logger with
-`serviceName: 'SNSService'`.
+Optional Powertools logger. Defaults to `new Logger()`,
+which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
+
+###### truncate?
+
+`boolean`
+
+When `true`, oversized `Message` / `Subject` are
+truncated (byte-safe / codepoint-safe) before sending instead of failing
+at the SDK. Defaults to `false` — the SDK throws on oversize, which is
+usually the right failure mode. Each `publish` call can override via
+its own `truncate` option.
 
 #### Returns
 
@@ -49,11 +59,15 @@ Optional Powertools logger. Defaults to a logger with
 
 ### publish()
 
-> **publish**(`input`): `Promise`\<`PublishCommandOutput`\>
+> **publish**(`input`, `opts?`): `Promise`\<`PublishCommandOutput`\>
 
-Defined in: [sns/sns.ts:39](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sns/sns.ts#L39)
+Defined in: [sns/sns.ts:70](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sns/sns.ts#L70)
 
 Publish a single message to an SNS topic.
+
+At INFO level the log line includes only routing / dedup metadata; see
+`PUBLISH_SAFE_FIELDS` for the list. Setting `POWERTOOLS_LOG_LEVEL=DEBUG`
+unlocks the full input.
 
 #### Parameters
 
@@ -62,6 +76,12 @@ Publish a single message to an SNS topic.
 `PublishCommandInput`
 
 PublishCommandInput including TopicArn and Message.
+
+##### opts?
+
+###### truncate?
+
+`boolean`
 
 #### Returns
 
@@ -75,7 +95,7 @@ PublishCommandInput including TopicArn and Message.
 
 > **publishBatch**(`input`): `Promise`\<`PublishBatchCommandOutput`[]\>
 
-Defined in: [sns/sns.ts:51](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sns/sns.ts#L51)
+Defined in: [sns/sns.ts:107](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sns/sns.ts#L107)
 
 Publish a batch of messages to an SNS topic. The SNS API caps
 PublishBatch at 10 entries per request, so this method auto-chunks

--- a/packages/aws-wrappers/docs/classes/SQSService.md
+++ b/packages/aws-wrappers/docs/classes/SQSService.md
@@ -6,7 +6,7 @@
 
 # Class: SQSService
 
-Defined in: [sqs/sqs.ts:30](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sqs/sqs.ts#L30)
+Defined in: [sqs/sqs.ts:46](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L46)
 
 Wrapper around the AWS SQS client providing structured Powertools logging
 and X-Ray tracing by default.
@@ -19,7 +19,7 @@ and X-Ray tracing by default.
 
 > **new SQSService**(`opts?`): `SQSService`
 
-Defined in: [sqs/sqs.ts:40](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sqs/sqs.ts#L40)
+Defined in: [sqs/sqs.ts:61](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L61)
 
 #### Parameters
 
@@ -34,10 +34,19 @@ the wrapper does not apply X-Ray instrumentation.
 
 ###### logger?
 
-`Logger`
+`LoggerInterface`
 
-Optional Powertools logger. Defaults to a logger with
-`serviceName: 'SQSService'`.
+Optional Powertools logger. Defaults to `new Logger()`,
+which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
+
+###### truncate?
+
+`boolean`
+
+When `true`, oversized `MessageBody` is truncated
+(byte-safe) before sending instead of failing at the SDK. Defaults to
+`false`. Each `sendMessage` call can override via its own `truncate`
+option.
 
 #### Returns
 
@@ -51,7 +60,7 @@ Optional Powertools logger. Defaults to a logger with
 
 > **deleteMessage**(`input`): `Promise`\<`DeleteMessageCommandOutput`\>
 
-Defined in: [sqs/sqs.ts:68](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sqs/sqs.ts#L68)
+Defined in: [sqs/sqs.ts:117](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L117)
 
 Delete a single message from an SQS queue.
 
@@ -73,7 +82,7 @@ Delete a single message from an SQS queue.
 
 > **deleteMessageBatch**(`input`): `Promise`\<`DeleteMessageBatchCommandOutput`[]\>
 
-Defined in: [sqs/sqs.ts:100](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sqs/sqs.ts#L100)
+Defined in: [sqs/sqs.ts:153](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L153)
 
 Delete a batch of messages from an SQS queue. The SQS API caps
 DeleteMessageBatch at 10 entries per request, so this method auto-chunks
@@ -97,7 +106,7 @@ the caller's entries and sends one request per chunk.
 
 > **receiveMessages**(`input`): `Promise`\<`Message`[]\>
 
-Defined in: [sqs/sqs.ts:59](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sqs/sqs.ts#L59)
+Defined in: [sqs/sqs.ts:108](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L108)
 
 Receive messages from an SQS queue. Returns an empty array when no
 messages are available. No automatic deletion is performed — visibility
@@ -121,17 +130,27 @@ The `Messages` array from the response, or `[]` if absent.
 
 ### sendMessage()
 
-> **sendMessage**(`input`): `Promise`\<`SendMessageCommandOutput`\>
+> **sendMessage**(`input`, `opts?`): `Promise`\<`SendMessageCommandOutput`\>
 
-Defined in: [sqs/sqs.ts:48](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sqs/sqs.ts#L48)
+Defined in: [sqs/sqs.ts:74](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L74)
 
 Send a single message to an SQS queue.
+
+At INFO level the log line includes only queue routing / FIFO metadata;
+see `SEND_MESSAGE_SAFE_FIELDS`. `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the
+full input.
 
 #### Parameters
 
 ##### input
 
 `SendMessageCommandInput`
+
+##### opts?
+
+###### truncate?
+
+`boolean`
 
 #### Returns
 
@@ -145,7 +164,7 @@ Send a single message to an SQS queue.
 
 > **sendMessageBatch**(`input`): `Promise`\<`SendMessageBatchCommandOutput`[]\>
 
-Defined in: [sqs/sqs.ts:78](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sqs/sqs.ts#L78)
+Defined in: [sqs/sqs.ts:127](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L127)
 
 Send a batch of messages to an SQS queue. The SQS API caps
 SendMessageBatch at 10 entries per request, so this method auto-chunks

--- a/packages/aws-wrappers/docs/classes/SSMService.md
+++ b/packages/aws-wrappers/docs/classes/SSMService.md
@@ -6,12 +6,18 @@
 
 # Class: SSMService
 
-Defined in: [ssm/ssm.ts:17](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/ssm/ssm.ts#L17)
+Defined in: [ssm/ssm.ts:47](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L47)
 
 Wrapper around the AWS SSM Parameter Store client providing structured
-Powertools logging and X-Ray tracing by default. All operations enable
+Powertools logging and X-Ray tracing by default. All read operations enable
 `WithDecryption` — callers needing plaintext should use `SSMClient`
 directly.
+
+Write operations (`putParameter`, `deleteParameter`) are exposed for
+convenience but should be used with care: parameter lifecycle is usually
+managed by IaC (CDK / Terraform). Prefer IaC for anything that exists at
+deploy time; reserve runtime writes for values that genuinely need to
+mutate within the application.
 
 ## Constructors
 
@@ -21,7 +27,7 @@ directly.
 
 > **new SSMService**(`opts?`): `SSMService`
 
-Defined in: [ssm/ssm.ts:27](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/ssm/ssm.ts#L27)
+Defined in: [ssm/ssm.ts:57](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L57)
 
 #### Parameters
 
@@ -36,10 +42,10 @@ the wrapper does not apply X-Ray instrumentation.
 
 ###### logger?
 
-`Logger`
+`LoggerInterface`
 
-Optional Powertools logger. Defaults to a logger with
-`serviceName: 'SSMService'`.
+Optional Powertools logger. Defaults to `new Logger()`,
+which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 #### Returns
 
@@ -47,13 +53,38 @@ Optional Powertools logger. Defaults to a logger with
 
 ## Methods
 
+<a id="deleteparameter"></a>
+
+### deleteParameter()
+
+> **deleteParameter**(`name`): `Promise`\<`void`\>
+
+Defined in: [ssm/ssm.ts:136](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L136)
+
+Delete an SSM parameter by name.
+
+Prefer IaC (CDK / Terraform) for parameter lifecycle — use this for
+runtime cleanup only.
+
+#### Parameters
+
+##### name
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
 <a id="getparameter"></a>
 
 ### getParameter()
 
 > **getParameter**(`name`): `Promise`\<`string` \| `undefined`\>
 
-Defined in: [ssm/ssm.ts:38](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/ssm/ssm.ts#L38)
+Defined in: [ssm/ssm.ts:68](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L68)
 
 Fetch a single SSM parameter's value.
 
@@ -80,7 +111,7 @@ value set.
 
 > **getParameters**\<`K`\>(`aliases`): `Promise`\<`Record`\<`K`, `string` \| `undefined`\>\>
 
-Defined in: [ssm/ssm.ts:65](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/ssm/ssm.ts#L65)
+Defined in: [ssm/ssm.ts:95](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L95)
 
 Fetch multiple SSM parameters in a single request. Callers supply an
 alias-to-path record, and the returned record is keyed by the same
@@ -125,7 +156,7 @@ no value.
 
 > **getParametersByPath**(`path`, `opts?`): `Promise`\<`Parameter`[]\>
 
-Defined in: [ssm/ssm.ts:97](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/ssm/ssm.ts#L97)
+Defined in: [ssm/ssm.ts:152](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L152)
 
 Fetch all parameters under an SSM hierarchy path, auto-paginating across
 all pages. `Recursive` defaults to `true` (overriding the AWS SDK
@@ -155,3 +186,29 @@ to `true`.
 
 The full `Parameter` objects (including `Version`,
 `LastModifiedDate`, etc.).
+
+***
+
+<a id="putparameter"></a>
+
+### putParameter()
+
+> **putParameter**(`input`): `Promise`\<`PutParameterCommandOutput`\>
+
+Defined in: [ssm/ssm.ts:123](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L123)
+
+Create or update an SSM parameter. The log line omits `Value` to avoid
+leaking secret material.
+
+Prefer IaC (CDK / Terraform) for parameter lifecycle — use this for
+runtime values only.
+
+#### Parameters
+
+##### input
+
+`PutParameterCommandInput`
+
+#### Returns
+
+`Promise`\<`PutParameterCommandOutput`\>

--- a/packages/aws-wrappers/docs/classes/SchedulerService.md
+++ b/packages/aws-wrappers/docs/classes/SchedulerService.md
@@ -1,0 +1,269 @@
+[**@aligent/aws-wrappers**](../modules.md)
+
+***
+
+[@aligent/aws-wrappers](../modules.md) / SchedulerService
+
+# Class: SchedulerService
+
+Defined in: scheduler/scheduler.ts:75
+
+Wrapper around the AWS EventBridge Scheduler client providing structured
+Powertools logging and X-Ray tracing by default.
+
+Covers CRUD on schedules and their groups. Named `SchedulerService` (not
+`EventBridgeSchedulerService`) so it doesn't collide with a future wrapper
+over the separate EventBridge bus/rules API (`@aws-sdk/client-eventbridge`).
+
+`FlexibleTimeWindow` is required by `CreateSchedule` and is passed through
+untouched — the wrapper bakes in no default, so the caller must state their
+intent (`{ Mode: 'OFF' }` for a fixed-time schedule).
+
+## Constructors
+
+<a id="constructor"></a>
+
+### Constructor
+
+> **new SchedulerService**(`opts?`): `SchedulerService`
+
+Defined in: scheduler/scheduler.ts:85
+
+#### Parameters
+
+##### opts?
+
+###### client?
+
+`SchedulerClient`
+
+Optional pre-configured `SchedulerClient`. When
+supplied, the wrapper does not apply X-Ray instrumentation.
+
+###### logger?
+
+`LoggerInterface`
+
+Optional Powertools logger. Defaults to `new Logger()`,
+which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
+
+#### Returns
+
+`SchedulerService`
+
+## Methods
+
+<a id="createschedule"></a>
+
+### createSchedule()
+
+> **createSchedule**(`input`): `Promise`\<`CreateScheduleCommandOutput`\>
+
+Defined in: scheduler/scheduler.ts:95
+
+Create a new schedule. At INFO the log line omits `Target.Input` (the
+target payload, a PII carrier); `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the
+full input.
+
+#### Parameters
+
+##### input
+
+`CreateScheduleCommandInput`
+
+#### Returns
+
+`Promise`\<`CreateScheduleCommandOutput`\>
+
+***
+
+<a id="createschedulegroup"></a>
+
+### createScheduleGroup()
+
+> **createScheduleGroup**(`input`): `Promise`\<`CreateScheduleGroupCommandOutput`\>
+
+Defined in: scheduler/scheduler.ts:154
+
+Create a new schedule group. Groups are containers for schedules and are
+typically IaC-managed; use this for dynamically-provisioned groups only.
+
+#### Parameters
+
+##### input
+
+`CreateScheduleGroupCommandInput`
+
+#### Returns
+
+`Promise`\<`CreateScheduleGroupCommandOutput`\>
+
+***
+
+<a id="deleteschedule"></a>
+
+### deleteSchedule()
+
+> **deleteSchedule**(`input`): `Promise`\<`DeleteScheduleCommandOutput`\>
+
+Defined in: scheduler/scheduler.ts:130
+
+Delete a schedule.
+
+#### Parameters
+
+##### input
+
+`DeleteScheduleCommandInput`
+
+#### Returns
+
+`Promise`\<`DeleteScheduleCommandOutput`\>
+
+***
+
+<a id="deleteschedulegroup"></a>
+
+### deleteScheduleGroup()
+
+> **deleteScheduleGroup**(`input`): `Promise`\<`DeleteScheduleGroupCommandOutput`\>
+
+Defined in: scheduler/scheduler.ts:176
+
+Delete a schedule group. Deleting a group also deletes every schedule it
+contains, asynchronously — the API has no `UpdateScheduleGroup`, so this
+is the only mutating group operation besides create.
+
+#### Parameters
+
+##### input
+
+`DeleteScheduleGroupCommandInput`
+
+#### Returns
+
+`Promise`\<`DeleteScheduleGroupCommandOutput`\>
+
+***
+
+<a id="getschedule"></a>
+
+### getSchedule()
+
+> **getSchedule**(`input`): `Promise`\<`GetScheduleCommandOutput`\>
+
+Defined in: scheduler/scheduler.ts:103
+
+Fetch a schedule's full configuration.
+
+#### Parameters
+
+##### input
+
+`GetScheduleCommandInput`
+
+#### Returns
+
+`Promise`\<`GetScheduleCommandOutput`\>
+
+***
+
+<a id="getschedulegroup"></a>
+
+### getScheduleGroup()
+
+> **getScheduleGroup**(`input`): `Promise`\<`GetScheduleGroupCommandOutput`\>
+
+Defined in: scheduler/scheduler.ts:164
+
+Fetch a schedule group's configuration.
+
+#### Parameters
+
+##### input
+
+`GetScheduleGroupCommandInput`
+
+#### Returns
+
+`Promise`\<`GetScheduleGroupCommandOutput`\>
+
+***
+
+<a id="listschedulegroups"></a>
+
+### listScheduleGroups()
+
+> **listScheduleGroups**(`input?`): `Promise`\<`ScheduleGroupSummary`[]\>
+
+Defined in: scheduler/scheduler.ts:187
+
+List schedule groups, auto-paginating across all pages. Bounded in
+practice by the account's group count and the `NamePrefix` filter.
+
+#### Parameters
+
+##### input?
+
+`ListScheduleGroupsCommandInput`
+
+#### Returns
+
+`Promise`\<`ScheduleGroupSummary`[]\>
+
+***
+
+<a id="listschedules"></a>
+
+### listSchedules()
+
+> **listSchedules**(`input?`): `Promise`\<`ScheduleSummary`[]\>
+
+Defined in: scheduler/scheduler.ts:140
+
+List schedules, auto-paginating across all pages. Bounded in practice by
+the account's schedule count and the `GroupName` / `NamePrefix` / `State`
+filters, so the flat-array shape is safe.
+
+#### Parameters
+
+##### input?
+
+`ListSchedulesCommandInput`
+
+#### Returns
+
+`Promise`\<`ScheduleSummary`[]\>
+
+***
+
+<a id="updateschedule"></a>
+
+### updateSchedule()
+
+> **updateSchedule**(`input`): `Promise`\<`UpdateScheduleCommandOutput`\>
+
+Defined in: scheduler/scheduler.ts:122
+
+Update an existing schedule.
+
+**`UpdateSchedule` has PUT (full-replacement) semantics.** Any field you
+omit is reset to its default — this is not a partial patch. To change one
+attribute, `getSchedule` first and resend the complete configuration with
+that attribute modified, or you will silently erase `ScheduleExpression`,
+`Target`, `Description`, `StartDate`, etc. The wrapper does not merge on
+your behalf: deep-merging a `Target` (with its mutually-exclusive
+target-type params) has no single correct semantics.
+
+At INFO the log line omits `Target.Input`; `POWERTOOLS_LOG_LEVEL=DEBUG`
+unlocks the full input.
+
+#### Parameters
+
+##### input
+
+`UpdateScheduleCommandInput`
+
+#### Returns
+
+`Promise`\<`UpdateScheduleCommandOutput`\>

--- a/packages/aws-wrappers/docs/classes/SecretsManagerService.md
+++ b/packages/aws-wrappers/docs/classes/SecretsManagerService.md
@@ -6,10 +6,17 @@
 
 # Class: SecretsManagerService
 
-Defined in: [secrets-manager/secrets-manager.ts:9](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L9)
+Defined in: [secrets-manager/secrets-manager.ts:72](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L72)
 
 Wrapper around the AWS Secrets Manager client providing structured
 Powertools logging and X-Ray tracing by default.
+
+Write operations (`createSecret`, `updateSecret`, `putSecretValue`,
+`deleteSecret`) are exposed for convenience but should be used with care:
+secret lifecycle is usually managed by IaC (CDK / Terraform). Prefer IaC
+for anything that exists at deploy time; reserve runtime writes for
+dynamically-issued credentials, rotation flows, or other genuinely
+mutable values.
 
 ## Constructors
 
@@ -19,7 +26,7 @@ Powertools logging and X-Ray tracing by default.
 
 > **new SecretsManagerService**(`opts?`): `SecretsManagerService`
 
-Defined in: [secrets-manager/secrets-manager.ts:20](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L20)
+Defined in: [secrets-manager/secrets-manager.ts:83](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L83)
 
 #### Parameters
 
@@ -35,10 +42,10 @@ owns that decision.
 
 ###### logger?
 
-`Logger`
+`LoggerInterface`
 
-Optional Powertools logger. Defaults to a logger with
-`serviceName: 'SecretsManagerService'`.
+Optional Powertools logger. Defaults to `new Logger()`,
+which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 #### Returns
 
@@ -46,13 +53,65 @@ Optional Powertools logger. Defaults to a logger with
 
 ## Methods
 
+<a id="createsecret"></a>
+
+### createSecret()
+
+> **createSecret**(`input`): `Promise`\<`CreateSecretCommandOutput`\>
+
+Defined in: [secrets-manager/secrets-manager.ts:121](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L121)
+
+Create a new secret. At INFO level the log line includes only identity
+and non-secret metadata; `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full
+input (including `SecretString` / `SecretBinary`).
+
+Prefer IaC (CDK / Terraform) for secret lifecycle — use this for
+dynamically-issued credentials only.
+
+#### Parameters
+
+##### input
+
+`CreateSecretCommandInput`
+
+#### Returns
+
+`Promise`\<`CreateSecretCommandOutput`\>
+
+***
+
+<a id="deletesecret"></a>
+
+### deleteSecret()
+
+> **deleteSecret**(`input`): `Promise`\<`DeleteSecretCommandOutput`\>
+
+Defined in: [secrets-manager/secrets-manager.ts:163](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L163)
+
+Delete a secret. Pass `ForceDeleteWithoutRecovery: true` to bypass the
+default 7-30 day recovery window (irreversible).
+
+Prefer IaC (CDK / Terraform) for secret lifecycle.
+
+#### Parameters
+
+##### input
+
+`DeleteSecretCommandInput`
+
+#### Returns
+
+`Promise`\<`DeleteSecretCommandOutput`\>
+
+***
+
 <a id="getjsonsecret"></a>
 
 ### getJsonSecret()
 
 > **getJsonSecret**\<`T`\>(`secretId`): `Promise`\<`T`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:44](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L44)
+Defined in: [secrets-manager/secrets-manager.ts:107](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L107)
 
 Fetch a secret and parse it as JSON.
 
@@ -90,7 +149,7 @@ If the secret has no `SecretString` or the value is not valid JSON.
 
 > **getSecret**(`secretId`): `Promise`\<`string`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:32](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L32)
+Defined in: [secrets-manager/secrets-manager.ts:95](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L95)
 
 Fetch a secret's string value from Secrets Manager.
 
@@ -112,3 +171,56 @@ The secret's `SecretString` value.
 
 If the response does not contain a `SecretString` (e.g. the secret
 stores binary data).
+
+***
+
+<a id="putsecretvalue"></a>
+
+### putSecretValue()
+
+> **putSecretValue**(`input`): `Promise`\<`PutSecretValueCommandOutput`\>
+
+Defined in: [secrets-manager/secrets-manager.ts:150](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L150)
+
+Store a new version of a secret's value. At INFO level the log line
+omits `SecretString` / `SecretBinary`; `POWERTOOLS_LOG_LEVEL=DEBUG`
+unlocks the full input.
+
+Typically used by rotation flows.
+
+#### Parameters
+
+##### input
+
+`PutSecretValueCommandInput`
+
+#### Returns
+
+`Promise`\<`PutSecretValueCommandOutput`\>
+
+***
+
+<a id="updatesecret"></a>
+
+### updateSecret()
+
+> **updateSecret**(`input`): `Promise`\<`UpdateSecretCommandOutput`\>
+
+Defined in: [secrets-manager/secrets-manager.ts:136](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L136)
+
+Update an existing secret's metadata or value. At INFO level the log
+line omits `SecretString` / `SecretBinary`; `POWERTOOLS_LOG_LEVEL=DEBUG`
+unlocks the full input.
+
+Prefer IaC (CDK / Terraform) for secret lifecycle — use this for
+runtime metadata updates only.
+
+#### Parameters
+
+##### input
+
+`UpdateSecretCommandInput`
+
+#### Returns
+
+`Promise`\<`UpdateSecretCommandOutput`\>

--- a/packages/aws-wrappers/docs/classes/StepFunctionsService.md
+++ b/packages/aws-wrappers/docs/classes/StepFunctionsService.md
@@ -6,7 +6,7 @@
 
 # Class: StepFunctionsService
 
-Defined in: [sfn/sfn.ts:23](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sfn/sfn.ts#L23)
+Defined in: [sfn/sfn.ts:36](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sfn/sfn.ts#L36)
 
 Wrapper around the AWS Step Functions client providing structured
 Powertools logging and X-Ray tracing by default.
@@ -19,7 +19,7 @@ Powertools logging and X-Ray tracing by default.
 
 > **new StepFunctionsService**(`opts?`): `StepFunctionsService`
 
-Defined in: [sfn/sfn.ts:33](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sfn/sfn.ts#L33)
+Defined in: [sfn/sfn.ts:46](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sfn/sfn.ts#L46)
 
 #### Parameters
 
@@ -34,10 +34,10 @@ the wrapper does not apply X-Ray instrumentation.
 
 ###### logger?
 
-`Logger`
+`LoggerInterface`
 
-Optional Powertools logger. Defaults to a logger with
-`serviceName: 'StepFunctionsService'`.
+Optional Powertools logger. Defaults to `new Logger()`,
+which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 #### Returns
 
@@ -51,7 +51,7 @@ Optional Powertools logger. Defaults to a logger with
 
 > **describeExecution**(`input`): `Promise`\<`DescribeExecutionCommandOutput`\>
 
-Defined in: [sfn/sfn.ts:64](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sfn/sfn.ts#L64)
+Defined in: [sfn/sfn.ts:79](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sfn/sfn.ts#L79)
 
 Describe an existing Step Functions execution.
 
@@ -73,7 +73,7 @@ Describe an existing Step Functions execution.
 
 > **listExecutions**(`input`): `Promise`\<`ExecutionListItem`[]\>
 
-Defined in: [sfn/sfn.ts:43](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sfn/sfn.ts#L43)
+Defined in: [sfn/sfn.ts:56](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sfn/sfn.ts#L56)
 
 List all executions for a state machine, auto-paginating across all
 pages. Typically bounded by `statusFilter` and state-machine retention,
@@ -97,7 +97,7 @@ so the flat-array shape is safe in practice.
 
 > **startExecution**(`input`): `Promise`\<`StartExecutionCommandOutput`\>
 
-Defined in: [sfn/sfn.ts:56](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sfn/sfn.ts#L56)
+Defined in: [sfn/sfn.ts:69](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sfn/sfn.ts#L69)
 
 Start a new Step Functions execution.
 
@@ -119,7 +119,7 @@ Start a new Step Functions execution.
 
 > **stopExecution**(`input`): `Promise`\<`StopExecutionCommandOutput`\>
 
-Defined in: [sfn/sfn.ts:74](https://github.com/aligent/microservice-development-utilities/blob/30b581ee09ba114f98caadf97f423e40b9b4f410/packages/aws-wrappers/src/sfn/sfn.ts#L74)
+Defined in: [sfn/sfn.ts:89](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sfn/sfn.ts#L89)
 
 Stop an in-progress Step Functions execution.
 

--- a/packages/aws-wrappers/docs/modules.md
+++ b/packages/aws-wrappers/docs/modules.md
@@ -8,6 +8,7 @@
 
 - [DynamoDBService](classes/DynamoDBService.md)
 - [S3Service](classes/S3Service.md)
+- [SchedulerService](classes/SchedulerService.md)
 - [SecretsManagerService](classes/SecretsManagerService.md)
 - [SNSService](classes/SNSService.md)
 - [SQSService](classes/SQSService.md)

--- a/packages/aws-wrappers/package.json
+++ b/packages/aws-wrappers/package.json
@@ -33,6 +33,7 @@
     "@aws-lambda-powertools/logger": "^2.33.1",
     "@aws-sdk/client-dynamodb": "^3.1068.0",
     "@aws-sdk/client-s3": "^3.1068.0",
+    "@aws-sdk/client-scheduler": "^3.1077.0",
     "@aws-sdk/client-secrets-manager": "^3.1068.0",
     "@aws-sdk/client-sfn": "^3.1068.0",
     "@aws-sdk/client-sns": "^3.1068.0",

--- a/packages/aws-wrappers/src/index.ts
+++ b/packages/aws-wrappers/src/index.ts
@@ -1,5 +1,6 @@
 export { DynamoDBService } from './dynamodb/dynamodb.js';
 export { S3Service } from './s3/s3.js';
+export { SchedulerService } from './scheduler/scheduler.js';
 export { SecretsManagerService } from './secrets-manager/secrets-manager.js';
 export { StepFunctionsService } from './sfn/sfn.js';
 export { SNSService } from './sns/sns.js';

--- a/packages/aws-wrappers/src/scheduler/scheduler.test.ts
+++ b/packages/aws-wrappers/src/scheduler/scheduler.test.ts
@@ -1,0 +1,261 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+import {
+    CreateScheduleCommand,
+    CreateScheduleGroupCommand,
+    DeleteScheduleCommand,
+    DeleteScheduleGroupCommand,
+    GetScheduleCommand,
+    GetScheduleGroupCommand,
+    ListScheduleGroupsCommand,
+    ListSchedulesCommand,
+    SchedulerClient,
+    UpdateScheduleCommand,
+} from '@aws-sdk/client-scheduler';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SchedulerService } from './scheduler';
+
+const schedulerMock = mockClient(SchedulerClient);
+
+const target = {
+    Arn: 'arn:aws:lambda:us-east-1:0:function:test',
+    RoleArn: 'arn:aws:iam::0:role/test',
+};
+
+describe('SchedulerService', () => {
+    afterEach(() => {
+        schedulerMock.reset();
+    });
+
+    it('constructs with default logger and client when no options supplied', () => {
+        expect(() => new SchedulerService()).not.toThrow();
+    });
+
+    describe('listSchedules', () => {
+        it('concatenates schedules across pages', async () => {
+            schedulerMock
+                .on(ListSchedulesCommand)
+                .resolvesOnce({ Schedules: [{ Name: 's1' }], NextToken: 'tok' })
+                .resolves({ Schedules: [{ Name: 's2' }] });
+
+            const service = new SchedulerService({ client: new SchedulerClient({}) });
+
+            const result = await service.listSchedules({ GroupName: 'default' });
+
+            expect(result.map(s => s.Name)).toEqual(['s1', 's2']);
+            expect(schedulerMock.commandCalls(ListSchedulesCommand)).toHaveLength(2);
+        });
+
+        it('returns an empty array when no schedules exist', async () => {
+            schedulerMock.on(ListSchedulesCommand).resolves({});
+            const service = new SchedulerService({ client: new SchedulerClient({}) });
+
+            await expect(service.listSchedules()).resolves.toEqual([]);
+        });
+    });
+
+    describe('listScheduleGroups', () => {
+        it('concatenates groups across pages', async () => {
+            schedulerMock
+                .on(ListScheduleGroupsCommand)
+                .resolvesOnce({ ScheduleGroups: [{ Name: 'g1' }], NextToken: 'tok' })
+                .resolves({ ScheduleGroups: [{ Name: 'g2' }] });
+
+            const service = new SchedulerService({ client: new SchedulerClient({}) });
+
+            const result = await service.listScheduleGroups();
+
+            expect(result.map(g => g.Name)).toEqual(['g1', 'g2']);
+            expect(schedulerMock.commandCalls(ListScheduleGroupsCommand)).toHaveLength(2);
+        });
+
+        it('returns an empty array when no groups exist', async () => {
+            schedulerMock.on(ListScheduleGroupsCommand).resolves({});
+            const service = new SchedulerService({ client: new SchedulerClient({}) });
+
+            await expect(service.listScheduleGroups()).resolves.toEqual([]);
+        });
+    });
+
+    describe('createSchedule', () => {
+        it('sends a CreateScheduleCommand', async () => {
+            schedulerMock.on(CreateScheduleCommand).resolves({ ScheduleArn: 'arn-1' });
+            const service = new SchedulerService({ client: new SchedulerClient({}) });
+
+            await service.createSchedule({
+                Name: 's1',
+                ScheduleExpression: 'rate(1 day)',
+                FlexibleTimeWindow: { Mode: 'OFF' },
+                Target: target,
+            });
+
+            expect(schedulerMock.commandCalls(CreateScheduleCommand)).toHaveLength(1);
+        });
+
+        it('omits Target.Input from the INFO log but keeps the rest of Target', async () => {
+            schedulerMock.on(CreateScheduleCommand).resolves({ ScheduleArn: 'arn-1' });
+            const logger = new Logger();
+            logger.setLogLevel('INFO');
+            const infoSpy = vi.spyOn(logger, 'info');
+            const service = new SchedulerService({ client: new SchedulerClient({}), logger });
+
+            await service.createSchedule({
+                Name: 's1',
+                ScheduleExpression: 'rate(1 day)',
+                FlexibleTimeWindow: { Mode: 'OFF' },
+                Target: {
+                    ...target,
+                    Input: JSON.stringify({ customerEmail: 'pii@example.com' }),
+                },
+            });
+
+            const [, payload] = infoSpy.mock.calls[0] ?? [];
+            const loggedTarget = (payload as { input: { Target: object } }).input.Target;
+            expect(loggedTarget).not.toHaveProperty('Input');
+            expect(loggedTarget).toHaveProperty('Arn', target.Arn);
+        });
+
+        it('logs Target.Input at DEBUG level', async () => {
+            schedulerMock.on(CreateScheduleCommand).resolves({ ScheduleArn: 'arn-1' });
+            const logger = new Logger();
+            logger.setLogLevel('DEBUG');
+            const infoSpy = vi.spyOn(logger, 'info');
+            const service = new SchedulerService({ client: new SchedulerClient({}), logger });
+
+            await service.createSchedule({
+                Name: 's1',
+                ScheduleExpression: 'rate(1 day)',
+                FlexibleTimeWindow: { Mode: 'OFF' },
+                Target: { ...target, Input: 'payload' },
+            });
+
+            const [, payload] = infoSpy.mock.calls[0] ?? [];
+            const loggedTarget = (payload as { input: { Target: object } }).input.Target;
+            expect(loggedTarget).toHaveProperty('Input', 'payload');
+        });
+
+        it('leaves the input untouched when the Target has no Input', async () => {
+            schedulerMock.on(CreateScheduleCommand).resolves({ ScheduleArn: 'arn-1' });
+            const logger = new Logger();
+            logger.setLogLevel('INFO');
+            const infoSpy = vi.spyOn(logger, 'info');
+            const service = new SchedulerService({ client: new SchedulerClient({}), logger });
+
+            await service.createSchedule({
+                Name: 's1',
+                ScheduleExpression: 'rate(1 day)',
+                FlexibleTimeWindow: { Mode: 'OFF' },
+                Target: target,
+            });
+
+            const [, payload] = infoSpy.mock.calls[0] ?? [];
+            const loggedTarget = (payload as { input: { Target: object } }).input.Target;
+            expect(loggedTarget).toEqual(target);
+        });
+    });
+
+    describe('updateSchedule', () => {
+        it('omits Target.Input from the INFO log but keeps the rest of Target', async () => {
+            schedulerMock.on(UpdateScheduleCommand).resolves({ ScheduleArn: 'arn-1' });
+            const logger = new Logger();
+            logger.setLogLevel('INFO');
+            const infoSpy = vi.spyOn(logger, 'info');
+            const service = new SchedulerService({ client: new SchedulerClient({}), logger });
+
+            await service.updateSchedule({
+                Name: 's1',
+                ScheduleExpression: 'rate(2 days)',
+                FlexibleTimeWindow: { Mode: 'OFF' },
+                Target: {
+                    ...target,
+                    Input: JSON.stringify({ customerEmail: 'pii@example.com' }),
+                },
+            });
+
+            const [, payload] = infoSpy.mock.calls[0] ?? [];
+            const loggedTarget = (payload as { input: { Target: object } }).input.Target;
+            expect(loggedTarget).not.toHaveProperty('Input');
+            expect(loggedTarget).toHaveProperty('Arn', target.Arn);
+        });
+
+        it('logs Target.Input at DEBUG level', async () => {
+            schedulerMock.on(UpdateScheduleCommand).resolves({ ScheduleArn: 'arn-1' });
+            const logger = new Logger();
+            logger.setLogLevel('DEBUG');
+            const infoSpy = vi.spyOn(logger, 'info');
+            const service = new SchedulerService({ client: new SchedulerClient({}), logger });
+
+            await service.updateSchedule({
+                Name: 's1',
+                ScheduleExpression: 'rate(2 days)',
+                FlexibleTimeWindow: { Mode: 'OFF' },
+                Target: { ...target, Input: 'payload' },
+            });
+
+            const [, payload] = infoSpy.mock.calls[0] ?? [];
+            const loggedTarget = (payload as { input: { Target: object } }).input.Target;
+            expect(loggedTarget).toHaveProperty('Input', 'payload');
+        });
+    });
+
+    describe('pass-through commands', () => {
+        it('getSchedule sends a GetScheduleCommand', async () => {
+            schedulerMock.on(GetScheduleCommand).resolves({});
+            const service = new SchedulerService({ client: new SchedulerClient({}) });
+
+            await service.getSchedule({ Name: 's1' });
+
+            expect(schedulerMock.commandCalls(GetScheduleCommand)).toHaveLength(1);
+        });
+
+        it('updateSchedule sends an UpdateScheduleCommand', async () => {
+            schedulerMock.on(UpdateScheduleCommand).resolves({ ScheduleArn: 'arn-1' });
+            const service = new SchedulerService({ client: new SchedulerClient({}) });
+
+            await service.updateSchedule({
+                Name: 's1',
+                ScheduleExpression: 'rate(2 days)',
+                FlexibleTimeWindow: { Mode: 'OFF' },
+                Target: target,
+            });
+
+            expect(schedulerMock.commandCalls(UpdateScheduleCommand)).toHaveLength(1);
+        });
+
+        it('deleteSchedule sends a DeleteScheduleCommand', async () => {
+            schedulerMock.on(DeleteScheduleCommand).resolves({});
+            const service = new SchedulerService({ client: new SchedulerClient({}) });
+
+            await service.deleteSchedule({ Name: 's1' });
+
+            expect(schedulerMock.commandCalls(DeleteScheduleCommand)).toHaveLength(1);
+        });
+
+        it('createScheduleGroup sends a CreateScheduleGroupCommand', async () => {
+            schedulerMock.on(CreateScheduleGroupCommand).resolves({ ScheduleGroupArn: 'arn-1' });
+            const service = new SchedulerService({ client: new SchedulerClient({}) });
+
+            await service.createScheduleGroup({ Name: 'g1' });
+
+            expect(schedulerMock.commandCalls(CreateScheduleGroupCommand)).toHaveLength(1);
+        });
+
+        it('getScheduleGroup sends a GetScheduleGroupCommand', async () => {
+            schedulerMock.on(GetScheduleGroupCommand).resolves({});
+            const service = new SchedulerService({ client: new SchedulerClient({}) });
+
+            await service.getScheduleGroup({ Name: 'g1' });
+
+            expect(schedulerMock.commandCalls(GetScheduleGroupCommand)).toHaveLength(1);
+        });
+
+        it('deleteScheduleGroup sends a DeleteScheduleGroupCommand', async () => {
+            schedulerMock.on(DeleteScheduleGroupCommand).resolves({});
+            const service = new SchedulerService({ client: new SchedulerClient({}) });
+
+            await service.deleteScheduleGroup({ Name: 'g1' });
+
+            expect(schedulerMock.commandCalls(DeleteScheduleGroupCommand)).toHaveLength(1);
+        });
+    });
+});

--- a/packages/aws-wrappers/src/scheduler/scheduler.ts
+++ b/packages/aws-wrappers/src/scheduler/scheduler.ts
@@ -1,0 +1,198 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+import type { LoggerInterface } from '@aws-lambda-powertools/logger/types';
+import {
+    CreateScheduleCommand,
+    CreateScheduleCommandInput,
+    CreateScheduleCommandOutput,
+    CreateScheduleGroupCommand,
+    CreateScheduleGroupCommandInput,
+    CreateScheduleGroupCommandOutput,
+    DeleteScheduleCommand,
+    DeleteScheduleCommandInput,
+    DeleteScheduleCommandOutput,
+    DeleteScheduleGroupCommand,
+    DeleteScheduleGroupCommandInput,
+    DeleteScheduleGroupCommandOutput,
+    GetScheduleCommand,
+    GetScheduleCommandInput,
+    GetScheduleCommandOutput,
+    GetScheduleGroupCommand,
+    GetScheduleGroupCommandInput,
+    GetScheduleGroupCommandOutput,
+    ListScheduleGroupsCommandInput,
+    ListSchedulesCommandInput,
+    paginateListScheduleGroups,
+    paginateListSchedules,
+    ScheduleGroupSummary,
+    SchedulerClient,
+    ScheduleSummary,
+    Target,
+    UpdateScheduleCommand,
+    UpdateScheduleCommandInput,
+    UpdateScheduleCommandOutput,
+} from '@aws-sdk/client-scheduler';
+import xray from 'aws-xray-sdk-core';
+
+/**
+ * `CreateSchedule` / `UpdateSchedule` inputs carry the payload handed to the
+ * target at `Target.Input` — arbitrary text or JSON that routinely contains
+ * PII (customer IDs, order contents, etc.), the same risk profile as SFN's
+ * execution `input`.
+ *
+ * This can't go through the package's usual `filterFieldsForLogLevel` helper:
+ * that helper picks **top-level** keys only, and the sensitive field is nested
+ * one level down inside `Target`. Allowlisting `Target` would leak `Input`;
+ * omitting `Target` would lose operationally-useful fields (`Arn`, `RoleArn`,
+ * `RetryPolicy`, `DeadLetterConfig`, the target-type params). So this is a
+ * bespoke case: keep every top-level field and shallow-strip only
+ * `Target.Input`.
+ *
+ * At `DEBUG` the input is returned unchanged — operators who set
+ * `POWERTOOLS_LOG_LEVEL=DEBUG` have opted into seeing payloads and PII.
+ */
+function redactTargetInput<T extends { Target?: Target | undefined }>(
+    logger: LoggerInterface,
+    input: T
+): T {
+    if (logger.getLevelName() === 'DEBUG') return input;
+    if (input.Target?.Input === undefined) return input;
+    const { Input: _input, ...safeTarget } = input.Target;
+    return { ...input, Target: safeTarget as Target };
+}
+
+/**
+ * Wrapper around the AWS EventBridge Scheduler client providing structured
+ * Powertools logging and X-Ray tracing by default.
+ *
+ * Covers CRUD on schedules and their groups. Named `SchedulerService` (not
+ * `EventBridgeSchedulerService`) so it doesn't collide with a future wrapper
+ * over the separate EventBridge bus/rules API (`@aws-sdk/client-eventbridge`).
+ *
+ * `FlexibleTimeWindow` is required by `CreateSchedule` and is passed through
+ * untouched — the wrapper bakes in no default, so the caller must state their
+ * intent (`{ Mode: 'OFF' }` for a fixed-time schedule).
+ */
+export class SchedulerService {
+    private readonly client: SchedulerClient;
+    private readonly logger: LoggerInterface;
+
+    /**
+     * @param opts.logger - Optional Powertools logger. Defaults to `new Logger()`,
+     * which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
+     * @param opts.client - Optional pre-configured `SchedulerClient`. When
+     * supplied, the wrapper does not apply X-Ray instrumentation.
+     */
+    constructor(opts?: { logger?: LoggerInterface; client?: SchedulerClient }) {
+        this.client = opts?.client ?? xray.captureAWSv3Client(new SchedulerClient());
+        this.logger = opts?.logger ?? new Logger();
+    }
+
+    /**
+     * Create a new schedule. At INFO the log line omits `Target.Input` (the
+     * target payload, a PII carrier); `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the
+     * full input.
+     */
+    async createSchedule(input: CreateScheduleCommandInput): Promise<CreateScheduleCommandOutput> {
+        this.logger.info('Creating schedule', { input: redactTargetInput(this.logger, input) });
+        return this.client.send(new CreateScheduleCommand(input));
+    }
+
+    /**
+     * Fetch a schedule's full configuration.
+     */
+    async getSchedule(input: GetScheduleCommandInput): Promise<GetScheduleCommandOutput> {
+        this.logger.info('Getting schedule', { input });
+        return this.client.send(new GetScheduleCommand(input));
+    }
+
+    /**
+     * Update an existing schedule.
+     *
+     * **`UpdateSchedule` has PUT (full-replacement) semantics.** Any field you
+     * omit is reset to its default — this is not a partial patch. To change one
+     * attribute, `getSchedule` first and resend the complete configuration with
+     * that attribute modified, or you will silently erase `ScheduleExpression`,
+     * `Target`, `Description`, `StartDate`, etc. The wrapper does not merge on
+     * your behalf: deep-merging a `Target` (with its mutually-exclusive
+     * target-type params) has no single correct semantics.
+     *
+     * At INFO the log line omits `Target.Input`; `POWERTOOLS_LOG_LEVEL=DEBUG`
+     * unlocks the full input.
+     */
+    async updateSchedule(input: UpdateScheduleCommandInput): Promise<UpdateScheduleCommandOutput> {
+        this.logger.info('Updating schedule', { input: redactTargetInput(this.logger, input) });
+        return this.client.send(new UpdateScheduleCommand(input));
+    }
+
+    /**
+     * Delete a schedule.
+     */
+    async deleteSchedule(input: DeleteScheduleCommandInput): Promise<DeleteScheduleCommandOutput> {
+        this.logger.info('Deleting schedule', { input });
+        return this.client.send(new DeleteScheduleCommand(input));
+    }
+
+    /**
+     * List schedules, auto-paginating across all pages. Bounded in practice by
+     * the account's schedule count and the `GroupName` / `NamePrefix` / `State`
+     * filters, so the flat-array shape is safe.
+     */
+    async listSchedules(input?: ListSchedulesCommandInput): Promise<ScheduleSummary[]> {
+        this.logger.info('Listing schedules', { input });
+        const paginator = paginateListSchedules({ client: this.client }, input ?? {});
+        const schedules: ScheduleSummary[] = [];
+        for await (const page of paginator) {
+            if (page.Schedules) schedules.push(...page.Schedules);
+        }
+        return schedules;
+    }
+
+    /**
+     * Create a new schedule group. Groups are containers for schedules and are
+     * typically IaC-managed; use this for dynamically-provisioned groups only.
+     */
+    async createScheduleGroup(
+        input: CreateScheduleGroupCommandInput
+    ): Promise<CreateScheduleGroupCommandOutput> {
+        this.logger.info('Creating schedule group', { input });
+        return this.client.send(new CreateScheduleGroupCommand(input));
+    }
+
+    /**
+     * Fetch a schedule group's configuration.
+     */
+    async getScheduleGroup(
+        input: GetScheduleGroupCommandInput
+    ): Promise<GetScheduleGroupCommandOutput> {
+        this.logger.info('Getting schedule group', { input });
+        return this.client.send(new GetScheduleGroupCommand(input));
+    }
+
+    /**
+     * Delete a schedule group. Deleting a group also deletes every schedule it
+     * contains, asynchronously — the API has no `UpdateScheduleGroup`, so this
+     * is the only mutating group operation besides create.
+     */
+    async deleteScheduleGroup(
+        input: DeleteScheduleGroupCommandInput
+    ): Promise<DeleteScheduleGroupCommandOutput> {
+        this.logger.info('Deleting schedule group', { input });
+        return this.client.send(new DeleteScheduleGroupCommand(input));
+    }
+
+    /**
+     * List schedule groups, auto-paginating across all pages. Bounded in
+     * practice by the account's group count and the `NamePrefix` filter.
+     */
+    async listScheduleGroups(
+        input?: ListScheduleGroupsCommandInput
+    ): Promise<ScheduleGroupSummary[]> {
+        this.logger.info('Listing schedule groups', { input });
+        const paginator = paginateListScheduleGroups({ client: this.client }, input ?? {});
+        const groups: ScheduleGroupSummary[] = [];
+        for await (const page of paginator) {
+            if (page.ScheduleGroups) groups.push(...page.ScheduleGroups);
+        }
+        return groups;
+    }
+}


### PR DESCRIPTION
**Description of the proposed changes**

- Add `SchedulerService` to `@aligent/aws-wrappers`, wrapping the AWS EventBridge Scheduler client (`@aws-sdk/client-scheduler`) with CRUD over schedules and schedule groups.
- Schedule ops: `createSchedule`, `getSchedule`, `updateSchedule`, `deleteSchedule`, `listSchedules`.
- Group ops: `createScheduleGroup`, `getScheduleGroup`, `deleteScheduleGroup`, `listScheduleGroups` (the API has no `UpdateScheduleGroup`).
- Follows the package's locked-in conventions: `LoggerInterface` constructor contract, one `logger.info` per method, X-Ray on the default client, pass-through SDK inputs, no generics, auto-paginated flat arrays for the list methods.
- `Target.Input` (the target payload, a PII carrier) is stripped from INFO-level logs via a **bespoke** `redactTargetInput` helper — the shared `filterFieldsForLogLevel` is top-level-only and the sensitive field is nested one level inside `Target`. TSDoc documents why.
- `updateSchedule` is a thin pass-through with a prominent PUT-semantics (full-replacement) warning; it does not auto-merge.
- `FlexibleTimeWindow` is passed through untouched — no baked-in default.
- 17 tests (`aws-sdk-client-mock`), 100% coverage on `scheduler.ts`; INFO/DEBUG redaction assertions on both `createSchedule` and `updateSchedule`.
- Version plan: `aws-wrappers: minor`.

**Screenshots**

N/A

**Other solutions considered**

- **Shared redaction helper** — rejected for the create/update log line because `filterFieldsForLogLevel` picks top-level keys only; allowlisting `Target` would leak `Input`, omitting it would lose `Arn`/`RoleArn`. Hence the documented bespoke helper.
- **`patchSchedule` / auto-merge on `updateSchedule`** — rejected. Deep-merging a `Target` (with its mutually-exclusive target-type params) has no single correct semantics; a documented full-replacement warning is safer than hiding a get-then-put.

**Notes to reviewers**

- 🛈 Toggl Code: _MI-330: Code Review_
- The `docs/` churn on the other services (SFN/S3/etc.) is **typedoc reconciliation only** — regenerating corrected stale `Logger`→`LoggerInterface` constructor docs and commit-hash permalinks that were already out of date on `main`. No behavioural change to those services.
- `package-lock.json` has sizeable churn: the `@aws-sdk/client-scheduler` install required `--legacy-peer-deps` due to a pre-existing `@nx/vitest`/`@nx/eslint` peer conflict unrelated to this change; npm re-deduped as a result. `packages/aws-wrappers/package.json` itself is a clean one-line add.
