### PR TITLE
MI-326: Adjustments to vite-plugin-handler

### DIFF
--- a/.nx/version-plans/version-plan-1783772746799.md
+++ b/.nx/version-plans/version-plan-1783772746799.md
@@ -1,0 +1,5 @@
+---
+vite-plugin-handler: minor
+---
+
+Use MagicString for proper sourcemap generation in renderChunk, always disable minify, and gate sourcemaps on NODE_ENV instead of Vite mode.

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "eslint-plugin-import": "^2.32.0",
         "jiti": "2.7.0",
         "jsonc-eslint-parser": "^2.4.1",
+        "magic-string": "^0.30.21",
         "nx": "22.7.6",
         "oauth-sign": "^0.9.0",
         "openapi-fetch": "0.17.0",
@@ -4399,7 +4400,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -15971,7 +15971,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -21737,6 +21736,9 @@
       "name": "@aligent/vite-plugin-handler",
       "version": "0.2.0",
       "license": "MIT",
+      "dependencies": {
+        "magic-string": "0.30.21"
+      },
       "peerDependencies": {
         "vite": ">=8.0.14"
       }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-import": "^2.32.0",
     "jiti": "2.7.0",
     "jsonc-eslint-parser": "^2.4.1",
+    "magic-string": "^0.30.21",
     "nx": "22.7.6",
     "oauth-sign": "^0.9.0",
     "openapi-fetch": "0.17.0",

--- a/packages/vite-plugin-handler/README.md
+++ b/packages/vite-plugin-handler/README.md
@@ -83,7 +83,7 @@ handlerBundle('src/runtime/handlers', {
   | `vite:build-html` | HTML entry processing — no HTML |
   | `vite:client-inject` | HMR client injection — no HMR |
   | `vite:forward-console` | Forwards console to Vite overlay — dev server only |
-  | `vite:terser` | Terser minifier — uses esbuild/oxc instead |
+  | `vite:terser` | Terser minifier — minification is disabled |
   | `vite:ssr-manifest` | SSR manifest generation — not doing SSR |
 - Conditionally injects shims via `renderChunk` only when the bundled output actually references the corresponding identifiers:
 
@@ -92,6 +92,9 @@ handlerBundle('src/runtime/handlers', {
   | `__dirname` / `__filename` | `__dirname` or `__filename` in chunk | ESM equivalents for bundled CJS dependencies |
   | `node:http2` | `node_http2` in chunk | Works around a rolldown bug that drops externalised builtin imports |
 
+- **Minification is always disabled.** Lambda handler bundles prioritise debuggability (readable stack traces, easier CloudWatch inspection) over bundle size.
+- **Sourcemaps** are controlled by `NODE_ENV` rather than Vite's `--mode` flag — they are enabled unless `NODE_ENV=production`. This uses the deploy-time environment as the signal because Lambda builds always invoke `vite build` regardless of target stage.
+- Shim injection in `renderChunk` uses [MagicString](https://github.com/rich-harris/magic-string) to produce proper sourcemaps, so prepended shim code does not shift source positions in downstream tooling.
 - Externalises all Node.js built-in modules.
 - Outputs ESM format with `index.mjs` entry file names.
 

--- a/packages/vite-plugin-handler/package.json
+++ b/packages/vite-plugin-handler/package.json
@@ -10,10 +10,12 @@
     "url": "https://github.com/aligent/microservice-development-utilities.git",
     "directory": "packages/vite-plugin-handler"
   },
+  "dependencies": {
+    "magic-string": "^0.30.21"
+  },
   "peerDependencies": {
     "vite": ">=8.0.14"
   },
-  "dependencies": {},
   "author": "Aligent",
   "license": "MIT"
 }

--- a/packages/vite-plugin-handler/src/lib/handler-bundle.spec.ts
+++ b/packages/vite-plugin-handler/src/lib/handler-bundle.spec.ts
@@ -123,17 +123,18 @@ describe('handlerBundle', () => {
         expect(build['minify']).toBe(false);
     });
 
-    it('enables oxc minify in development mode', () => {
+    it('disables minify in development mode', () => {
         const plugin = handlerBundle(HANDLERS_PATH);
         const result = callConfigHook(plugin, 'development') as Record<string, unknown>;
 
         const environments = result['environments'] as Record<string, Record<string, unknown>>;
         const env = Object.values(environments)[0] as Record<string, unknown>;
         const build = env['build'] as Record<string, unknown>;
-        expect(build['minify']).toBe('oxc');
+        expect(build['minify']).toBe(false);
     });
 
-    it('disables sourcemap in production mode', () => {
+    it('disables sourcemap when NODE_ENV is production', () => {
+        vi.stubEnv('NODE_ENV', 'production');
         const plugin = handlerBundle(HANDLERS_PATH);
         const result = callConfigHook(plugin, 'production') as Record<string, unknown>;
 
@@ -143,7 +144,8 @@ describe('handlerBundle', () => {
         expect(build['sourcemap']).toBe(false);
     });
 
-    it('enables sourcemap in development mode', () => {
+    it('enables sourcemap when NODE_ENV is not production', () => {
+        vi.stubEnv('NODE_ENV', 'development');
         const plugin = handlerBundle(HANDLERS_PATH);
         const result = callConfigHook(plugin, 'development') as Record<string, unknown>;
 
@@ -240,8 +242,12 @@ describe('handlerBundle', () => {
 
         it('prepends node_http2 import when chunk references it', () => {
             const renderChunk = getRenderChunk();
-            const output = renderChunk('const x = node_http2.connect();') as { code: string };
+            const output = renderChunk('const x = node_http2.connect();') as {
+                code: string;
+                map: unknown;
+            };
             expect(output.code).toContain("import * as node_http2 from 'node:http2';");
+            expect(output.map).toBeDefined();
         });
 
         it('prepends __dirname/__filename shim when chunk references __dirname', () => {

--- a/packages/vite-plugin-handler/src/lib/handler-bundle.ts
+++ b/packages/vite-plugin-handler/src/lib/handler-bundle.ts
@@ -1,3 +1,4 @@
+import MagicString from 'magic-string';
 import { globSync } from 'node:fs';
 import { builtinModules } from 'node:module';
 import { extname, resolve } from 'node:path';
@@ -26,7 +27,6 @@ const ENV_PREFIX = 'handler';
  */
 function buildHandlerEnvironments(
     handlersDir: string,
-    mode: string | undefined,
     options: HandlerBundleOptions
 ): Record<string, EnvironmentOptions> {
     const external = [
@@ -48,8 +48,11 @@ function buildHandlerEnvironments(
             build: {
                 license: false,
                 outDir: `dist/${entryName}`,
-                minify: mode === 'development' ? 'oxc' : false,
-                sourcemap: mode !== 'production',
+                minify: false,
+                // Use NODE_ENV rather than Vite's mode so sourcemaps are
+                // controlled by the deploy-time environment, not the Vite
+                // CLI --mode flag (Lambda builds always use `vite build`).
+                sourcemap: process.env['NODE_ENV'] !== 'production',
                 rolldownOptions: {
                     input: { index: handler },
                     moduleTypes: { ...options.moduleTypes },
@@ -110,7 +113,7 @@ export function handlerBundle(handlersPath: string, options: HandlerBundleOption
 
     return {
         name: 'handler-bundle',
-        config(config) {
+        config() {
             // When running vitest, skip handler environments entirely
             if (process.env['VITEST'] === 'true') {
                 return null;
@@ -122,7 +125,7 @@ export function handlerBundle(handlersPath: string, options: HandlerBundleOption
 
             const concurrency = options.concurrency ?? Infinity;
             const handlersDir = resolve(process.cwd(), handlersPath);
-            const environments = buildHandlerEnvironments(handlersDir, config.mode, options);
+            const environments = buildHandlerEnvironments(handlersDir, options);
 
             return {
                 plugins: [stripUnneededPlugins],
@@ -136,7 +139,11 @@ export function handlerBundle(handlersPath: string, options: HandlerBundleOption
         renderChunk(code) {
             const matched = activeShims.filter(s => s.needles.some(n => code.includes(n)));
             if (matched.length === 0) return null;
-            return { code: `${matched.map(s => s.statement).join('\n')}\n${code}` };
+
+            const prefix = matched.map(s => s.statement).join('\n') + '\n';
+            const ms = new MagicString(code);
+            ms.prepend(prefix);
+            return { code: ms.toString(), map: ms.generateMap({ hires: true }) };
         },
     };
 }


### PR DESCRIPTION
**Description of the proposed changes**

- Always disable minify for Lambda handler bundles (was `'oxc'` in dev mode)
- Gate sourcemaps on `NODE_ENV` instead of Vite's `mode` so they are controlled by the deploy-time environment
- Use `MagicString` in `renderChunk` for proper sourcemap generation instead of string concatenation
- Add `magic-string` as a runtime dependency

**Other solutions considered**

- Keeping Vite's `config.mode` for sourcemap control — rejected because Lambda builds always use `vite build` and the deploy-time `NODE_ENV` is the correct signal

**Notes to reviewers**

- 🛈 Toggl Code: _MI-326: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback