### PR TITLE
MI-251: Fix nx-openapi generated tsconfig template

### DIFF
--- a/.nx/version-plans/version-plan-1783386633845.md
+++ b/.nx/version-plans/version-plan-1783386633845.md
@@ -1,0 +1,5 @@
+---
+nx-openapi: patch
+---
+
+Fix generated tsconfig.json template to include proper compilerOptions and correct include glob pattern

--- a/packages/nx-openapi/src/generators/client/files/tsconfig.json.template
+++ b/packages/nx-openapi/src/generators/client/files/tsconfig.json.template
@@ -1,6 +1,12 @@
 {
     "extends": "@aligent/ts-code-standards/tsconfigs-extend",
-    "files": [],
-    "include": [],
+    "compilerOptions": {
+        "baseUrl": ".",
+        "rootDir": "src",
+        "outDir": "out-tsc",
+        "tsBuildInfoFile": "out-tsc/tsconfig.lib.tsbuildinfo",
+        "types": ["node"]
+    },
+    "include": ["src/**/*.ts"],
     "references": []
 }


### PR DESCRIPTION
**Description of the proposed changes**

- Fix the generated `tsconfig.json` template in the `nx-openapi` client generator to include proper `compilerOptions` (`baseUrl`, `rootDir`, `outDir`, `tsBuildInfoFile`, `types`) and a correct `include` glob pattern (`src/**/*.ts`), replacing the previous empty `files` and `include` arrays

**Other solutions considered**

N/A

**Notes to reviewers**

- 🛈 Toggl Code: _MI-251: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)