### PR TITLE
MI-331: Fix await body in HttpResponseError and add TBody generic

### DIFF
--- a/.nx/version-plans/version-plan-1784702503668.md
+++ b/.nx/version-plans/version-plan-1784702503668.md
@@ -1,0 +1,5 @@
+---
+microservice-util-lib: patch
+---
+
+Fix missing `await` on `parseBody()` calls in `HttpResponseError.create()` and add generic `TBody` type parameter to `HttpResponseError`, `HttpResponseData`, and `isHttpResponseError`.

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts
@@ -18,11 +18,11 @@ export interface HttpRequestData {
  * Captures all meaningful data at creation time so it can be
  * logged, serialized, or inspected without stream-consumption issues.
  */
-export interface HttpResponseData {
+export interface HttpResponseData<TBody = unknown> {
     readonly status: number;
     readonly statusText: string;
     readonly headers: Record<string, string>;
-    readonly body: unknown;
+    readonly body: TBody;
 }
 
 /**
@@ -33,15 +33,15 @@ export interface HttpResponseData {
  * rather than raw Request/Response objects, ensuring bodies are always
  * available for logging and debugging.
  */
-export class HttpResponseError extends Error {
+export class HttpResponseError<TBody = unknown> extends Error {
     override readonly name = 'HttpResponseError';
     readonly status: number;
     readonly statusText: string;
-    readonly response: HttpResponseData;
+    readonly response: HttpResponseData<TBody>;
     readonly request: HttpRequestData;
     readonly isHttpResponseError = true;
 
-    private constructor(request: HttpRequestData, response: HttpResponseData) {
+    private constructor(request: HttpRequestData, response: HttpResponseData<TBody>) {
         super(`${response.status}: ${response.statusText}`);
         this.status = response.status;
         this.statusText = response.statusText;
@@ -58,16 +58,19 @@ export class HttpResponseError extends Error {
      * Creates an HttpResponseError with pre-read request and response bodies.
      * Bodies are read eagerly so they are available for logging/serialization.
      */
-    static async create(response: Response, request: Request): Promise<HttpResponseError> {
+    static async create<TBody = unknown>(
+        response: Response,
+        request: Request
+    ): Promise<HttpResponseError<TBody>> {
         const url = new URL(request.url);
 
         // If request.bodyUsed is true then it can't be cloned and will throw a type error
         const requestBody = request.bodyUsed
             ? null
-            : parseBody(request.clone(), request.headers.get('content-type'));
+            : await parseBody(request.clone(), request.headers.get('content-type'));
         const responseBody = response.bodyUsed
             ? null
-            : parseBody(response.clone(), response.headers.get('content-type'));
+            : await parseBody(response.clone(), response.headers.get('content-type'));
 
         const requestData: HttpRequestData = {
             method: request.method,
@@ -77,14 +80,14 @@ export class HttpResponseError extends Error {
             body: requestBody,
         };
 
-        const responseData: HttpResponseData = {
+        const responseData: HttpResponseData<TBody> = {
             status: response.status,
             statusText: response.statusText,
             headers: Object.fromEntries(response.headers.entries()),
-            body: responseBody,
+            body: responseBody as TBody,
         };
 
-        return new HttpResponseError(requestData, responseData);
+        return new HttpResponseError<TBody>(requestData, responseData);
     }
 
     /**
@@ -119,7 +122,9 @@ export class HttpResponseError extends Error {
  *     }
  * }
  */
-export function isHttpResponseError(error: unknown): error is HttpResponseError {
+export function isHttpResponseError<TBody = unknown>(
+    error: unknown
+): error is HttpResponseError<TBody> {
     return (
         error instanceof HttpResponseError ||
         (typeof error === 'object' &&

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts
@@ -17,6 +17,9 @@ export interface HttpRequestData {
  * Serializable snapshot of an HTTP response.
  * Captures all meaningful data at creation time so it can be
  * logged, serialized, or inspected without stream-consumption issues.
+ *
+ * @typeParam TBody - The expected shape of the parsed response body.
+ *   Defaults to `unknown`; no runtime validation is performed.
  */
 export interface HttpResponseData<TBody = unknown> {
     readonly status: number;
@@ -32,6 +35,25 @@ export interface HttpResponseData<TBody = unknown> {
  * Stores pre-read, serializable snapshots of the request and response
  * rather than raw Request/Response objects, ensuring bodies are always
  * available for logging and debugging.
+ *
+ * @typeParam TBody - The expected shape of the parsed response body.
+ *   Defaults to `unknown`. The body is cast to this type at creation
+ *   time — no runtime validation is performed, so callers should only
+ *   supply a type parameter when they are confident of the response shape.
+ *
+ * @example
+ * ```ts
+ * interface ApiError { code: string; message: string }
+ *
+ * try {
+ *     await client.GET('/resource');
+ * } catch (err) {
+ *     if (isHttpResponseError<ApiError>(err)) {
+ *         // err.response.body is typed as ApiError
+ *         console.log(err.response.body.code);
+ *     }
+ * }
+ * ```
  */
 export class HttpResponseError<TBody = unknown> extends Error {
     override readonly name = 'HttpResponseError';
@@ -57,6 +79,11 @@ export class HttpResponseError<TBody = unknown> extends Error {
     /**
      * Creates an HttpResponseError with pre-read request and response bodies.
      * Bodies are read eagerly so they are available for logging/serialization.
+     *
+     * @typeParam TBody - The expected shape of the parsed response body.
+     *   The parsed body is cast to this type without runtime validation.
+     * @param response - The raw {@link Response} to snapshot.
+     * @param request - The raw {@link Request} to snapshot.
      */
     static async create<TBody = unknown>(
         response: Response,
@@ -106,13 +133,17 @@ export class HttpResponseError<TBody = unknown> extends Error {
 }
 
 /**
- * Type guard to check if an error is an HttpResponseError.
+ * Type guard to check if an error is an {@link HttpResponseError}.
  * Useful for narrowing error types in catch blocks.
  *
- * @param {unknown} error - The error to check.
- * @returns {boolean} True if the error is an HttpResponseError.
+ * @typeParam TBody - Optional type parameter to narrow the response body.
+ *   No runtime validation of the body shape is performed — this is purely
+ *   a compile-time convenience for callers who know the expected body type.
+ * @param error - The error to check.
+ * @returns `true` if the error is an HttpResponseError.
  *
  * @example
+ * ```ts
  * try {
  *     await fetchData();
  * } catch (error) {
@@ -121,6 +152,7 @@ export class HttpResponseError<TBody = unknown> extends Error {
  *         console.log(`URL: ${error.request.url}`);
  *     }
  * }
+ * ```
  */
 export function isHttpResponseError<TBody = unknown>(
     error: unknown


### PR DESCRIPTION
**Description of the proposed changes**

- Fix missing `await` on `parseBody()` calls in `HttpResponseError.create()` — previously body fields stored unresolved Promises instead of parsed values
- Add generic `TBody` type parameter to `HttpResponseError`, `HttpResponseData`, and `isHttpResponseError` for compile-time body type narrowing
- Update JSDoc to document the new type parameter and its behaviour (no runtime validation)

**Other solutions considered**

- Considered adding runtime validation for `TBody` (e.g. via Zod), but this would add unnecessary complexity — the generic is intentional DX sugar consistent with patterns in libraries like Axios

**Notes to reviewers**

- 🛈 Toggl Code: _MI-331: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback