### PR TITLE
MI-331: Patches & improvements for multiple packages

### DIFF
--- a/.nx/version-plans/version-plan-1783992638848.md
+++ b/.nx/version-plans/version-plan-1783992638848.md
@@ -1,0 +1,13 @@
+---
+microservice-util-lib: patch
+vite-plugin-handler: patch
+nx-openapi: patch
+nx-cdk: patch
+---
+
+MI-331: Patches & improvements
+
+- microservice-util-lib: Export ClientOptions type from throwing client
+- vite-plugin-handler: Warn and skip when no handler files found; externalize native .node addons
+- nx-openapi: Add workspace and bundle dependency management for generated clients
+- nx-cdk: Add bundle dependency management for services; use joinPathFragments for Nx tree paths

--- a/packages/microservice-util-lib/src/index.ts
+++ b/packages/microservice-util-lib/src/index.ts
@@ -20,6 +20,7 @@ import {
     retryMiddleware,
 } from './openapi-fetch-middlewares/retry';
 import {
+    ClientOptions,
     ErrorThrowingClient,
     createErrorThrowingClient,
 } from './openapi-fetch-middlewares/throwing-client';
@@ -34,6 +35,7 @@ import S3Dao from './s3/s3';
 export type {
     ApiKey,
     Basic,
+    ClientOptions,
     ErrorThrowingClient,
     LogLevel,
     Logger,

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts
@@ -22,7 +22,6 @@
  */
 
 import type { ClientOptions, MaybeOptionalInit, Middleware, ParseAsResponse } from 'openapi-fetch';
-export type { ClientOptions } from 'openapi-fetch';
 import createClient from 'openapi-fetch';
 import type {
     HttpMethod,
@@ -33,6 +32,7 @@ import type {
     ResponseObjectMap,
     SuccessResponse,
 } from 'openapi-typescript-helpers';
+export type { ClientOptions } from 'openapi-fetch';
 
 type InitParam<Init> =
     RequiredKeysOf<Init> extends never

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts
@@ -22,6 +22,7 @@
  */
 
 import type { ClientOptions, MaybeOptionalInit, Middleware, ParseAsResponse } from 'openapi-fetch';
+export type { ClientOptions } from 'openapi-fetch';
 import createClient from 'openapi-fetch';
 import type {
     HttpMethod,

--- a/packages/nx-cdk/src/generators/helpers/configs/base-package/package.json
+++ b/packages/nx-cdk/src/generators/helpers/configs/base-package/package.json
@@ -62,7 +62,6 @@
   },
   "workspaces": [
     "application",
-    "clients",
     "libs/*",
     "services/*"
   ],

--- a/packages/nx-cdk/src/generators/helpers/utilities.ts
+++ b/packages/nx-cdk/src/generators/helpers/utilities.ts
@@ -1,5 +1,11 @@
 /* v8 ignore start */
-import { readJsonFile, readProjectConfiguration, Tree, updateJson } from '@nx/devkit';
+import {
+    joinPathFragments,
+    readJsonFile,
+    readProjectConfiguration,
+    Tree,
+    updateJson,
+} from '@nx/devkit';
 import { join } from 'path';
 import { InMemoryFileSystemHost, Project } from 'ts-morph';
 import { ProjectType, SERVICES_SCOPE } from '../constants';
@@ -142,7 +148,7 @@ export function addServiceStackToMainApplication(
         throw new Error('Invalid application root path');
     }
 
-    const stacksRelativePath = join(application.root, 'lib/service-stacks.ts');
+    const stacksRelativePath = joinPathFragments(application.root, 'lib/service-stacks.ts');
 
     if (!tree.exists(stacksRelativePath)) {
         console.log('Service Stacks does not exist, skipping service stacks registration.');
@@ -205,7 +211,7 @@ export function removeServiceFromMainApplication(
         throw new Error('Invalid application root path');
     }
 
-    const stacksRelativePath = join(application.root, 'lib/service-stacks.ts');
+    const stacksRelativePath = joinPathFragments(application.root, 'lib/service-stacks.ts');
 
     if (!tree.exists(stacksRelativePath)) {
         console.log('Service Stacks does not exist, skipping service stacks cleanup.');
@@ -248,6 +254,58 @@ export function removeServiceFromMainApplication(
     }
 
     tree.write(stacksRelativePath, stackSource.getFullText());
+}
+
+/**
+ * Adds a service to the main application's bundleDependencies in package.json.
+ *
+ * @param tree - The Nx virtual file system tree
+ * @param serviceName - The name of the service (e.g., "companies")
+ * @param projectName - The name of the main application project
+ */
+export function addBundleDependency(tree: Tree, serviceName: string, projectName: string) {
+    const application = readProjectConfiguration(tree, projectName);
+    const packageJsonPath = joinPathFragments(application.root, 'package.json');
+
+    if (!tree.exists(packageJsonPath)) {
+        return;
+    }
+
+    updateJson(tree, packageJsonPath, json => {
+        json.bundleDependencies ??= [];
+
+        const dependency = `${SERVICES_SCOPE}/${serviceName}`;
+        if (!json.bundleDependencies.includes(dependency)) {
+            json.bundleDependencies.push(dependency);
+        }
+
+        return json;
+    });
+}
+
+/**
+ * Removes a service from the main application's bundleDependencies in package.json.
+ *
+ * @param tree - The Nx virtual file system tree
+ * @param serviceName - The name of the service (e.g., "companies")
+ * @param projectName - The name of the main application project
+ */
+export function removeBundleDependency(tree: Tree, serviceName: string, projectName: string) {
+    const application = readProjectConfiguration(tree, projectName);
+    const packageJsonPath = joinPathFragments(application.root, 'package.json');
+
+    if (!tree.exists(packageJsonPath)) {
+        return;
+    }
+
+    updateJson(tree, packageJsonPath, json => {
+        if (Array.isArray(json.bundleDependencies)) {
+            json.bundleDependencies = json.bundleDependencies.filter(
+                (dep: string) => dep !== `${SERVICES_SCOPE}/${serviceName}`
+            );
+        }
+        return json;
+    });
 }
 
 /**

--- a/packages/nx-cdk/src/generators/remove-service/generator.spec.ts
+++ b/packages/nx-cdk/src/generators/remove-service/generator.spec.ts
@@ -104,16 +104,12 @@ describe('remove generator', () => {
     it('should remove the service from application bundleDependencies', async () => {
         await serviceGenerator(tree, { name: 'companies' });
 
-        const pkgBefore = JSON.parse(
-            tree.read('application/package.json', 'utf-8') ?? '{}'
-        );
+        const pkgBefore = JSON.parse(tree.read('application/package.json', 'utf-8') ?? '{}');
         expect(pkgBefore.bundleDependencies).toContain('@services/companies');
 
         await removeGenerator(tree, { name: 'companies', forceRemove: true });
 
-        const pkgAfter = JSON.parse(
-            tree.read('application/package.json', 'utf-8') ?? '{}'
-        );
+        const pkgAfter = JSON.parse(tree.read('application/package.json', 'utf-8') ?? '{}');
         expect(pkgAfter.bundleDependencies).not.toContain('@services/companies');
         expect(pkgAfter.bundleDependencies).toContain('@libs/infra');
     });

--- a/packages/nx-cdk/src/generators/remove-service/generator.spec.ts
+++ b/packages/nx-cdk/src/generators/remove-service/generator.spec.ts
@@ -24,6 +24,7 @@ const application = {
     type: 'module',
     main: './bin/main.ts',
     types: './bin/main.ts',
+    bundleDependencies: ['@libs/infra'],
     nx: { tags: ['scope:application'] },
 };
 
@@ -98,6 +99,23 @@ describe('remove generator', () => {
 
         const stacksAfter = tree.read('application/lib/service-stacks.ts', 'utf-8');
         expect(stacksAfter).not.toContain('new CompaniesStack(');
+    });
+
+    it('should remove the service from application bundleDependencies', async () => {
+        await serviceGenerator(tree, { name: 'companies' });
+
+        const pkgBefore = JSON.parse(
+            tree.read('application/package.json', 'utf-8') ?? '{}'
+        );
+        expect(pkgBefore.bundleDependencies).toContain('@services/companies');
+
+        await removeGenerator(tree, { name: 'companies', forceRemove: true });
+
+        const pkgAfter = JSON.parse(
+            tree.read('application/package.json', 'utf-8') ?? '{}'
+        );
+        expect(pkgAfter.bundleDependencies).not.toContain('@services/companies');
+        expect(pkgAfter.bundleDependencies).toContain('@libs/infra');
     });
 
     it('should only remove the targeted service when multiple services exist', async () => {

--- a/packages/nx-cdk/src/generators/remove-service/generator.ts
+++ b/packages/nx-cdk/src/generators/remove-service/generator.ts
@@ -1,6 +1,10 @@
 import { createProjectGraphAsync, formatFiles, Tree, updateJson } from '@nx/devkit';
 import { MAIN_APPLICATION_NAME, SERVICES_FOLDER, SERVICES_SCOPE } from '../constants';
-import { removeServiceFromMainApplication, removeTsConfigReference } from '../helpers/utilities';
+import {
+    removeBundleDependency,
+    removeServiceFromMainApplication,
+    removeTsConfigReference,
+} from '../helpers/utilities';
 import { RemoveGeneratorSchema } from './schema';
 
 export async function removeGenerator(tree: Tree, options: RemoveGeneratorSchema) {
@@ -30,6 +34,7 @@ export async function removeGenerator(tree: Tree, options: RemoveGeneratorSchema
 
     removeServiceFromMainApplication(tree, name, MAIN_APPLICATION_NAME);
     removeTsConfigReference(tree, `./${projectRoot}`);
+    removeBundleDependency(tree, name, MAIN_APPLICATION_NAME);
 
     tree.delete(projectRoot);
 

--- a/packages/nx-cdk/src/generators/service/files/package.json.template
+++ b/packages/nx-cdk/src/generators/service/files/package.json.template
@@ -12,7 +12,6 @@
     "./package.json": "./package.json"
   },
   "bundleDependencies": [
-    "clients",
     "@libs/infra"
   ],
   "nx": {

--- a/packages/nx-cdk/src/generators/service/generator.spec.ts
+++ b/packages/nx-cdk/src/generators/service/generator.spec.ts
@@ -8,6 +8,7 @@ const application = {
     type: 'module',
     main: './bin/main.ts',
     types: './bin/main.ts',
+    bundleDependencies: ['@libs/infra'],
     nx: { tags: ['scope:application'] },
 };
 
@@ -54,6 +55,19 @@ describe('service generator', () => {
         await expect(serviceGenerator(tree, options)).rejects.toThrow(
             'You already have a library using the import path'
         );
+    });
+
+    it('should add the service to application bundleDependencies', async () => {
+        const options: ServiceGeneratorSchema = { name: 'test' };
+
+        await serviceGenerator(tree, options);
+
+        const packageJson = JSON.parse(
+            tree.read('application/package.json', 'utf-8') ?? '{}'
+        );
+
+        expect(packageJson.bundleDependencies).toContain('@services/test');
+        expect(packageJson.bundleDependencies).toContain('@libs/infra');
     });
 
     it('should not recreate the services folder if it already exists', async () => {

--- a/packages/nx-cdk/src/generators/service/generator.spec.ts
+++ b/packages/nx-cdk/src/generators/service/generator.spec.ts
@@ -62,9 +62,7 @@ describe('service generator', () => {
 
         await serviceGenerator(tree, options);
 
-        const packageJson = JSON.parse(
-            tree.read('application/package.json', 'utf-8') ?? '{}'
-        );
+        const packageJson = JSON.parse(tree.read('application/package.json', 'utf-8') ?? '{}');
 
         expect(packageJson.bundleDependencies).toContain('@services/test');
         expect(packageJson.bundleDependencies).toContain('@libs/infra');

--- a/packages/nx-cdk/src/generators/service/generator.ts
+++ b/packages/nx-cdk/src/generators/service/generator.ts
@@ -2,6 +2,7 @@ import { formatFiles, generateFiles, Tree, updateJson, writeJson } from '@nx/dev
 import { join } from 'path';
 import { MAIN_APPLICATION_NAME, SERVICES_FOLDER } from '../constants';
 import {
+    addBundleDependency,
     addServiceStackToMainApplication,
     constructProjectTsConfigFiles,
     splitInputName,
@@ -62,6 +63,7 @@ export async function serviceGenerator(tree: Tree, options: ServiceGeneratorSche
         { name: options.name, constant, stack },
         MAIN_APPLICATION_NAME
     );
+    addBundleDependency(tree, options.name, MAIN_APPLICATION_NAME);
 
     await formatFiles(tree);
 }

--- a/packages/nx-openapi/src/generators/client/generator.spec.ts
+++ b/packages/nx-openapi/src/generators/client/generator.spec.ts
@@ -1,4 +1,4 @@
-import { Tree, addProjectConfiguration, readProjectConfiguration } from '@nx/devkit';
+import { Tree, addProjectConfiguration, readJson, readProjectConfiguration } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { clientGenerator } from './generator';
 import { ClientGeneratorSchema } from './schema';
@@ -233,6 +233,100 @@ describe('client generator', () => {
         const clientContent = tree.read('clients/src/test/client.ts', 'utf-8');
         expect(clientContent).toContain('logMiddleware');
         expect(clientContent).toContain("logMiddleware('Test')");
+    });
+
+    it('should add clients to root package.json workspaces', async () => {
+        tree.write('package.json', JSON.stringify({ name: 'workspace', workspaces: ['libs/*'] }));
+
+        const options: ClientGeneratorSchema = {
+            name: 'test',
+            schemaPath: `${__dirname}/unit-test-schemas/valid.yaml`,
+            skipValidate: true,
+            override: false,
+            authMethod: 'api-key',
+        };
+
+        await clientGenerator(tree, options);
+
+        const packageJson = readJson(tree, 'package.json');
+        expect(packageJson.workspaces).toContain('clients');
+    });
+
+    it('should not duplicate clients in workspaces when already present', async () => {
+        tree.write(
+            'package.json',
+            JSON.stringify({ name: 'workspace', workspaces: ['libs/*', 'clients'] })
+        );
+
+        const options: ClientGeneratorSchema = {
+            name: 'test',
+            schemaPath: `${__dirname}/unit-test-schemas/valid.yaml`,
+            skipValidate: true,
+            override: false,
+            authMethod: 'api-key',
+        };
+
+        await clientGenerator(tree, options);
+
+        const packageJson = readJson(tree, 'package.json');
+        const clientsEntries = packageJson.workspaces.filter((w: string) => w === 'clients');
+        expect(clientsEntries).toHaveLength(1);
+    });
+
+    it('should add clients to existing service bundleDependencies', async () => {
+        addProjectConfiguration(tree, 'my-service', {
+            root: 'services/my-service',
+            projectType: 'library',
+            tags: ['scope:services'],
+            targets: {},
+        });
+        tree.write(
+            'services/my-service/package.json',
+            JSON.stringify({
+                name: '@services/my-service',
+                bundleDependencies: ['@libs/infra'],
+            })
+        );
+
+        const options: ClientGeneratorSchema = {
+            name: 'test',
+            schemaPath: `${__dirname}/unit-test-schemas/valid.yaml`,
+            skipValidate: true,
+            override: false,
+            authMethod: 'api-key',
+        };
+
+        await clientGenerator(tree, options);
+
+        const servicePackageJson = readJson(tree, 'services/my-service/package.json');
+        expect(servicePackageJson.bundleDependencies).toContain('clients');
+        expect(servicePackageJson.bundleDependencies).toContain('@libs/infra');
+    });
+
+    it('should not add clients to bundleDependencies of non-service projects', async () => {
+        addProjectConfiguration(tree, 'my-lib', {
+            root: 'libs/my-lib',
+            projectType: 'library',
+            tags: ['scope:libs'],
+            targets: {},
+        });
+        tree.write(
+            'libs/my-lib/package.json',
+            JSON.stringify({ name: '@libs/my-lib', bundleDependencies: [] })
+        );
+
+        const options: ClientGeneratorSchema = {
+            name: 'test',
+            schemaPath: `${__dirname}/unit-test-schemas/valid.yaml`,
+            skipValidate: true,
+            override: false,
+            authMethod: 'api-key',
+        };
+
+        await clientGenerator(tree, options);
+
+        const libPackageJson = readJson(tree, 'libs/my-lib/package.json');
+        expect(libPackageJson.bundleDependencies).not.toContain('clients');
     });
 
     describe('authMethod option', () => {

--- a/packages/nx-openapi/src/generators/client/generator.ts
+++ b/packages/nx-openapi/src/generators/client/generator.ts
@@ -6,6 +6,8 @@ import {
     validateSchema,
 } from '../../helpers/generate-openapi-types';
 import {
+    addToServiceBundleDependencies,
+    addToWorkspaces,
     addTsConfigPath,
     addTsConfigReference,
     appendToIndexFile,
@@ -94,6 +96,9 @@ export async function clientGenerator(tree: Tree, options: ClientGeneratorSchema
             const lookupPath = joinPathFragments(projectRoot, './src', 'index.ts');
             addTsConfigPath(tree, tsConfigFile, importPath, [lookupPath]);
         }
+
+        addToWorkspaces(tree, projectRoot);
+        addToServiceBundleDependencies(tree, PROJECT_NAME);
     }
 
     await copySchema(tree, schemaDest, schemaPath);

--- a/packages/nx-openapi/src/helpers/utilities.ts
+++ b/packages/nx-openapi/src/helpers/utilities.ts
@@ -1,4 +1,11 @@
-import { logger, readProjectConfiguration, Tree, updateJson } from '@nx/devkit';
+import {
+    getProjects,
+    joinPathFragments,
+    logger,
+    readProjectConfiguration,
+    Tree,
+    updateJson,
+} from '@nx/devkit';
 
 /**
  * Get existing project by name.
@@ -132,4 +139,61 @@ export function toClassName(input: string): string {
         .split('-')
         .map(c => c.charAt(0).toUpperCase() + c.slice(1))
         .join('');
+}
+
+/**
+ * Adds the clients project to the root package.json workspaces array.
+ * No-op if the entry is already listed.
+ *
+ * @param tree - The Nx virtual file system tree
+ * @param projectRoot - The root path of the clients project (e.g. "clients")
+ */
+export function addToWorkspaces(tree: Tree, projectRoot: string) {
+    const packageJsonPath = 'package.json';
+    if (!tree.exists(packageJsonPath)) {
+        return;
+    }
+
+    updateJson(tree, packageJsonPath, json => {
+        json.workspaces ??= [];
+
+        if (!json.workspaces.includes(projectRoot)) {
+            json.workspaces.push(projectRoot);
+        }
+
+        return json;
+    });
+}
+
+/**
+ * Adds a dependency to the bundleDependencies of every service package.json.
+ * Services are identified by the "scope:services" tag.
+ *
+ * @param tree - The Nx virtual file system tree
+ * @param dependency - The dependency name to add (e.g. "clients")
+ */
+export function addToServiceBundleDependencies(tree: Tree, dependency: string) {
+    const projects = getProjects(tree);
+
+    for (const [, config] of projects) {
+        const tags = config.tags ?? [];
+        if (!tags.includes('scope:services')) {
+            continue;
+        }
+
+        const packageJsonPath = joinPathFragments(config.root, 'package.json');
+        if (!tree.exists(packageJsonPath)) {
+            continue;
+        }
+
+        updateJson(tree, packageJsonPath, json => {
+            json.bundleDependencies ??= [];
+
+            if (!json.bundleDependencies.includes(dependency)) {
+                json.bundleDependencies.push(dependency);
+            }
+
+            return json;
+        });
+    }
 }

--- a/packages/vite-plugin-handler/README.md
+++ b/packages/vite-plugin-handler/README.md
@@ -96,6 +96,7 @@ handlerBundle('src/runtime/handlers', {
 - **Sourcemaps** are controlled by `NODE_ENV` rather than Vite's `--mode` flag — they are enabled unless `NODE_ENV=production`. This uses the deploy-time environment as the signal because Lambda builds always invoke `vite build` regardless of target stage.
 - Shim injection in `renderChunk` uses [MagicString](https://github.com/rich-harris/magic-string) to produce proper sourcemaps, so prepended shim code does not shift source positions in downstream tooling.
 - Externalises all Node.js built-in modules.
+- Externalises `.node` native addon files. Compiled C/C++ addons cannot be bundled into JavaScript, so they are automatically excluded. Common packages with native addons include `cpu-features` (used by `ssh2`), `sharp`, `bcrypt`, `better-sqlite3`, and `@parcel/watcher`.
 - Outputs ESM format with `index.mjs` entry file names.
 
 ## Development

--- a/packages/vite-plugin-handler/src/lib/handler-bundle.spec.ts
+++ b/packages/vite-plugin-handler/src/lib/handler-bundle.spec.ts
@@ -203,10 +203,7 @@ describe('handlerBundle', () => {
         const strings = external.filter((e): e is string => typeof e === 'string');
         const regexps = external.filter((e): e is RegExp => e instanceof RegExp);
         const { builtinModules } = await import('node:module');
-        const builtins = new Set([
-            ...builtinModules,
-            ...builtinModules.map(m => `node:${m}`),
-        ]);
+        const builtins = new Set([...builtinModules, ...builtinModules.map(m => `node:${m}`)]);
         expect(strings.every(e => builtins.has(e))).toBe(true);
         expect(regexps).toEqual([/\.node$/]);
     });
@@ -375,9 +372,7 @@ describe('handlerBundle', () => {
         const result = callConfigHook(plugin);
 
         expect(result).toBeUndefined();
-        expect(warnSpy).toHaveBeenCalledWith(
-            expect.stringContaining('No handler files found in:')
-        );
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No handler files found in:'));
         warnSpy.mockRestore();
     });
 });

--- a/packages/vite-plugin-handler/src/lib/handler-bundle.spec.ts
+++ b/packages/vite-plugin-handler/src/lib/handler-bundle.spec.ts
@@ -189,7 +189,7 @@ describe('handlerBundle', () => {
         expect(external).toContainEqual(/^@smithy\//);
     });
 
-    it('does not add extra externals when external is not provided', () => {
+    it('does not add extra externals when external is not provided', async () => {
         const plugin = handlerBundle(HANDLERS_PATH);
         const result = callConfigHook(plugin) as Record<string, unknown>;
 
@@ -202,7 +202,12 @@ describe('handlerBundle', () => {
         // Only built-in modules (bare + node: prefixed) and .node native addon pattern
         const strings = external.filter((e): e is string => typeof e === 'string');
         const regexps = external.filter((e): e is RegExp => e instanceof RegExp);
-        expect(strings.every(e => typeof e === 'string')).toBe(true);
+        const { builtinModules } = await import('node:module');
+        const builtins = new Set([
+            ...builtinModules,
+            ...builtinModules.map(m => `node:${m}`),
+        ]);
+        expect(strings.every(e => builtins.has(e))).toBe(true);
         expect(regexps).toEqual([/\.node$/]);
     });
 

--- a/packages/vite-plugin-handler/src/lib/handler-bundle.spec.ts
+++ b/packages/vite-plugin-handler/src/lib/handler-bundle.spec.ts
@@ -77,7 +77,7 @@ describe('handlerBundle', () => {
         expect(output['format']).toBe('esm');
     });
 
-    it('externalises node built-in modules', () => {
+    it('externalises node built-in modules and native addons', () => {
         const plugin = handlerBundle(HANDLERS_PATH);
         const result = callConfigHook(plugin) as Record<string, unknown>;
 
@@ -85,12 +85,13 @@ describe('handlerBundle', () => {
         const env = Object.values(environments)[0] as Record<string, unknown>;
         const build = env['build'] as Record<string, unknown>;
         const rolldownOptions = build['rolldownOptions'] as Record<string, unknown>;
-        const external = rolldownOptions['external'] as string[];
+        const external = rolldownOptions['external'] as Array<string | RegExp>;
 
         expect(external).toContain('fs');
         expect(external).toContain('node:fs');
         expect(external).toContain('path');
         expect(external).toContain('node:path');
+        expect(external).toContainEqual(/\.node$/);
     });
 
     it('sets resolve.noExternal to true', () => {
@@ -196,10 +197,13 @@ describe('handlerBundle', () => {
         const env = Object.values(environments)[0] as Record<string, unknown>;
         const build = env['build'] as Record<string, unknown>;
         const rolldownOptions = build['rolldownOptions'] as Record<string, unknown>;
-        const external = rolldownOptions['external'] as string[];
+        const external = rolldownOptions['external'] as Array<string | RegExp>;
 
-        // Only built-in modules (bare + node: prefixed)
-        expect(external.every(e => typeof e === 'string')).toBe(true);
+        // Only built-in modules (bare + node: prefixed) and .node native addon pattern
+        const strings = external.filter((e): e is string => typeof e === 'string');
+        const regexps = external.filter((e): e is RegExp => e instanceof RegExp);
+        expect(strings.every(e => typeof e === 'string')).toBe(true);
+        expect(regexps).toEqual([/\.node$/]);
     });
 
     it('merges moduleTypes into rolldown config', () => {
@@ -360,11 +364,15 @@ describe('handlerBundle', () => {
         });
     });
 
-    it('returns no environments when handler directory is empty', () => {
+    it('warns when handler directory is empty', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const plugin = handlerBundle('/project/src/empty');
-        const result = callConfigHook(plugin) as Record<string, unknown>;
+        const result = callConfigHook(plugin);
 
-        const environments = result['environments'] as Record<string, unknown>;
-        expect(Object.keys(environments)).toHaveLength(0);
+        expect(result).toBeUndefined();
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('No handler files found in:')
+        );
+        warnSpy.mockRestore();
     });
 });

--- a/packages/vite-plugin-handler/src/lib/handler-bundle.ts
+++ b/packages/vite-plugin-handler/src/lib/handler-bundle.ts
@@ -21,6 +21,9 @@ export interface HandlerBundleOptions {
 
 const ENV_PREFIX = 'handler';
 
+// Native .node addons (e.g. cpu-features, sharp) cannot be bundled
+const NATIVE_NODE_ADDONS = /\.node$/;
+
 /**
  * Creates a Vite environment configuration for each handler file, producing
  * an ESM bundle per handler under `dist/<entryName>/index.mjs`.
@@ -28,16 +31,20 @@ const ENV_PREFIX = 'handler';
 function buildHandlerEnvironments(
     handlersDir: string,
     options: HandlerBundleOptions
-): Record<string, EnvironmentOptions> {
-    const external = [
+): Record<string, EnvironmentOptions> | undefined {
+    const handlers = globSync(`${handlersDir}/**/*.ts`);
+    if (!handlers.length) {
+        return undefined;
+    }
+
+    const external: Array<string | RegExp> = [
+        NATIVE_NODE_ADDONS,
         ...builtinModules,
         ...builtinModules.map(m => `node:${m}`),
         ...(options.external ?? []),
     ];
 
     const environments: Record<string, EnvironmentOptions> = {};
-    const handlers = globSync(`${handlersDir}/**/*.ts`);
-
     for (const handler of handlers) {
         const bundledPath = handler.replace(`${handlersDir}/`, '');
         const entryName = bundledPath.replace(extname(bundledPath), '');
@@ -126,6 +133,11 @@ export function handlerBundle(handlersPath: string, options: HandlerBundleOption
             const concurrency = options.concurrency ?? Infinity;
             const handlersDir = resolve(process.cwd(), handlersPath);
             const environments = buildHandlerEnvironments(handlersDir, options);
+
+            if (!environments) {
+                console.warn(`[handler-bundle] No handler files found in: ${handlersDir}`);
+                return;
+            }
 
             return {
                 plugins: [stripUnneededPlugins],


### PR DESCRIPTION
**Description of the proposed changes**

- Export `ClientOptions` type from throwing client in `microservice-util-lib`
- Warn and skip when handler directory is empty in `vite-plugin-handler`; externalize native `.node` addons
- Add workspace and bundle dependency management for generated clients in `nx-openapi`
- Add bundle dependency management for services in `nx-cdk`; use `joinPathFragments` for Nx tree paths

**Notes to reviewers**

- 🛈 Toggl Code: _MI-331: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback