### PR TITLE
chore: deprecate microservice-util-lib utilities superseded by aws-wrappers

### DIFF
--- a/.nx/version-plans/version-plan-1785113440000.md
+++ b/.nx/version-plans/version-plan-1785113440000.md
@@ -1,0 +1,5 @@
+---
+microservice-util-lib: patch
+---
+
+Deprecate `fetchSsmParams` and `S3Dao` in favour of `SSMService` and `S3Service` from `@aligent/aws-wrappers`, and add a migration guide to the package README.

--- a/packages/microservice-util-lib/README.md
+++ b/packages/microservice-util-lib/README.md
@@ -7,6 +7,78 @@ MicroServices tasks.
 
 Documentation on each function can be found [here](docs/modules.md)
 
+## Deprecations
+
+`fetchSsmParams` and `S3Dao` are deprecated in favour of `SSMService` and
+`S3Service` from [`@aligent/aws-wrappers`](../aws-wrappers/README.md), which add
+Powertools structured logging and X-Ray tracing by default.
+
+### `fetchSsmParams` → `SSMService`
+
+Parameters are addressed by caller-chosen aliases rather than positionally, and
+values are returned directly instead of wrapped in SDK `Parameter` objects.
+
+```ts
+// Before
+const [username, password] = await fetchSsmParams('/app/username', '/app/password');
+console.log(username?.Value);
+
+// After
+const ssm = new SSMService();
+const { username, password } = await ssm.getParameters({
+  username: '/app/username',
+  password: '/app/password',
+});
+```
+
+For a single parameter, use `ssm.getParameter('/app/username')`.
+
+### `S3Dao` → `S3Service`
+
+`S3Service` takes the bucket per call rather than per instance, so one instance
+serves every bucket. `Key` is always explicit — supply the `object-hash` value
+yourself if you relied on `storeData`'s hashed default.
+
+```ts
+// Before
+const dao = new S3Dao('my-bucket');
+const object = await dao.storeData(payload, key);
+const data = await dao.fetchData<Payload>(object);
+await dao.deleteData(object);
+
+// After
+const s3 = new S3Service();
+await s3.putJsonObject({ Bucket: 'my-bucket', Key: key, Body: payload });
+const data = await s3.getJsonObject<Payload>({ Bucket: 'my-bucket', Key: key });
+await s3.deleteObject({ Bucket: 'my-bucket', Key: key });
+```
+
+| `S3Dao`        | `S3Service`                             |
+| -------------- | --------------------------------------- |
+| `storeData`    | `putJsonObject`                         |
+| `fetchData`    | `getJsonObject`                         |
+| `deleteData`   | `deleteObject`                          |
+| `storeChunked` | `chunkBy` + `putJsonObject` per chunk   |
+| `fetchChunks`  | iterate keys, `getJsonObject` per chunk |
+
+`storeChunked` and `fetchChunks` have no direct equivalent — compose the
+existing `chunkBy` helper with the per-object methods:
+
+```ts
+const s3 = new S3Service();
+const keys = await Promise.all(
+  chunkBy(rows, 100).map(async (chunk, i) => {
+    const Key = `${prefix}/${i}`;
+    await s3.putJsonObject({ Bucket: 'my-bucket', Key, Body: chunk });
+    return Key;
+  })
+);
+
+for (const Key of keys) {
+  const chunk = await s3.getJsonObject<Row[]>({ Bucket: 'my-bucket', Key });
+}
+```
+
 ## Build
 
 This library is written in typescript and can be built using the NPM script:

--- a/packages/microservice-util-lib/src/fetch-ssm-params/fetch-ssm-params.ts
+++ b/packages/microservice-util-lib/src/fetch-ssm-params/fetch-ssm-params.ts
@@ -10,17 +10,36 @@ const ssm = new SSMClient({});
 /**
  * Fetch one SSM parameter
  * @param param key of the parameter to fetch
+ * @deprecated Use `SSMService#getParameter` from `@aligent/aws-wrappers` instead.
  */
 async function fetchSsmParams(param: string): Promise<Parameter | undefined>;
 
 /**
  * Fetch a list of SSM parameters
  * @param params list of parameter keys to fetch
+ * @deprecated Use `SSMService#getParameters` from `@aligent/aws-wrappers` instead.
  */
 async function fetchSsmParams(...params: string[]): Promise<Array<Parameter | undefined>>;
 
 /**
  * Fetch SSM Parameters
+ *
+ * @deprecated Superseded by `SSMService` in `@aligent/aws-wrappers`, which adds
+ * Powertools logging and X-Ray tracing, and returns values keyed by caller-chosen
+ * aliases rather than positionally.
+ *
+ * ```ts
+ * // Before
+ * const [username, password] = await fetchSsmParams('/app/username', '/app/password');
+ *
+ * // After
+ * const ssm = new SSMService();
+ * const { username, password } = await ssm.getParameters({
+ *     username: '/app/username',
+ *     password: '/app/password',
+ * });
+ * ```
+ *
  * @param params the keys of the parameters to fetch
  */
 async function fetchSsmParams(...params: string[]) {

--- a/packages/microservice-util-lib/src/s3/s3.ts
+++ b/packages/microservice-util-lib/src/s3/s3.ts
@@ -8,7 +8,25 @@ import {
 import hash from 'object-hash';
 import chunkBy from '../chunk-by/chunk-by';
 
-/** A data access object for an S3 bucket */
+/**
+ * A data access object for an S3 bucket
+ *
+ * @deprecated Superseded by `S3Service` in `@aligent/aws-wrappers`, which adds
+ * Powertools logging and X-Ray tracing, and takes the bucket per-call rather
+ * than per-instance.
+ *
+ * ```ts
+ * // Before
+ * const dao = new S3Dao('my-bucket');
+ * const object = await dao.storeData(payload);
+ * const data = await dao.fetchData(object);
+ *
+ * // After
+ * const s3 = new S3Service();
+ * await s3.putJsonObject({ Bucket: 'my-bucket', Key: key, Body: payload });
+ * const data = await s3.getJsonObject({ Bucket: 'my-bucket', Key: key });
+ * ```
+ */
 class S3Dao {
     private s3: S3Client;
     private bucket: string;
@@ -26,6 +44,9 @@ class S3Dao {
      * @param data the data to store
      * @param name the name to call the object in S3 @default the hash of the data
      * @returns an object which can be used to fetch the data
+     * @deprecated Use `S3Service#putJsonObject` from `@aligent/aws-wrappers` instead.
+     * `Key` is required there — supply the `object-hash` value yourself if you
+     * relied on the hashed default.
      */
     public async storeData<T>(data: T, name?: string): Promise<GetObjectCommandInput> {
         if (typeof data === 'undefined') {
@@ -52,6 +73,8 @@ class S3Dao {
      * @param data the data to store
      * @param chunkSize the number of entries that should be in each chunk
      * @returns an array of objects which can be used to fetch the chunks
+     * @deprecated No direct equivalent in `@aligent/aws-wrappers` — compose
+     * `chunkBy` with `S3Service#putJsonObject`.
      */
     public async storeChunked<T extends unknown[]>(data: T, chunkSize: number) {
         const chunks = chunkBy(data, chunkSize);
@@ -62,6 +85,7 @@ class S3Dao {
      * Fetch an object from the S3 bucket
      * @param objectDetails the object which describes the location of the object
      * @returns the body of the object
+     * @deprecated Use `S3Service#getJsonObject` from `@aligent/aws-wrappers` instead.
      */
     public async fetchData<T>(objectDetails: GetObjectCommandInput): Promise<T> {
         const data = await this.s3.send(new GetObjectCommand(objectDetails));
@@ -77,6 +101,8 @@ class S3Dao {
     /**
      * Generator to fetch chunked data, chunk by chunk
      * @param chunks the list of object chunks
+     * @deprecated No direct equivalent in `@aligent/aws-wrappers` — iterate the
+     * chunks yourself with `S3Service#getJsonObject`.
      */
     public async *fetchChunks<T>(chunks: GetObjectCommandInput[]) {
         for (let i = 0; i < chunks.length; i++) {
@@ -96,6 +122,7 @@ class S3Dao {
     /**
      * Delete an object from the S3 bucket
      * @param objectDetails the object to delete
+     * @deprecated Use `S3Service#deleteObject` from `@aligent/aws-wrappers` instead.
      */
     public async deleteData(objectDetails: GetObjectCommandInput) {
         return this.s3.send(new DeleteObjectCommand(objectDetails));


### PR DESCRIPTION
**Description of the proposed changes**

- Mark `fetchSsmParams` as `@deprecated` (both overload signatures and the implementation) in favour of `SSMService#getParameter` / `#getParameters` from `@aligent/aws-wrappers`.
- Mark `S3Dao` and all five of its methods as `@deprecated` in favour of `S3Service`.
- Add a "Deprecations" section to `packages/microservice-util-lib/README.md` with before/after migration examples and a method mapping table.

No runtime behaviour changes — JSDoc and docs only. Both symbols remain exported and functional.

`storeChunked` / `fetchChunks` have no direct `S3Service` counterpart, so those tags point at a `chunkBy` + per-object composition recipe rather than a one-to-one replacement.

`getAwsIdFromArn` is listed in `packages/aws-wrappers/CLAUDE.md` as a future move but has no equivalent yet, so it is left alone.

**Other solutions considered (if any)**

Removing the superseded utilities outright. Deferred — deprecation first gives consumers a migration window, and removal is a breaking change that should land in its own release.

**Notes to reviewers**

- 🛈 Toggl Code: _MI-XXX: Code Review_
- The generated `packages/microservice-util-lib/docs/` output is deliberately **not** regenerated here. The committed copy is well out of date, so regenerating pulls in ~13 unrelated files and moves `S3Dao.md` between directories. That will follow in a separate PR.
  - Whoever picks that up: run `npx nx run microservice-util-lib:typedoc` from the **main checkout, not a git worktree** — typedoc derives its "Defined in" links from the working directory and bakes the worktree path into every file.
- Version plan included (`microservice-util-lib: patch`) — JSDoc and README only, no runtime change.
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

