### PR TITLE
MI-251: Fix TypeScript configs in nx-cdk generators

### DIFF
--- a/.nx/version-plans/version-plan-1783323815557.md
+++ b/.nx/version-plans/version-plan-1783323815557.md
@@ -1,0 +1,8 @@
+---
+nx-cdk: patch
+---
+
+MI-251: Fix TypeScript configs and switch service build mode to BUNDLE_MODE env var
+
+- Updated generated tsconfigs with proper `compilerOptions` (`rootDir`, `outDir`, `tsBuildInfoFile`, `types`)
+- Service build command now uses `${BUNDLE_MODE:-development}` (shell env var) instead of `{args.mode}` (Nx arg interpolation). Set `BUNDLE_MODE` to control the vite build mode; defaults to `development` when unset.

--- a/packages/nx-cdk/src/generators/helpers/configs/base-package/package.json
+++ b/packages/nx-cdk/src/generators/helpers/configs/base-package/package.json
@@ -11,22 +11,22 @@
     "typecheck": "nx affected -t typecheck",
     "typecheck:all": "nx run-many -t typecheck",
     "audit": "nx run-many -t lint typecheck test --configuration coverage --skip-nx-cache",
-    "pg:synth": "nx run application:cdk -- synth '**' --mode=development --profile playground",
-    "pg:deploy": "nx run application:cdk -- deploy '**' --mode=development --method=direct --require-approval never --profile playground",
-    "pg:diff": "nx run application:cdk -- diff '**' --mode=development --profile playground",
-    "pg:destroy": "nx run application:cdk -- destroy '**' --mode=development --profile playground",
+    "pg:synth": "nx run application:cdk -- synth --profile playground",
+    "pg:deploy": "nx run application:cdk -- deploy --method=direct --require-approval never --profile playground",
+    "pg:diff": "nx run application:cdk -- diff --profile playground",
+    "pg:destroy": "nx run application:cdk -- destroy --profile playground",
     "postinstall": "[ -d .git ] && git config core.hooksPath '.git-hooks' && chmod +x .git-hooks/* || true"
   },
   "dependencies": {
-    "@aligent/microservice-util-lib": "^1.6.0"
+    "@aligent/microservice-util-lib": "^1.7.0"
   },
   "devDependencies": {
-    "@aligent/cdk-aspects": "^0.6.3",
+    "@aligent/cdk-aspects": "^0.6.5",
     "@aligent/cdk-nodejs-function-from-entry": "^0.2.3",
     "@aligent/cdk-step-function-from-file": "^0.5.3",
-    "@aligent/nx-openapi": "^2.1.2",
+    "@aligent/nx-openapi": "^2.2.1",
     "@aligent/ts-code-standards": "^5.0.0",
-    "@aligent/vite-plugin-handler": "^0.1.0",
+    "@aligent/vite-plugin-handler": "^0.2.0",
     "@nx/eslint": "22.7.3",
     "@nx/eslint-plugin": "22.7.3",
     "@nx/js": "22.7.3",

--- a/packages/nx-cdk/src/generators/helpers/configs/nxJson.ts
+++ b/packages/nx-cdk/src/generators/helpers/configs/nxJson.ts
@@ -38,7 +38,11 @@ export const NX_JSON: NxJsonConfiguration = {
             dependsOn: ['^build'], // Stack tests may require lambda handlers to be built first
             configurations: { coverage: { coverage: true } },
         },
-        typecheck: { cache: true, inputs: ['default', '^production'] },
+        typecheck: {
+            cache: true,
+            inputs: ['default', '^production'],
+            outputs: ['{projectRoot}/out-tsc'],
+        },
         cdk: {
             dependsOn: [{ target: 'build', params: 'forward', projects: `${SERVICES_SCOPE}/*` }],
         },

--- a/packages/nx-cdk/src/generators/helpers/configs/tsConfigs.ts
+++ b/packages/nx-cdk/src/generators/helpers/configs/tsConfigs.ts
@@ -1,7 +1,6 @@
 interface TsConfig {
     extends: string;
     compilerOptions?: Record<string, unknown>;
-    files?: string[];
     include: string[];
     exclude?: string[];
     references: Array<Record<string, string>>;
@@ -9,21 +8,21 @@ interface TsConfig {
 
 const BASE_CONFIG = '@aligent/ts-code-standards/tsconfigs-extend';
 
+export const BASE_COMPILER_OPTIONS: Record<string, unknown> = {
+    outDir: 'out-tsc/lib',
+    tsBuildInfoFile: 'out-tsc/tsconfig.lib.tsbuildinfo',
+    types: ['node'],
+} as const;
+
 export const TS_CONFIG_JSON: TsConfig = {
     extends: BASE_CONFIG,
-    files: [],
-    include: [],
+    include: ['src/**/*.ts', 'tests/**/*.ts'],
     references: [],
 } as const;
 
 export const TS_CONFIG_LIB_JSON: TsConfig = {
     extends: './tsconfig.json',
-    compilerOptions: {
-        rootDir: 'src',
-        outDir: 'out-tsc/lib',
-        tsBuildInfoFile: 'out-tsc/tsconfig.lib.tsbuildinfo',
-        types: ['node'],
-    },
+    compilerOptions: { rootDir: 'src', ...BASE_COMPILER_OPTIONS },
     include: ['src/**/*.ts'],
     exclude: ['vitest.config.mjs', 'src/**/*.spec.ts', 'src/**/*.test.ts'],
     references: [],

--- a/packages/nx-cdk/src/generators/helpers/utilities.ts
+++ b/packages/nx-cdk/src/generators/helpers/utilities.ts
@@ -3,7 +3,12 @@ import { readJsonFile, readProjectConfiguration, Tree, updateJson } from '@nx/de
 import { join } from 'path';
 import { InMemoryFileSystemHost, Project } from 'ts-morph';
 import { ProjectType, SERVICES_SCOPE } from '../constants';
-import { TS_CONFIG_JSON, TS_CONFIG_LIB_JSON, TS_CONFIG_SPEC_JSON } from './configs/tsConfigs';
+import {
+    BASE_COMPILER_OPTIONS,
+    TS_CONFIG_JSON,
+    TS_CONFIG_LIB_JSON,
+    TS_CONFIG_SPEC_JSON,
+} from './configs/tsConfigs';
 
 interface PackageJsonInput {
     name: string;
@@ -71,9 +76,19 @@ export function constructPackageJsonFile(input: PackageJsonInput) {
 }
 
 export function constructProjectTsConfigFiles(type: ProjectType) {
-    const tsConfig = { ...TS_CONFIG_JSON };
+    const tsConfig = { ...TS_CONFIG_JSON, compilerOptions: { ...TS_CONFIG_JSON.compilerOptions } };
+
+    if (type === 'application') {
+        tsConfig.compilerOptions = { ...BASE_COMPILER_OPTIONS };
+        tsConfig.include = ['bin/**/*.ts', 'lib/**/*.ts'];
+    }
+
     if (type === 'service') {
-        tsConfig.references = [{ path: './tsconfig.lib.json' }, { path: './tsconfig.spec.json' }];
+        tsConfig.references = [
+            { path: '../../libs/infra' },
+            { path: './tsconfig.lib.json' },
+            { path: './tsconfig.spec.json' },
+        ];
     }
 
     return {

--- a/packages/nx-cdk/src/generators/preset/files/README.md.template
+++ b/packages/nx-cdk/src/generators/preset/files/README.md.template
@@ -58,6 +58,12 @@ Before committing this repository, review and update the following generated def
 
 For deployment instructions (synthesize, deploy, destroy), see the [CDK Application README](./application/README.md).
 
+### Environment Variables
+
+| Variable      | Default       | Description                                                                 |
+| ------------- | ------------- | --------------------------------------------------------------------------- |
+| `BUNDLE_MODE` | `development` | Vite build mode used by all service `build` targets. Set to `production` in CI/CD pipelines. |
+
 ## Contributing
 
 We follow [trunk-based development framework](https://trunkbaseddevelopment.com/) as a start and will evolve depending on our need.

--- a/packages/nx-cdk/src/generators/preset/files/application/bin/main.ts.template
+++ b/packages/nx-cdk/src/generators/preset/files/application/bin/main.ts.template
@@ -35,7 +35,12 @@ if (typeof stageName !== 'string' || !/^[a-z0-9]{3}$/.test(stageName)) {
     );
 }
 
-const stage = new ApplicationStage(app, stageName);
+const stage = new ApplicationStage(app, stageName, {
+    env: {
+        account: process.env.CDK_DEFAULT_ACCOUNT as string,
+        region: process.env.CDK_DEFAULT_REGION as string,
+    },
+});
 Tags.of(stage).add('APPLICATION', APPLICATION_CONTEXT.NAME);
 Tags.of(stage).add('OWNER', APPLICATION_CONTEXT.OWNER);
 Tags.of(stage).add('STAGE', stageName);

--- a/packages/nx-cdk/src/generators/preset/files/application/package.json.template
+++ b/packages/nx-cdk/src/generators/preset/files/application/package.json.template
@@ -3,6 +3,9 @@
   "type": "module",
   "main": "./bin/main.ts",
   "types": "./bin/main.ts",
+  "bundleDependencies": [
+    "@libs/infra"
+  ],
   "nx": {
     "projectType": "application",
     "tags": [

--- a/packages/nx-cdk/src/generators/preset/files/libs/infra/tsconfig.json.template
+++ b/packages/nx-cdk/src/generators/preset/files/libs/infra/tsconfig.json.template
@@ -1,6 +1,12 @@
 {
     "extends": "@aligent/ts-code-standards/tsconfigs-extend",
-    "files": [],
-    "include": [],
+    "compilerOptions": {
+        "baseUrl": ".",
+        "rootDir": "src",
+        "outDir": "out-tsc",
+        "tsBuildInfoFile": "out-tsc/tsconfig.lib.tsbuildinfo",
+        "types": ["node"]
+    },
+    "include": ["src/**/*.ts"],
     "references": []
 }

--- a/packages/nx-cdk/src/generators/service/files/package.json.template
+++ b/packages/nx-cdk/src/generators/service/files/package.json.template
@@ -24,7 +24,7 @@
       "build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "vite build --mode {args.mode}",
+          "command": "vite build --mode ${BUNDLE_MODE:-development}",
           "color": true,
           "cwd": "{projectRoot}"
         }


### PR DESCRIPTION
**Description of the proposed changes**

- Update generated TypeScript configs with proper `compilerOptions` (`rootDir`, `outDir`, `tsBuildInfoFile`, `types`) replacing empty `files`/`include` arrays
- Add `outputs` to the `typecheck` Nx target for correct caching via `out-tsc`
- Extract `BASE_COMPILER_OPTIONS` constant shared between root and lib tsconfigs
- Add project type-specific tsconfig handling (application vs service) in `constructProjectTsConfigFiles`
- Add CDK environment config (`CDK_DEFAULT_ACCOUNT`/`CDK_DEFAULT_REGION`) to generated `main.ts` template
- Add `bundleDependencies` for `@libs/infra` in application `package.json` template
- Switch vite build mode from Nx arg interpolation to shell env var (`${BUNDLE_MODE:-development}`)
- Simplify playground CDK commands (remove `'**'` glob and `--mode=development`)
- Bump dependency versions (`microservice-util-lib`, `cdk-aspects`, `nx-openapi`, `vite-plugin-handler`)

**Other solutions considered**

- Using `structuredClone` for deep-cloning tsconfig objects — opted for explicit shallow copies with spread since the structure is flat

**Notes to reviewers**

- 🛈 Toggl Code: _MI-251: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback