### PR TITLE
fix(vite-plugin-handler): resolve handlers path from Vite config.root

### DIFF
--- a/.nx/version-plans/version-plan-1784529216075.md
+++ b/.nx/version-plans/version-plan-1784529216075.md
@@ -1,0 +1,5 @@
+---
+vite-plugin-handler: patch
+---
+
+fix(vite-plugin-handler): resolve handlers path from Vite config.root instead of process.cwd()

--- a/packages/vite-plugin-handler/src/lib/handler-bundle.ts
+++ b/packages/vite-plugin-handler/src/lib/handler-bundle.ts
@@ -101,7 +101,7 @@ async function buildHandlersConcurrently(builder: ViteBuilder, concurrency: numb
  * Vite plugin that creates one build environment per handler file found under
  * the given subpath. Each handler is bundled as an ESM Node.js entry point.
  *
- * @param handlersPath - Path to the handler directory, resolved relative to `process.cwd()`.
+ * @param handlersPath - Path to the handler directory, resolved relative to Vite's `config.root` (falling back to `process.cwd()`).
  * @param options - Optional configuration for concurrency, shims, and module types.
  *
  * @example
@@ -120,7 +120,7 @@ export function handlerBundle(handlersPath: string, options: HandlerBundleOption
 
     return {
         name: 'handler-bundle',
-        config() {
+        config(config) {
             // When running vitest, skip handler environments entirely
             if (process.env['VITEST'] === 'true') {
                 return null;
@@ -131,7 +131,7 @@ export function handlerBundle(handlersPath: string, options: HandlerBundleOption
             }
 
             const concurrency = options.concurrency ?? Infinity;
-            const handlersDir = resolve(process.cwd(), handlersPath);
+            const handlersDir = resolve(config.root || process.cwd(), handlersPath);
             const environments = buildHandlerEnvironments(handlersDir, options);
 
             if (!environments) {


### PR DESCRIPTION
**Description of the proposed changes**

- Use `config.root` (passed by Vite) instead of `process.cwd()` when resolving the handlers directory in the `handlerBundle` plugin's `config` hook. This ensures `@nx/vite/plugin` correctly infers a `build` target during project graph construction, where `process.cwd()` is the workspace root but `config.root` is set to the project root.

**Other solutions considered**

- Using `configResolved` hook instead — rejected because `builder.buildApp` must be set during `config`, not `configResolved`

**Notes to reviewers**

- 🛈 Toggl Code: _MI-331: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback