### PR TITLE
MI-332: make aws-wrappers log redaction TRACE-aware

### DIFF
--- a/.nx/version-plans/version-plan-1785716035000.md
+++ b/.nx/version-plans/version-plan-1785716035000.md
@@ -1,0 +1,9 @@
+---
+aws-wrappers: minor
+---
+
+Log redaction now treats `TRACE` as more verbose than `DEBUG`, matching Powertools' level ordering. Previously `POWERTOOLS_LOG_LEVEL=TRACE` incorrectly redacted payloads while `DEBUG` did not.
+
+**Action required:** environments already running at `TRACE` will begin logging full SDK inputs — including `SecretString`, SQS/SNS message bodies, DynamoDB items and keys, and Step Functions execution inputs — to CloudWatch. Review any `TRACE`-level deployments before upgrading.
+
+Released as a minor rather than a patch because this widens secret disclosure for existing `TRACE` deployments; a patch could be auto-merged without the note being read.

--- a/packages/aws-wrappers/CLAUDE.md
+++ b/packages/aws-wrappers/CLAUDE.md
@@ -119,12 +119,9 @@ Each service file states the unlock rule **once**, in its class-level TSDoc. Per
 
 Adding a new redacted method: define a `<METHOD>_SAFE_FIELDS` constant near the top of the service file with TSDoc describing *what* is omitted and *why* (not the unlock mechanism — that's stated once in the class TSDoc), and wire `filterFieldsForLogLevel(this.logger, input, FIELDS)` into the `logger.info` call.
 
-Lock the behaviour with **two** tests, not one:
+Lock the redaction with `expect(loggedInput).not.toHaveProperty('<sensitive>')` against an INFO-level logger. For a method that routes through `filterFieldsForLogLevel`, that single test is enough — the unlock direction is covered centrally by `redact.test.ts`, so a per-method TRACE test would only re-prove `shouldLogFullInput`.
 
-- `expect(loggedInput).not.toHaveProperty('<sensitive>')` against an INFO-level logger — the security property.
-- `expect(loggedInput).toHaveProperty('<sensitive>')` against a TRACE-level logger — the unlock property.
-
-The second matters more than it looks. Without it, a method wired to a stale or hand-rolled level check still passes the whole suite, because the INFO assertion only pins the redacted direction. That's precisely how the pre-MI-332 bug survived in eight places.
+**A method with a bespoke inline check needs a second test**: `expect(loggedInput).toHaveProperty('<sensitive>')` against a TRACE-level logger. These are the batch methods that hand-roll `shouldLogFullInput(this.logger)` to synthesise a computed field, so nothing central covers their unlock branch. Without it a site wired to a stale or hand-rolled level check still passes the whole suite, because the INFO assertion only pins the redacted direction — that's precisely how the pre-MI-332 bug survived in eight places.
 
 ### Patterns
 

--- a/packages/aws-wrappers/CLAUDE.md
+++ b/packages/aws-wrappers/CLAUDE.md
@@ -89,19 +89,23 @@ constructor(opts?: { logger?: LoggerInterface; client?: <ServiceClient> })
 
 ### Logging
 
-Every public method emits exactly one `logger.info('<verb> <noun>', { input })` line at the start. The shape of `input` is **level-driven**:
+Every public method emits exactly one `logger.info('<verb> <noun>', { input })` line at the start. The shape of `input` is **level-driven** — see the "Log redaction" section of the package `README.md` for the consumer-facing statement of which levels unlock.
 
-- At `DEBUG` (e.g. `POWERTOOLS_LOG_LEVEL=DEBUG`), the full SDK input is logged. Operators have explicitly opted into seeing payloads, secret material, and PII.
+- At the **verbose** levels (`TRACE` and `DEBUG`), the full SDK input is logged. Operators have explicitly opted into seeing payloads, secret material, and PII.
 - At any other level, only a per-method **safe-fields allowlist** is logged.
 
-The mechanism is `filterFieldsForLogLevel(logger, input, SAFE_FIELDS)` in `src/util/redact.ts`. Internal-only helper, not exported from `src/index.ts`.
+`shouldLogFullInput(logger)` in `src/util/redact.ts` is **the only place in the package that reads the log level** — never compare `logger.getLevelName()` yourself. Powertools orders `TRACE` (threshold 6) as *more* verbose than `DEBUG` (8), so the obvious `getLevelName() === 'DEBUG'` check silently redacts at the most verbose level available. That was a real bug (MI-332); the predicate exists so it can only be fixed once. Its TSDoc carries the rule for anyone reading the source without this file.
+
+The projection mechanism is `filterFieldsForLogLevel(logger, input, SAFE_FIELDS)` in the same file. Both are internal-only helpers, not exported from `src/index.ts`.
+
+Each service file states the unlock rule **once**, in its class-level TSDoc. Per-method and per-`SAFE_FIELDS` docs describe only *what* is omitted and *why* — don't restate the mechanism, or the next level-semantics change has to touch two dozen comments again.
 
 #### Conventions for the allowlist
 
 - **Module-level constant per method**, typed as `ReadonlyArray<keyof CommandInput>`, named `<METHOD>_SAFE_FIELDS`. TSDoc explains what's omitted and why.
 - **Targeted application** — only methods where there's an actual omission use the helper. Methods whose input is already a tight `Required<Pick<...>>` or contains no sensitive fields (e.g. `S3.getObject`, `SFN.listExecutions`) keep their current `{ input }` shape.
 - **Maximal safe set** — include every field *except* known payload, secret, or PII carriers. The level-based design provides the safety valve; the INFO log should still be operationally useful.
-- **Batch methods stay bespoke** — methods that already compute a derived field (e.g. `entryCount`, `keyCount`, `tables`) inline the DEBUG check directly rather than using `filterFieldsForLogLevel`, since the helper only picks input keys and can't synthesise computed fields. A comment explains why.
+- **Batch methods stay bespoke** — methods that already compute a derived field (e.g. `entryCount`, `keyCount`, `tables`) call `shouldLogFullInput(this.logger)` directly rather than using `filterFieldsForLogLevel`, since the helper only picks input keys and can't synthesise computed fields. A comment explains why.
 
 #### Currently redacted
 
@@ -113,7 +117,14 @@ The mechanism is `filterFieldsForLogLevel(logger, input, SAFE_FIELDS)` in `src/u
 - **SSM** — `putParameter` omits `Value`.
 - **SFN** — `startExecution` omits the execution `input` (often carries PII).
 
-Adding a new redacted method: define a `<METHOD>_SAFE_FIELDS` constant near the top of the service file with TSDoc, wire `filterFieldsForLogLevel(this.logger, input, FIELDS)` into the `logger.info` call, and add a single `expect(loggedInput).not.toHaveProperty('<sensitive>')` test against an INFO-level logger to lock in the security property.
+Adding a new redacted method: define a `<METHOD>_SAFE_FIELDS` constant near the top of the service file with TSDoc describing *what* is omitted and *why* (not the unlock mechanism — that's stated once in the class TSDoc), and wire `filterFieldsForLogLevel(this.logger, input, FIELDS)` into the `logger.info` call.
+
+Lock the behaviour with **two** tests, not one:
+
+- `expect(loggedInput).not.toHaveProperty('<sensitive>')` against an INFO-level logger — the security property.
+- `expect(loggedInput).toHaveProperty('<sensitive>')` against a TRACE-level logger — the unlock property.
+
+The second matters more than it looks. Without it, a method wired to a stale or hand-rolled level check still passes the whole suite, because the INFO assertion only pins the redacted direction. That's precisely how the pre-MI-332 bug survived in eight places.
 
 ### Patterns
 

--- a/packages/aws-wrappers/README.md
+++ b/packages/aws-wrappers/README.md
@@ -21,7 +21,7 @@ new XService({ logger?, client? })
 
 ### Log redaction
 
-Every wrapper emits one `logger.info` line per SDK call with a per-method safe-field allowlist (omitting payloads, secret material, and PII recipient identifiers). Set `POWERTOOLS_LOG_LEVEL=DEBUG` to unlock the full SDK input in those log lines — useful for local development and incident triage. See `packages/aws-wrappers/CLAUDE.md` for the per-method allowlists currently in force.
+Every wrapper emits one `logger.info` line per SDK call with a per-method safe-field allowlist (omitting payloads, secret material, and PII recipient identifiers). Set `POWERTOOLS_LOG_LEVEL` to either `DEBUG` or `TRACE` to unlock the full SDK input in those log lines — useful for local development and incident triage. Both levels unlock because Powertools orders `TRACE` as more verbose than `DEBUG`; every level from `INFO` upwards redacts. See `packages/aws-wrappers/CLAUDE.md` for the per-method allowlists currently in force.
 
 ### X-Ray outside Lambda
 
@@ -232,7 +232,7 @@ const schedules = await scheduler.listSchedules({ GroupName: 'default' });
 await scheduler.deleteSchedule({ Name: 'nightly-sync' });
 ```
 
-`Target.Input` is the payload handed to the target and is omitted from INFO logs (it routinely carries PII); `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full input.
+`Target.Input` is the payload handed to the target and is omitted from INFO logs (it routinely carries PII). See [Log redaction](#log-redaction) for how to unlock it.
 
 ```ts
 // Schedule groups. Groups have no update operation — only create, get,

--- a/packages/aws-wrappers/docs/classes/DynamoDBService.md
+++ b/packages/aws-wrappers/docs/classes/DynamoDBService.md
@@ -6,13 +6,14 @@
 
 # Class: DynamoDBService
 
-Defined in: [dynamodb/dynamodb.ts:152](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L152)
+Defined in: [dynamodb/dynamodb.ts:153](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L153)
 
 Wrapper around the AWS DynamoDB Document client providing structured
 Powertools logging and X-Ray tracing by default.
 
-At INFO the log lines omit payloads, secret material and PII; the verbose
-levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+Where a method's input carries payloads, secret material or PII, the INFO
+log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+`TRACE`) log full SDK inputs.
 
 Items are automatically marshalled / unmarshalled via the document client —
 callers work with plain TypeScript objects in both directions.
@@ -25,7 +26,7 @@ callers work with plain TypeScript objects in both directions.
 
 > **new DynamoDBService**(`opts?`): `DynamoDBService`
 
-Defined in: [dynamodb/dynamodb.ts:165](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L165)
+Defined in: [dynamodb/dynamodb.ts:166](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L166)
 
 #### Parameters
 
@@ -60,7 +61,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **batchGet**(`input`): `Promise`\<`BatchGetCommandOutput`\>
 
-Defined in: [dynamodb/dynamodb.ts:316](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L316)
+Defined in: [dynamodb/dynamodb.ts:317](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L317)
 
 Batch-get items from one or more DynamoDB tables.
 
@@ -87,7 +88,7 @@ Callers should narrow the result type at the call site.
 
 > **batchWrite**(`input`): `Promise`\<`BatchWriteCommandOutput`\>
 
-Defined in: [dynamodb/dynamodb.ts:333](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L333)
+Defined in: [dynamodb/dynamodb.ts:334](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L334)
 
 Batch-write items to DynamoDB, retrying `UnprocessedItems` with jittered
 exponential backoff. Up to 5 attempts (200ms base delay). Throws when
@@ -111,7 +112,7 @@ items remain unprocessed after the final attempt.
 
 > **deleteItem**\<`K`, `R`\>(`input`): `Promise`\<`Omit`\<`DeleteCommandOutput`, `"Attributes"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:246](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L246)
+Defined in: [dynamodb/dynamodb.ts:247](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L247)
 
 Delete an item from DynamoDB. The `Attributes` field on the response is
 typed as `R` — relevant when `ReturnValues: 'ALL_OLD'` is set.
@@ -148,7 +149,7 @@ Expected shape of the returned `Attributes`.
 
 > **getItem**\<`K`, `R`\>(`input`): `Promise`\<`R` \| `undefined`\>
 
-Defined in: [dynamodb/dynamodb.ts:180](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L180)
+Defined in: [dynamodb/dynamodb.ts:181](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L181)
 
 Get an item from DynamoDB.
 
@@ -186,7 +187,7 @@ The item, or `undefined` if not found.
 
 > **paginateItems**\<`T`\>(`input`): `AsyncGenerator`\<`T`\>
 
-Defined in: [dynamodb/dynamodb.ts:361](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L361)
+Defined in: [dynamodb/dynamodb.ts:362](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L362)
 
 Paginate over Query results, yielding one unmarshalled item at a time.
 
@@ -216,7 +217,7 @@ Expected shape of each yielded item.
 
 > **paginateScan**\<`T`\>(`input`): `AsyncGenerator`\<`T`\>
 
-Defined in: [dynamodb/dynamodb.ts:378](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L378)
+Defined in: [dynamodb/dynamodb.ts:379](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L379)
 
 Paginate over Scan results, yielding one unmarshalled item at a time.
 
@@ -246,7 +247,7 @@ Expected shape of each yielded item.
 
 > **putItem**\<`T`\>(`input`): `Promise`\<`PutCommandOutput`\>
 
-Defined in: [dynamodb/dynamodb.ts:200](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L200)
+Defined in: [dynamodb/dynamodb.ts:201](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L201)
 
 Put an item into DynamoDB. The caller's `Item` is typed as `T`, which
 the document client marshalls automatically.
@@ -277,7 +278,7 @@ Type of the item being stored.
 
 > **query**\<`T`\>(`input`): `Promise`\<`Omit`\<`QueryCommandOutput`, `"Items"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:269](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L269)
+Defined in: [dynamodb/dynamodb.ts:270](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L270)
 
 Execute a DynamoDB Query. The full `QueryCommandOutput` is returned with
 `Items` typed as `T[]` so callers retain pagination metadata
@@ -309,7 +310,7 @@ Expected shape of each unmarshalled item.
 
 > **scan**\<`T`\>(`input`): `Promise`\<`Omit`\<`ScanCommandOutput`, `"Items"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:298](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L298)
+Defined in: [dynamodb/dynamodb.ts:299](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L299)
 
 Scan a DynamoDB table. The full `ScanCommandOutput` is returned with
 `Items` typed as `T[]` so callers retain pagination metadata.
@@ -353,7 +354,7 @@ Expected shape of each unmarshalled item.
 
 > **updateItem**\<`K`, `R`\>(`input`): `Promise`\<`Omit`\<`UpdateCommandOutput`, `"Attributes"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:223](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L223)
+Defined in: [dynamodb/dynamodb.ts:224](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L224)
 
 Update an item in DynamoDB. The `Attributes` field on the response is
 typed as `R` — the caller should choose `R` to match their

--- a/packages/aws-wrappers/docs/classes/DynamoDBService.md
+++ b/packages/aws-wrappers/docs/classes/DynamoDBService.md
@@ -6,10 +6,13 @@
 
 # Class: DynamoDBService
 
-Defined in: [dynamodb/dynamodb.ts:155](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L155)
+Defined in: [dynamodb/dynamodb.ts:152](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L152)
 
 Wrapper around the AWS DynamoDB Document client providing structured
 Powertools logging and X-Ray tracing by default.
+
+At INFO the log lines omit payloads, secret material and PII; the verbose
+levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
 
 Items are automatically marshalled / unmarshalled via the document client —
 callers work with plain TypeScript objects in both directions.
@@ -22,7 +25,7 @@ callers work with plain TypeScript objects in both directions.
 
 > **new DynamoDBService**(`opts?`): `DynamoDBService`
 
-Defined in: [dynamodb/dynamodb.ts:168](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L168)
+Defined in: [dynamodb/dynamodb.ts:165](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L165)
 
 #### Parameters
 
@@ -57,7 +60,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **batchGet**(`input`): `Promise`\<`BatchGetCommandOutput`\>
 
-Defined in: [dynamodb/dynamodb.ts:319](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L319)
+Defined in: [dynamodb/dynamodb.ts:316](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L316)
 
 Batch-get items from one or more DynamoDB tables.
 
@@ -84,7 +87,7 @@ Callers should narrow the result type at the call site.
 
 > **batchWrite**(`input`): `Promise`\<`BatchWriteCommandOutput`\>
 
-Defined in: [dynamodb/dynamodb.ts:336](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L336)
+Defined in: [dynamodb/dynamodb.ts:333](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L333)
 
 Batch-write items to DynamoDB, retrying `UnprocessedItems` with jittered
 exponential backoff. Up to 5 attempts (200ms base delay). Throws when
@@ -108,7 +111,7 @@ items remain unprocessed after the final attempt.
 
 > **deleteItem**\<`K`, `R`\>(`input`): `Promise`\<`Omit`\<`DeleteCommandOutput`, `"Attributes"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:249](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L249)
+Defined in: [dynamodb/dynamodb.ts:246](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L246)
 
 Delete an item from DynamoDB. The `Attributes` field on the response is
 typed as `R` — relevant when `ReturnValues: 'ALL_OLD'` is set.
@@ -145,7 +148,7 @@ Expected shape of the returned `Attributes`.
 
 > **getItem**\<`K`, `R`\>(`input`): `Promise`\<`R` \| `undefined`\>
 
-Defined in: [dynamodb/dynamodb.ts:183](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L183)
+Defined in: [dynamodb/dynamodb.ts:180](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L180)
 
 Get an item from DynamoDB.
 
@@ -183,7 +186,7 @@ The item, or `undefined` if not found.
 
 > **paginateItems**\<`T`\>(`input`): `AsyncGenerator`\<`T`\>
 
-Defined in: [dynamodb/dynamodb.ts:364](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L364)
+Defined in: [dynamodb/dynamodb.ts:361](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L361)
 
 Paginate over Query results, yielding one unmarshalled item at a time.
 
@@ -213,7 +216,7 @@ Expected shape of each yielded item.
 
 > **paginateScan**\<`T`\>(`input`): `AsyncGenerator`\<`T`\>
 
-Defined in: [dynamodb/dynamodb.ts:381](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L381)
+Defined in: [dynamodb/dynamodb.ts:378](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L378)
 
 Paginate over Scan results, yielding one unmarshalled item at a time.
 
@@ -243,7 +246,7 @@ Expected shape of each yielded item.
 
 > **putItem**\<`T`\>(`input`): `Promise`\<`PutCommandOutput`\>
 
-Defined in: [dynamodb/dynamodb.ts:203](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L203)
+Defined in: [dynamodb/dynamodb.ts:200](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L200)
 
 Put an item into DynamoDB. The caller's `Item` is typed as `T`, which
 the document client marshalls automatically.
@@ -274,7 +277,7 @@ Type of the item being stored.
 
 > **query**\<`T`\>(`input`): `Promise`\<`Omit`\<`QueryCommandOutput`, `"Items"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:272](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L272)
+Defined in: [dynamodb/dynamodb.ts:269](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L269)
 
 Execute a DynamoDB Query. The full `QueryCommandOutput` is returned with
 `Items` typed as `T[]` so callers retain pagination metadata
@@ -306,7 +309,7 @@ Expected shape of each unmarshalled item.
 
 > **scan**\<`T`\>(`input`): `Promise`\<`Omit`\<`ScanCommandOutput`, `"Items"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:301](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L301)
+Defined in: [dynamodb/dynamodb.ts:298](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L298)
 
 Scan a DynamoDB table. The full `ScanCommandOutput` is returned with
 `Items` typed as `T[]` so callers retain pagination metadata.
@@ -350,7 +353,7 @@ Expected shape of each unmarshalled item.
 
 > **updateItem**\<`K`, `R`\>(`input`): `Promise`\<`Omit`\<`UpdateCommandOutput`, `"Attributes"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:226](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L226)
+Defined in: [dynamodb/dynamodb.ts:223](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L223)
 
 Update an item in DynamoDB. The `Attributes` field on the response is
 typed as `R` — the caller should choose `R` to match their

--- a/packages/aws-wrappers/docs/classes/S3Service.md
+++ b/packages/aws-wrappers/docs/classes/S3Service.md
@@ -6,10 +6,13 @@
 
 # Class: S3Service
 
-Defined in: [s3/s3.ts:68](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L68)
+Defined in: [s3/s3.ts:69](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L69)
 
 Wrapper around the AWS S3 client providing structured Powertools logging
 and X-Ray tracing by default.
+
+At INFO the log lines omit payloads, secret material and PII; the verbose
+levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
 
 Input shapes are intentionally tight (Bucket/Key/Body only). Callers
 needing SDK-level options not exposed here (server-side encryption,
@@ -23,7 +26,7 @@ tagging, version IDs) should use `S3Client` directly.
 
 > **new S3Service**(`opts?`): `S3Service`
 
-Defined in: [s3/s3.ts:78](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L78)
+Defined in: [s3/s3.ts:79](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L79)
 
 #### Parameters
 
@@ -55,7 +58,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **copyObject**(`input`): `Promise`\<`CopyObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:173](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L173)
+Defined in: [s3/s3.ts:174](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L174)
 
 Copy an object within S3.
 
@@ -77,7 +80,7 @@ Copy an object within S3.
 
 > **deleteObject**(`input`): `Promise`\<`DeleteObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:266](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L266)
+Defined in: [s3/s3.ts:267](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L267)
 
 Delete a single object from S3.
 
@@ -99,7 +102,7 @@ Delete a single object from S3.
 
 > **deleteObjects**(`bucket`, `keys`): `Promise`\<`DeleteObjectsCommandOutput`[]\>
 
-Defined in: [s3/s3.ts:278](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L278)
+Defined in: [s3/s3.ts:279](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L279)
 
 Delete multiple objects from S3, auto-chunking the request into batches
 of 1000 keys (the S3-enforced DeleteObjects limit). Returns one output
@@ -127,7 +130,7 @@ per chunk.
 
 > **emptyBucket**(`bucket`): `Promise`\<`string`[]\>
 
-Defined in: [s3/s3.ts:307](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L307)
+Defined in: [s3/s3.ts:308](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L308)
 
 Delete every object in a bucket. Streams the listing page-by-page and
 delegates each page's deletion to `deleteObjects`, so peak memory stays
@@ -153,7 +156,7 @@ The keys of every deleted object.
 
 > **getAllObjects**\<`T`\>(`bucket`, `prefix?`): `Promise`\<`T`[]\>
 
-Defined in: [s3/s3.ts:204](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L204)
+Defined in: [s3/s3.ts:205](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L205)
 
 List and JSON-parse every object under a bucket and optional prefix.
 Auto-paginated. Objects without a body are skipped.
@@ -188,7 +191,7 @@ Expected type of each parsed object.
 
 > **getJsonObject**\<`T`\>(`input`): `Promise`\<`T` \| `undefined`\>
 
-Defined in: [s3/s3.ts:151](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L151)
+Defined in: [s3/s3.ts:152](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L152)
 
 Get an object from S3 and parse it as JSON.
 
@@ -224,7 +227,7 @@ If the body is non-empty and not valid JSON.
 
 > **getObject**(`input`): `Promise`\<`GetObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:125](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L125)
+Defined in: [s3/s3.ts:126](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L126)
 
 Get an object from S3.
 
@@ -246,7 +249,7 @@ Get an object from S3.
 
 > **getObjectBody**(`input`): `Promise`\<`string` \| `undefined`\>
 
-Defined in: [s3/s3.ts:137](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L137)
+Defined in: [s3/s3.ts:138](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L138)
 
 Get an object from S3 and return its body as a string.
 
@@ -271,7 +274,7 @@ has no body.
 
 > **getPresignedUrl**(`input`): `Promise`\<`string`\>
 
-Defined in: [s3/s3.ts:242](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L242)
+Defined in: [s3/s3.ts:243](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L243)
 
 Generate a presigned URL that callers can use to GET or PUT an S3 object
 directly, without going through the wrapper. The signing happens against
@@ -325,7 +328,7 @@ The S3 object key.
 
 > **headObject**(`input`): `Promise`\<`HeadObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:163](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L163)
+Defined in: [s3/s3.ts:164](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L164)
 
 Fetch the metadata for an S3 object without downloading its body.
 
@@ -347,7 +350,7 @@ Fetch the metadata for an S3 object without downloading its body.
 
 > **listObjects**(`bucket`, `prefix?`): `Promise`\<`string`[]\>
 
-Defined in: [s3/s3.ts:184](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L184)
+Defined in: [s3/s3.ts:185](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L185)
 
 List object keys under a bucket and optional prefix, auto-paginating
 across all pages.
@@ -374,7 +377,7 @@ across all pages.
 
 > **putJsonObject**\<`T`\>(`input`): `Promise`\<`PutObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:108](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L108)
+Defined in: [s3/s3.ts:109](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L109)
 
 Serialise a value to JSON and store it as an S3 object.
 
@@ -408,7 +411,7 @@ Type of the value being stored.
 
 > **putObject**(`input`): `Promise`\<`PutObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:92](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/s3/s3.ts#L92)
+Defined in: [s3/s3.ts:93](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L93)
 
 Put an object into S3.
 

--- a/packages/aws-wrappers/docs/classes/S3Service.md
+++ b/packages/aws-wrappers/docs/classes/S3Service.md
@@ -6,13 +6,14 @@
 
 # Class: S3Service
 
-Defined in: [s3/s3.ts:69](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L69)
+Defined in: [s3/s3.ts:70](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L70)
 
 Wrapper around the AWS S3 client providing structured Powertools logging
 and X-Ray tracing by default.
 
-At INFO the log lines omit payloads, secret material and PII; the verbose
-levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+Where a method's input carries payloads, secret material or PII, the INFO
+log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+`TRACE`) log full SDK inputs.
 
 Input shapes are intentionally tight (Bucket/Key/Body only). Callers
 needing SDK-level options not exposed here (server-side encryption,
@@ -26,7 +27,7 @@ tagging, version IDs) should use `S3Client` directly.
 
 > **new S3Service**(`opts?`): `S3Service`
 
-Defined in: [s3/s3.ts:79](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L79)
+Defined in: [s3/s3.ts:80](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L80)
 
 #### Parameters
 
@@ -58,7 +59,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **copyObject**(`input`): `Promise`\<`CopyObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:174](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L174)
+Defined in: [s3/s3.ts:175](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L175)
 
 Copy an object within S3.
 
@@ -80,7 +81,7 @@ Copy an object within S3.
 
 > **deleteObject**(`input`): `Promise`\<`DeleteObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:267](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L267)
+Defined in: [s3/s3.ts:268](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L268)
 
 Delete a single object from S3.
 
@@ -102,7 +103,7 @@ Delete a single object from S3.
 
 > **deleteObjects**(`bucket`, `keys`): `Promise`\<`DeleteObjectsCommandOutput`[]\>
 
-Defined in: [s3/s3.ts:279](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L279)
+Defined in: [s3/s3.ts:280](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L280)
 
 Delete multiple objects from S3, auto-chunking the request into batches
 of 1000 keys (the S3-enforced DeleteObjects limit). Returns one output
@@ -130,7 +131,7 @@ per chunk.
 
 > **emptyBucket**(`bucket`): `Promise`\<`string`[]\>
 
-Defined in: [s3/s3.ts:308](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L308)
+Defined in: [s3/s3.ts:309](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L309)
 
 Delete every object in a bucket. Streams the listing page-by-page and
 delegates each page's deletion to `deleteObjects`, so peak memory stays
@@ -156,7 +157,7 @@ The keys of every deleted object.
 
 > **getAllObjects**\<`T`\>(`bucket`, `prefix?`): `Promise`\<`T`[]\>
 
-Defined in: [s3/s3.ts:205](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L205)
+Defined in: [s3/s3.ts:206](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L206)
 
 List and JSON-parse every object under a bucket and optional prefix.
 Auto-paginated. Objects without a body are skipped.
@@ -191,7 +192,7 @@ Expected type of each parsed object.
 
 > **getJsonObject**\<`T`\>(`input`): `Promise`\<`T` \| `undefined`\>
 
-Defined in: [s3/s3.ts:152](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L152)
+Defined in: [s3/s3.ts:153](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L153)
 
 Get an object from S3 and parse it as JSON.
 
@@ -227,7 +228,7 @@ If the body is non-empty and not valid JSON.
 
 > **getObject**(`input`): `Promise`\<`GetObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:126](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L126)
+Defined in: [s3/s3.ts:127](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L127)
 
 Get an object from S3.
 
@@ -249,7 +250,7 @@ Get an object from S3.
 
 > **getObjectBody**(`input`): `Promise`\<`string` \| `undefined`\>
 
-Defined in: [s3/s3.ts:138](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L138)
+Defined in: [s3/s3.ts:139](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L139)
 
 Get an object from S3 and return its body as a string.
 
@@ -274,7 +275,7 @@ has no body.
 
 > **getPresignedUrl**(`input`): `Promise`\<`string`\>
 
-Defined in: [s3/s3.ts:243](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L243)
+Defined in: [s3/s3.ts:244](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L244)
 
 Generate a presigned URL that callers can use to GET or PUT an S3 object
 directly, without going through the wrapper. The signing happens against
@@ -328,7 +329,7 @@ The S3 object key.
 
 > **headObject**(`input`): `Promise`\<`HeadObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:164](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L164)
+Defined in: [s3/s3.ts:165](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L165)
 
 Fetch the metadata for an S3 object without downloading its body.
 
@@ -350,7 +351,7 @@ Fetch the metadata for an S3 object without downloading its body.
 
 > **listObjects**(`bucket`, `prefix?`): `Promise`\<`string`[]\>
 
-Defined in: [s3/s3.ts:185](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L185)
+Defined in: [s3/s3.ts:186](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L186)
 
 List object keys under a bucket and optional prefix, auto-paginating
 across all pages.
@@ -377,7 +378,7 @@ across all pages.
 
 > **putJsonObject**\<`T`\>(`input`): `Promise`\<`PutObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:109](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L109)
+Defined in: [s3/s3.ts:110](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L110)
 
 Serialise a value to JSON and store it as an S3 object.
 
@@ -411,7 +412,7 @@ Type of the value being stored.
 
 > **putObject**(`input`): `Promise`\<`PutObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:93](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/s3/s3.ts#L93)
+Defined in: [s3/s3.ts:94](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L94)
 
 Put an object into S3.
 

--- a/packages/aws-wrappers/docs/classes/SNSService.md
+++ b/packages/aws-wrappers/docs/classes/SNSService.md
@@ -6,13 +6,14 @@
 
 # Class: SNSService
 
-Defined in: [sns/sns.ts:42](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sns/sns.ts#L42)
+Defined in: [sns/sns.ts:43](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sns/sns.ts#L43)
 
 Wrapper around the AWS SNS client providing structured Powertools logging
 and X-Ray tracing by default.
 
-At INFO the log lines omit payloads, secret material and PII; the verbose
-levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+Where a method's input carries payloads, secret material or PII, the INFO
+log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+`TRACE`) log full SDK inputs.
 
 ## Constructors
 
@@ -22,7 +23,7 @@ levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
 
 > **new SNSService**(`opts?`): `SNSService`
 
-Defined in: [sns/sns.ts:58](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sns/sns.ts#L58)
+Defined in: [sns/sns.ts:59](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sns/sns.ts#L59)
 
 #### Parameters
 
@@ -64,7 +65,7 @@ its own `truncate` option.
 
 > **publish**(`input`, `opts?`): `Promise`\<`PublishCommandOutput`\>
 
-Defined in: [sns/sns.ts:72](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sns/sns.ts#L72)
+Defined in: [sns/sns.ts:73](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sns/sns.ts#L73)
 
 Publish a single message to an SNS topic.
 
@@ -97,7 +98,7 @@ PublishCommandInput including TopicArn and Message.
 
 > **publishBatch**(`input`): `Promise`\<`PublishBatchCommandOutput`[]\>
 
-Defined in: [sns/sns.ts:109](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sns/sns.ts#L109)
+Defined in: [sns/sns.ts:110](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sns/sns.ts#L110)
 
 Publish a batch of messages to an SNS topic. The SNS API caps
 PublishBatch at 10 entries per request, so this method auto-chunks

--- a/packages/aws-wrappers/docs/classes/SNSService.md
+++ b/packages/aws-wrappers/docs/classes/SNSService.md
@@ -6,10 +6,13 @@
 
 # Class: SNSService
 
-Defined in: [sns/sns.ts:39](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sns/sns.ts#L39)
+Defined in: [sns/sns.ts:42](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sns/sns.ts#L42)
 
 Wrapper around the AWS SNS client providing structured Powertools logging
 and X-Ray tracing by default.
+
+At INFO the log lines omit payloads, secret material and PII; the verbose
+levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
 
 ## Constructors
 
@@ -19,7 +22,7 @@ and X-Ray tracing by default.
 
 > **new SNSService**(`opts?`): `SNSService`
 
-Defined in: [sns/sns.ts:55](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sns/sns.ts#L55)
+Defined in: [sns/sns.ts:58](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sns/sns.ts#L58)
 
 #### Parameters
 
@@ -61,13 +64,12 @@ its own `truncate` option.
 
 > **publish**(`input`, `opts?`): `Promise`\<`PublishCommandOutput`\>
 
-Defined in: [sns/sns.ts:70](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sns/sns.ts#L70)
+Defined in: [sns/sns.ts:72](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sns/sns.ts#L72)
 
 Publish a single message to an SNS topic.
 
 At INFO level the log line includes only routing / dedup metadata; see
-`PUBLISH_SAFE_FIELDS` for the list. Setting `POWERTOOLS_LOG_LEVEL=DEBUG`
-unlocks the full input.
+`PUBLISH_SAFE_FIELDS` for the list.
 
 #### Parameters
 
@@ -95,7 +97,7 @@ PublishCommandInput including TopicArn and Message.
 
 > **publishBatch**(`input`): `Promise`\<`PublishBatchCommandOutput`[]\>
 
-Defined in: [sns/sns.ts:107](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sns/sns.ts#L107)
+Defined in: [sns/sns.ts:109](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sns/sns.ts#L109)
 
 Publish a batch of messages to an SNS topic. The SNS API caps
 PublishBatch at 10 entries per request, so this method auto-chunks

--- a/packages/aws-wrappers/docs/classes/SQSService.md
+++ b/packages/aws-wrappers/docs/classes/SQSService.md
@@ -6,13 +6,14 @@
 
 # Class: SQSService
 
-Defined in: [sqs/sqs.ts:48](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L48)
+Defined in: [sqs/sqs.ts:49](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L49)
 
 Wrapper around the AWS SQS client providing structured Powertools logging
 and X-Ray tracing by default.
 
-At INFO the log lines omit payloads, secret material and PII; the verbose
-levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+Where a method's input carries payloads, secret material or PII, the INFO
+log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+`TRACE`) log full SDK inputs.
 
 ## Constructors
 
@@ -22,7 +23,7 @@ levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
 
 > **new SQSService**(`opts?`): `SQSService`
 
-Defined in: [sqs/sqs.ts:63](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L63)
+Defined in: [sqs/sqs.ts:64](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L64)
 
 #### Parameters
 
@@ -63,7 +64,7 @@ option.
 
 > **deleteMessage**(`input`): `Promise`\<`DeleteMessageCommandOutput`\>
 
-Defined in: [sqs/sqs.ts:118](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L118)
+Defined in: [sqs/sqs.ts:119](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L119)
 
 Delete a single message from an SQS queue.
 
@@ -85,7 +86,7 @@ Delete a single message from an SQS queue.
 
 > **deleteMessageBatch**(`input`): `Promise`\<`DeleteMessageBatchCommandOutput`[]\>
 
-Defined in: [sqs/sqs.ts:154](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L154)
+Defined in: [sqs/sqs.ts:155](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L155)
 
 Delete a batch of messages from an SQS queue. The SQS API caps
 DeleteMessageBatch at 10 entries per request, so this method auto-chunks
@@ -109,7 +110,7 @@ the caller's entries and sends one request per chunk.
 
 > **receiveMessages**(`input`): `Promise`\<`Message`[]\>
 
-Defined in: [sqs/sqs.ts:109](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L109)
+Defined in: [sqs/sqs.ts:110](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L110)
 
 Receive messages from an SQS queue. Returns an empty array when no
 messages are available. No automatic deletion is performed — visibility
@@ -135,7 +136,7 @@ The `Messages` array from the response, or `[]` if absent.
 
 > **sendMessage**(`input`, `opts?`): `Promise`\<`SendMessageCommandOutput`\>
 
-Defined in: [sqs/sqs.ts:75](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L75)
+Defined in: [sqs/sqs.ts:76](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L76)
 
 Send a single message to an SQS queue.
 
@@ -166,7 +167,7 @@ see `SEND_MESSAGE_SAFE_FIELDS`.
 
 > **sendMessageBatch**(`input`): `Promise`\<`SendMessageBatchCommandOutput`[]\>
 
-Defined in: [sqs/sqs.ts:128](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L128)
+Defined in: [sqs/sqs.ts:129](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L129)
 
 Send a batch of messages to an SQS queue. The SQS API caps
 SendMessageBatch at 10 entries per request, so this method auto-chunks

--- a/packages/aws-wrappers/docs/classes/SQSService.md
+++ b/packages/aws-wrappers/docs/classes/SQSService.md
@@ -6,10 +6,13 @@
 
 # Class: SQSService
 
-Defined in: [sqs/sqs.ts:46](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L46)
+Defined in: [sqs/sqs.ts:48](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L48)
 
 Wrapper around the AWS SQS client providing structured Powertools logging
 and X-Ray tracing by default.
+
+At INFO the log lines omit payloads, secret material and PII; the verbose
+levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
 
 ## Constructors
 
@@ -19,7 +22,7 @@ and X-Ray tracing by default.
 
 > **new SQSService**(`opts?`): `SQSService`
 
-Defined in: [sqs/sqs.ts:61](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L61)
+Defined in: [sqs/sqs.ts:63](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L63)
 
 #### Parameters
 
@@ -60,7 +63,7 @@ option.
 
 > **deleteMessage**(`input`): `Promise`\<`DeleteMessageCommandOutput`\>
 
-Defined in: [sqs/sqs.ts:117](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L117)
+Defined in: [sqs/sqs.ts:118](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L118)
 
 Delete a single message from an SQS queue.
 
@@ -82,7 +85,7 @@ Delete a single message from an SQS queue.
 
 > **deleteMessageBatch**(`input`): `Promise`\<`DeleteMessageBatchCommandOutput`[]\>
 
-Defined in: [sqs/sqs.ts:153](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L153)
+Defined in: [sqs/sqs.ts:154](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L154)
 
 Delete a batch of messages from an SQS queue. The SQS API caps
 DeleteMessageBatch at 10 entries per request, so this method auto-chunks
@@ -106,7 +109,7 @@ the caller's entries and sends one request per chunk.
 
 > **receiveMessages**(`input`): `Promise`\<`Message`[]\>
 
-Defined in: [sqs/sqs.ts:108](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L108)
+Defined in: [sqs/sqs.ts:109](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L109)
 
 Receive messages from an SQS queue. Returns an empty array when no
 messages are available. No automatic deletion is performed — visibility
@@ -132,13 +135,12 @@ The `Messages` array from the response, or `[]` if absent.
 
 > **sendMessage**(`input`, `opts?`): `Promise`\<`SendMessageCommandOutput`\>
 
-Defined in: [sqs/sqs.ts:74](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L74)
+Defined in: [sqs/sqs.ts:75](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L75)
 
 Send a single message to an SQS queue.
 
 At INFO level the log line includes only queue routing / FIFO metadata;
-see `SEND_MESSAGE_SAFE_FIELDS`. `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the
-full input.
+see `SEND_MESSAGE_SAFE_FIELDS`.
 
 #### Parameters
 
@@ -164,7 +166,7 @@ full input.
 
 > **sendMessageBatch**(`input`): `Promise`\<`SendMessageBatchCommandOutput`[]\>
 
-Defined in: [sqs/sqs.ts:127](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sqs/sqs.ts#L127)
+Defined in: [sqs/sqs.ts:128](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sqs/sqs.ts#L128)
 
 Send a batch of messages to an SQS queue. The SQS API caps
 SendMessageBatch at 10 entries per request, so this method auto-chunks

--- a/packages/aws-wrappers/docs/classes/SSMService.md
+++ b/packages/aws-wrappers/docs/classes/SSMService.md
@@ -6,12 +6,15 @@
 
 # Class: SSMService
 
-Defined in: [ssm/ssm.ts:47](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L47)
+Defined in: [ssm/ssm.ts:49](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L49)
 
 Wrapper around the AWS SSM Parameter Store client providing structured
 Powertools logging and X-Ray tracing by default. All read operations enable
 `WithDecryption` — callers needing plaintext should use `SSMClient`
 directly.
+
+At INFO the log lines omit payloads, secret material and PII; the verbose
+levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
 
 Write operations (`putParameter`, `deleteParameter`) are exposed for
 convenience but should be used with care: parameter lifecycle is usually
@@ -27,7 +30,7 @@ mutate within the application.
 
 > **new SSMService**(`opts?`): `SSMService`
 
-Defined in: [ssm/ssm.ts:57](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L57)
+Defined in: [ssm/ssm.ts:59](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L59)
 
 #### Parameters
 
@@ -59,7 +62,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **deleteParameter**(`name`): `Promise`\<`void`\>
 
-Defined in: [ssm/ssm.ts:136](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L136)
+Defined in: [ssm/ssm.ts:138](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L138)
 
 Delete an SSM parameter by name.
 
@@ -84,7 +87,7 @@ runtime cleanup only.
 
 > **getParameter**(`name`): `Promise`\<`string` \| `undefined`\>
 
-Defined in: [ssm/ssm.ts:68](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L68)
+Defined in: [ssm/ssm.ts:70](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L70)
 
 Fetch a single SSM parameter's value.
 
@@ -111,7 +114,7 @@ value set.
 
 > **getParameters**\<`K`\>(`aliases`): `Promise`\<`Record`\<`K`, `string` \| `undefined`\>\>
 
-Defined in: [ssm/ssm.ts:95](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L95)
+Defined in: [ssm/ssm.ts:97](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L97)
 
 Fetch multiple SSM parameters in a single request. Callers supply an
 alias-to-path record, and the returned record is keyed by the same
@@ -156,7 +159,7 @@ no value.
 
 > **getParametersByPath**(`path`, `opts?`): `Promise`\<`Parameter`[]\>
 
-Defined in: [ssm/ssm.ts:152](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L152)
+Defined in: [ssm/ssm.ts:154](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L154)
 
 Fetch all parameters under an SSM hierarchy path, auto-paginating across
 all pages. `Recursive` defaults to `true` (overriding the AWS SDK
@@ -195,7 +198,7 @@ The full `Parameter` objects (including `Version`,
 
 > **putParameter**(`input`): `Promise`\<`PutParameterCommandOutput`\>
 
-Defined in: [ssm/ssm.ts:123](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/ssm/ssm.ts#L123)
+Defined in: [ssm/ssm.ts:125](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L125)
 
 Create or update an SSM parameter. The log line omits `Value` to avoid
 leaking secret material.

--- a/packages/aws-wrappers/docs/classes/SSMService.md
+++ b/packages/aws-wrappers/docs/classes/SSMService.md
@@ -6,15 +6,16 @@
 
 # Class: SSMService
 
-Defined in: [ssm/ssm.ts:49](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L49)
+Defined in: [ssm/ssm.ts:50](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L50)
 
 Wrapper around the AWS SSM Parameter Store client providing structured
 Powertools logging and X-Ray tracing by default. All read operations enable
 `WithDecryption` — callers needing plaintext should use `SSMClient`
 directly.
 
-At INFO the log lines omit payloads, secret material and PII; the verbose
-levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+Where a method's input carries payloads, secret material or PII, the INFO
+log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+`TRACE`) log full SDK inputs.
 
 Write operations (`putParameter`, `deleteParameter`) are exposed for
 convenience but should be used with care: parameter lifecycle is usually
@@ -30,7 +31,7 @@ mutate within the application.
 
 > **new SSMService**(`opts?`): `SSMService`
 
-Defined in: [ssm/ssm.ts:59](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L59)
+Defined in: [ssm/ssm.ts:60](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L60)
 
 #### Parameters
 
@@ -62,7 +63,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **deleteParameter**(`name`): `Promise`\<`void`\>
 
-Defined in: [ssm/ssm.ts:138](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L138)
+Defined in: [ssm/ssm.ts:139](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L139)
 
 Delete an SSM parameter by name.
 
@@ -87,7 +88,7 @@ runtime cleanup only.
 
 > **getParameter**(`name`): `Promise`\<`string` \| `undefined`\>
 
-Defined in: [ssm/ssm.ts:70](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L70)
+Defined in: [ssm/ssm.ts:71](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L71)
 
 Fetch a single SSM parameter's value.
 
@@ -114,7 +115,7 @@ value set.
 
 > **getParameters**\<`K`\>(`aliases`): `Promise`\<`Record`\<`K`, `string` \| `undefined`\>\>
 
-Defined in: [ssm/ssm.ts:97](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L97)
+Defined in: [ssm/ssm.ts:98](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L98)
 
 Fetch multiple SSM parameters in a single request. Callers supply an
 alias-to-path record, and the returned record is keyed by the same
@@ -159,7 +160,7 @@ no value.
 
 > **getParametersByPath**(`path`, `opts?`): `Promise`\<`Parameter`[]\>
 
-Defined in: [ssm/ssm.ts:154](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L154)
+Defined in: [ssm/ssm.ts:155](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L155)
 
 Fetch all parameters under an SSM hierarchy path, auto-paginating across
 all pages. `Recursive` defaults to `true` (overriding the AWS SDK
@@ -198,7 +199,7 @@ The full `Parameter` objects (including `Version`,
 
 > **putParameter**(`input`): `Promise`\<`PutParameterCommandOutput`\>
 
-Defined in: [ssm/ssm.ts:125](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/ssm/ssm.ts#L125)
+Defined in: [ssm/ssm.ts:126](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L126)
 
 Create or update an SSM parameter. The log line omits `Value` to avoid
 leaking secret material.

--- a/packages/aws-wrappers/docs/classes/SchedulerService.md
+++ b/packages/aws-wrappers/docs/classes/SchedulerService.md
@@ -6,13 +6,14 @@
 
 # Class: SchedulerService
 
-Defined in: [scheduler/scheduler.ts:80](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L80)
+Defined in: [scheduler/scheduler.ts:81](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L81)
 
 Wrapper around the AWS EventBridge Scheduler client providing structured
 Powertools logging and X-Ray tracing by default.
 
-At INFO the log lines omit payloads, secret material and PII; the verbose
-levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+Where a method's input carries payloads, secret material or PII, the INFO
+log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+`TRACE`) log full SDK inputs.
 
 Covers CRUD on schedules and their groups. Named `SchedulerService` (not
 `EventBridgeSchedulerService`) so it doesn't collide with a future wrapper
@@ -30,7 +31,7 @@ intent (`{ Mode: 'OFF' }` for a fixed-time schedule).
 
 > **new SchedulerService**(`opts?`): `SchedulerService`
 
-Defined in: [scheduler/scheduler.ts:90](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L90)
+Defined in: [scheduler/scheduler.ts:91](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L91)
 
 #### Parameters
 
@@ -62,7 +63,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **createSchedule**(`input`): `Promise`\<`CreateScheduleCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:99](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L99)
+Defined in: [scheduler/scheduler.ts:100](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L100)
 
 Create a new schedule. At INFO the log line omits `Target.Input` (the
 target payload, a PII carrier).
@@ -85,7 +86,7 @@ target payload, a PII carrier).
 
 > **createScheduleGroup**(`input`): `Promise`\<`CreateScheduleGroupCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:157](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L157)
+Defined in: [scheduler/scheduler.ts:158](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L158)
 
 Create a new schedule group. Groups are containers for schedules and are
 typically IaC-managed; use this for dynamically-provisioned groups only.
@@ -108,7 +109,7 @@ typically IaC-managed; use this for dynamically-provisioned groups only.
 
 > **deleteSchedule**(`input`): `Promise`\<`DeleteScheduleCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:133](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L133)
+Defined in: [scheduler/scheduler.ts:134](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L134)
 
 Delete a schedule.
 
@@ -130,7 +131,7 @@ Delete a schedule.
 
 > **deleteScheduleGroup**(`input`): `Promise`\<`DeleteScheduleGroupCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:179](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L179)
+Defined in: [scheduler/scheduler.ts:180](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L180)
 
 Delete a schedule group. Deleting a group also deletes every schedule it
 contains, asynchronously — the API has no `UpdateScheduleGroup`, so this
@@ -154,7 +155,7 @@ is the only mutating group operation besides create.
 
 > **getSchedule**(`input`): `Promise`\<`GetScheduleCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:107](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L107)
+Defined in: [scheduler/scheduler.ts:108](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L108)
 
 Fetch a schedule's full configuration.
 
@@ -176,7 +177,7 @@ Fetch a schedule's full configuration.
 
 > **getScheduleGroup**(`input`): `Promise`\<`GetScheduleGroupCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:167](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L167)
+Defined in: [scheduler/scheduler.ts:168](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L168)
 
 Fetch a schedule group's configuration.
 
@@ -198,7 +199,7 @@ Fetch a schedule group's configuration.
 
 > **listScheduleGroups**(`input?`): `Promise`\<`ScheduleGroupSummary`[]\>
 
-Defined in: [scheduler/scheduler.ts:190](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L190)
+Defined in: [scheduler/scheduler.ts:191](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L191)
 
 List schedule groups, auto-paginating across all pages. Bounded in
 practice by the account's group count and the `NamePrefix` filter.
@@ -221,7 +222,7 @@ practice by the account's group count and the `NamePrefix` filter.
 
 > **listSchedules**(`input?`): `Promise`\<`ScheduleSummary`[]\>
 
-Defined in: [scheduler/scheduler.ts:143](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L143)
+Defined in: [scheduler/scheduler.ts:144](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L144)
 
 List schedules, auto-paginating across all pages. Bounded in practice by
 the account's schedule count and the `GroupName` / `NamePrefix` / `State`
@@ -245,7 +246,7 @@ filters, so the flat-array shape is safe.
 
 > **updateSchedule**(`input`): `Promise`\<`UpdateScheduleCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:125](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L125)
+Defined in: [scheduler/scheduler.ts:126](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L126)
 
 Update an existing schedule.
 

--- a/packages/aws-wrappers/docs/classes/SchedulerService.md
+++ b/packages/aws-wrappers/docs/classes/SchedulerService.md
@@ -6,10 +6,13 @@
 
 # Class: SchedulerService
 
-Defined in: scheduler/scheduler.ts:75
+Defined in: [scheduler/scheduler.ts:80](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L80)
 
 Wrapper around the AWS EventBridge Scheduler client providing structured
 Powertools logging and X-Ray tracing by default.
+
+At INFO the log lines omit payloads, secret material and PII; the verbose
+levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
 
 Covers CRUD on schedules and their groups. Named `SchedulerService` (not
 `EventBridgeSchedulerService`) so it doesn't collide with a future wrapper
@@ -27,7 +30,7 @@ intent (`{ Mode: 'OFF' }` for a fixed-time schedule).
 
 > **new SchedulerService**(`opts?`): `SchedulerService`
 
-Defined in: scheduler/scheduler.ts:85
+Defined in: [scheduler/scheduler.ts:90](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L90)
 
 #### Parameters
 
@@ -59,11 +62,10 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **createSchedule**(`input`): `Promise`\<`CreateScheduleCommandOutput`\>
 
-Defined in: scheduler/scheduler.ts:95
+Defined in: [scheduler/scheduler.ts:99](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L99)
 
 Create a new schedule. At INFO the log line omits `Target.Input` (the
-target payload, a PII carrier); `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the
-full input.
+target payload, a PII carrier).
 
 #### Parameters
 
@@ -83,7 +85,7 @@ full input.
 
 > **createScheduleGroup**(`input`): `Promise`\<`CreateScheduleGroupCommandOutput`\>
 
-Defined in: scheduler/scheduler.ts:154
+Defined in: [scheduler/scheduler.ts:157](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L157)
 
 Create a new schedule group. Groups are containers for schedules and are
 typically IaC-managed; use this for dynamically-provisioned groups only.
@@ -106,7 +108,7 @@ typically IaC-managed; use this for dynamically-provisioned groups only.
 
 > **deleteSchedule**(`input`): `Promise`\<`DeleteScheduleCommandOutput`\>
 
-Defined in: scheduler/scheduler.ts:130
+Defined in: [scheduler/scheduler.ts:133](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L133)
 
 Delete a schedule.
 
@@ -128,7 +130,7 @@ Delete a schedule.
 
 > **deleteScheduleGroup**(`input`): `Promise`\<`DeleteScheduleGroupCommandOutput`\>
 
-Defined in: scheduler/scheduler.ts:176
+Defined in: [scheduler/scheduler.ts:179](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L179)
 
 Delete a schedule group. Deleting a group also deletes every schedule it
 contains, asynchronously — the API has no `UpdateScheduleGroup`, so this
@@ -152,7 +154,7 @@ is the only mutating group operation besides create.
 
 > **getSchedule**(`input`): `Promise`\<`GetScheduleCommandOutput`\>
 
-Defined in: scheduler/scheduler.ts:103
+Defined in: [scheduler/scheduler.ts:107](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L107)
 
 Fetch a schedule's full configuration.
 
@@ -174,7 +176,7 @@ Fetch a schedule's full configuration.
 
 > **getScheduleGroup**(`input`): `Promise`\<`GetScheduleGroupCommandOutput`\>
 
-Defined in: scheduler/scheduler.ts:164
+Defined in: [scheduler/scheduler.ts:167](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L167)
 
 Fetch a schedule group's configuration.
 
@@ -196,7 +198,7 @@ Fetch a schedule group's configuration.
 
 > **listScheduleGroups**(`input?`): `Promise`\<`ScheduleGroupSummary`[]\>
 
-Defined in: scheduler/scheduler.ts:187
+Defined in: [scheduler/scheduler.ts:190](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L190)
 
 List schedule groups, auto-paginating across all pages. Bounded in
 practice by the account's group count and the `NamePrefix` filter.
@@ -219,7 +221,7 @@ practice by the account's group count and the `NamePrefix` filter.
 
 > **listSchedules**(`input?`): `Promise`\<`ScheduleSummary`[]\>
 
-Defined in: scheduler/scheduler.ts:140
+Defined in: [scheduler/scheduler.ts:143](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L143)
 
 List schedules, auto-paginating across all pages. Bounded in practice by
 the account's schedule count and the `GroupName` / `NamePrefix` / `State`
@@ -243,7 +245,7 @@ filters, so the flat-array shape is safe.
 
 > **updateSchedule**(`input`): `Promise`\<`UpdateScheduleCommandOutput`\>
 
-Defined in: scheduler/scheduler.ts:122
+Defined in: [scheduler/scheduler.ts:125](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/scheduler/scheduler.ts#L125)
 
 Update an existing schedule.
 
@@ -255,8 +257,7 @@ that attribute modified, or you will silently erase `ScheduleExpression`,
 your behalf: deep-merging a `Target` (with its mutually-exclusive
 target-type params) has no single correct semantics.
 
-At INFO the log line omits `Target.Input`; `POWERTOOLS_LOG_LEVEL=DEBUG`
-unlocks the full input.
+At INFO the log line omits `Target.Input`.
 
 #### Parameters
 

--- a/packages/aws-wrappers/docs/classes/SecretsManagerService.md
+++ b/packages/aws-wrappers/docs/classes/SecretsManagerService.md
@@ -6,10 +6,13 @@
 
 # Class: SecretsManagerService
 
-Defined in: [secrets-manager/secrets-manager.ts:72](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L72)
+Defined in: [secrets-manager/secrets-manager.ts:74](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L74)
 
 Wrapper around the AWS Secrets Manager client providing structured
 Powertools logging and X-Ray tracing by default.
+
+At INFO the log lines omit payloads, secret material and PII; the verbose
+levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
 
 Write operations (`createSecret`, `updateSecret`, `putSecretValue`,
 `deleteSecret`) are exposed for convenience but should be used with care:
@@ -26,7 +29,7 @@ mutable values.
 
 > **new SecretsManagerService**(`opts?`): `SecretsManagerService`
 
-Defined in: [secrets-manager/secrets-manager.ts:83](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L83)
+Defined in: [secrets-manager/secrets-manager.ts:85](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L85)
 
 #### Parameters
 
@@ -59,11 +62,10 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **createSecret**(`input`): `Promise`\<`CreateSecretCommandOutput`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:121](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L121)
+Defined in: [secrets-manager/secrets-manager.ts:122](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L122)
 
 Create a new secret. At INFO level the log line includes only identity
-and non-secret metadata; `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full
-input (including `SecretString` / `SecretBinary`).
+and non-secret metadata.
 
 Prefer IaC (CDK / Terraform) for secret lifecycle — use this for
 dynamically-issued credentials only.
@@ -86,7 +88,7 @@ dynamically-issued credentials only.
 
 > **deleteSecret**(`input`): `Promise`\<`DeleteSecretCommandOutput`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:163](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L163)
+Defined in: [secrets-manager/secrets-manager.ts:162](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L162)
 
 Delete a secret. Pass `ForceDeleteWithoutRecovery: true` to bypass the
 default 7-30 day recovery window (irreversible).
@@ -111,7 +113,7 @@ Prefer IaC (CDK / Terraform) for secret lifecycle.
 
 > **getJsonSecret**\<`T`\>(`secretId`): `Promise`\<`T`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:107](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L107)
+Defined in: [secrets-manager/secrets-manager.ts:109](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L109)
 
 Fetch a secret and parse it as JSON.
 
@@ -149,7 +151,7 @@ If the secret has no `SecretString` or the value is not valid JSON.
 
 > **getSecret**(`secretId`): `Promise`\<`string`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:95](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L95)
+Defined in: [secrets-manager/secrets-manager.ts:97](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L97)
 
 Fetch a secret's string value from Secrets Manager.
 
@@ -180,11 +182,10 @@ stores binary data).
 
 > **putSecretValue**(`input`): `Promise`\<`PutSecretValueCommandOutput`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:150](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L150)
+Defined in: [secrets-manager/secrets-manager.ts:149](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L149)
 
 Store a new version of a secret's value. At INFO level the log line
-omits `SecretString` / `SecretBinary`; `POWERTOOLS_LOG_LEVEL=DEBUG`
-unlocks the full input.
+omits `SecretString` / `SecretBinary`.
 
 Typically used by rotation flows.
 
@@ -206,11 +207,10 @@ Typically used by rotation flows.
 
 > **updateSecret**(`input`): `Promise`\<`UpdateSecretCommandOutput`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:136](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L136)
+Defined in: [secrets-manager/secrets-manager.ts:136](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L136)
 
 Update an existing secret's metadata or value. At INFO level the log
-line omits `SecretString` / `SecretBinary`; `POWERTOOLS_LOG_LEVEL=DEBUG`
-unlocks the full input.
+line omits `SecretString` / `SecretBinary`.
 
 Prefer IaC (CDK / Terraform) for secret lifecycle — use this for
 runtime metadata updates only.

--- a/packages/aws-wrappers/docs/classes/SecretsManagerService.md
+++ b/packages/aws-wrappers/docs/classes/SecretsManagerService.md
@@ -6,13 +6,14 @@
 
 # Class: SecretsManagerService
 
-Defined in: [secrets-manager/secrets-manager.ts:74](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L74)
+Defined in: [secrets-manager/secrets-manager.ts:75](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L75)
 
 Wrapper around the AWS Secrets Manager client providing structured
 Powertools logging and X-Ray tracing by default.
 
-At INFO the log lines omit payloads, secret material and PII; the verbose
-levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+Where a method's input carries payloads, secret material or PII, the INFO
+log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+`TRACE`) log full SDK inputs.
 
 Write operations (`createSecret`, `updateSecret`, `putSecretValue`,
 `deleteSecret`) are exposed for convenience but should be used with care:
@@ -29,7 +30,7 @@ mutable values.
 
 > **new SecretsManagerService**(`opts?`): `SecretsManagerService`
 
-Defined in: [secrets-manager/secrets-manager.ts:85](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L85)
+Defined in: [secrets-manager/secrets-manager.ts:86](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L86)
 
 #### Parameters
 
@@ -62,7 +63,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **createSecret**(`input`): `Promise`\<`CreateSecretCommandOutput`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:122](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L122)
+Defined in: [secrets-manager/secrets-manager.ts:123](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L123)
 
 Create a new secret. At INFO level the log line includes only identity
 and non-secret metadata.
@@ -88,7 +89,7 @@ dynamically-issued credentials only.
 
 > **deleteSecret**(`input`): `Promise`\<`DeleteSecretCommandOutput`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:162](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L162)
+Defined in: [secrets-manager/secrets-manager.ts:163](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L163)
 
 Delete a secret. Pass `ForceDeleteWithoutRecovery: true` to bypass the
 default 7-30 day recovery window (irreversible).
@@ -113,7 +114,7 @@ Prefer IaC (CDK / Terraform) for secret lifecycle.
 
 > **getJsonSecret**\<`T`\>(`secretId`): `Promise`\<`T`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:109](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L109)
+Defined in: [secrets-manager/secrets-manager.ts:110](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L110)
 
 Fetch a secret and parse it as JSON.
 
@@ -151,7 +152,7 @@ If the secret has no `SecretString` or the value is not valid JSON.
 
 > **getSecret**(`secretId`): `Promise`\<`string`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:97](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L97)
+Defined in: [secrets-manager/secrets-manager.ts:98](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L98)
 
 Fetch a secret's string value from Secrets Manager.
 
@@ -182,7 +183,7 @@ stores binary data).
 
 > **putSecretValue**(`input`): `Promise`\<`PutSecretValueCommandOutput`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:149](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L149)
+Defined in: [secrets-manager/secrets-manager.ts:150](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L150)
 
 Store a new version of a secret's value. At INFO level the log line
 omits `SecretString` / `SecretBinary`.
@@ -207,7 +208,7 @@ Typically used by rotation flows.
 
 > **updateSecret**(`input`): `Promise`\<`UpdateSecretCommandOutput`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:136](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L136)
+Defined in: [secrets-manager/secrets-manager.ts:137](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L137)
 
 Update an existing secret's metadata or value. At INFO level the log
 line omits `SecretString` / `SecretBinary`.

--- a/packages/aws-wrappers/docs/classes/StepFunctionsService.md
+++ b/packages/aws-wrappers/docs/classes/StepFunctionsService.md
@@ -6,10 +6,13 @@
 
 # Class: StepFunctionsService
 
-Defined in: [sfn/sfn.ts:36](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sfn/sfn.ts#L36)
+Defined in: [sfn/sfn.ts:39](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sfn/sfn.ts#L39)
 
 Wrapper around the AWS Step Functions client providing structured
 Powertools logging and X-Ray tracing by default.
+
+At INFO the log lines omit payloads, secret material and PII; the verbose
+levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
 
 ## Constructors
 
@@ -19,7 +22,7 @@ Powertools logging and X-Ray tracing by default.
 
 > **new StepFunctionsService**(`opts?`): `StepFunctionsService`
 
-Defined in: [sfn/sfn.ts:46](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sfn/sfn.ts#L46)
+Defined in: [sfn/sfn.ts:49](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sfn/sfn.ts#L49)
 
 #### Parameters
 
@@ -51,7 +54,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **describeExecution**(`input`): `Promise`\<`DescribeExecutionCommandOutput`\>
 
-Defined in: [sfn/sfn.ts:79](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sfn/sfn.ts#L79)
+Defined in: [sfn/sfn.ts:82](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sfn/sfn.ts#L82)
 
 Describe an existing Step Functions execution.
 
@@ -73,7 +76,7 @@ Describe an existing Step Functions execution.
 
 > **listExecutions**(`input`): `Promise`\<`ExecutionListItem`[]\>
 
-Defined in: [sfn/sfn.ts:56](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sfn/sfn.ts#L56)
+Defined in: [sfn/sfn.ts:59](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sfn/sfn.ts#L59)
 
 List all executions for a state machine, auto-paginating across all
 pages. Typically bounded by `statusFilter` and state-machine retention,
@@ -97,7 +100,7 @@ so the flat-array shape is safe in practice.
 
 > **startExecution**(`input`): `Promise`\<`StartExecutionCommandOutput`\>
 
-Defined in: [sfn/sfn.ts:69](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sfn/sfn.ts#L69)
+Defined in: [sfn/sfn.ts:72](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sfn/sfn.ts#L72)
 
 Start a new Step Functions execution.
 
@@ -119,7 +122,7 @@ Start a new Step Functions execution.
 
 > **stopExecution**(`input`): `Promise`\<`StopExecutionCommandOutput`\>
 
-Defined in: [sfn/sfn.ts:89](https://github.com/aligent/microservice-development-utilities/blob/1c8403742cbf82a4bd82725126d0860e0996e39d/packages/aws-wrappers/src/sfn/sfn.ts#L89)
+Defined in: [sfn/sfn.ts:92](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sfn/sfn.ts#L92)
 
 Stop an in-progress Step Functions execution.
 

--- a/packages/aws-wrappers/docs/classes/StepFunctionsService.md
+++ b/packages/aws-wrappers/docs/classes/StepFunctionsService.md
@@ -6,13 +6,14 @@
 
 # Class: StepFunctionsService
 
-Defined in: [sfn/sfn.ts:39](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sfn/sfn.ts#L39)
+Defined in: [sfn/sfn.ts:40](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sfn/sfn.ts#L40)
 
 Wrapper around the AWS Step Functions client providing structured
 Powertools logging and X-Ray tracing by default.
 
-At INFO the log lines omit payloads, secret material and PII; the verbose
-levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+Where a method's input carries payloads, secret material or PII, the INFO
+log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+`TRACE`) log full SDK inputs.
 
 ## Constructors
 
@@ -22,7 +23,7 @@ levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
 
 > **new StepFunctionsService**(`opts?`): `StepFunctionsService`
 
-Defined in: [sfn/sfn.ts:49](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sfn/sfn.ts#L49)
+Defined in: [sfn/sfn.ts:50](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sfn/sfn.ts#L50)
 
 #### Parameters
 
@@ -54,7 +55,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **describeExecution**(`input`): `Promise`\<`DescribeExecutionCommandOutput`\>
 
-Defined in: [sfn/sfn.ts:82](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sfn/sfn.ts#L82)
+Defined in: [sfn/sfn.ts:83](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sfn/sfn.ts#L83)
 
 Describe an existing Step Functions execution.
 
@@ -76,7 +77,7 @@ Describe an existing Step Functions execution.
 
 > **listExecutions**(`input`): `Promise`\<`ExecutionListItem`[]\>
 
-Defined in: [sfn/sfn.ts:59](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sfn/sfn.ts#L59)
+Defined in: [sfn/sfn.ts:60](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sfn/sfn.ts#L60)
 
 List all executions for a state machine, auto-paginating across all
 pages. Typically bounded by `statusFilter` and state-machine retention,
@@ -100,7 +101,7 @@ so the flat-array shape is safe in practice.
 
 > **startExecution**(`input`): `Promise`\<`StartExecutionCommandOutput`\>
 
-Defined in: [sfn/sfn.ts:72](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sfn/sfn.ts#L72)
+Defined in: [sfn/sfn.ts:73](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sfn/sfn.ts#L73)
 
 Start a new Step Functions execution.
 
@@ -122,7 +123,7 @@ Start a new Step Functions execution.
 
 > **stopExecution**(`input`): `Promise`\<`StopExecutionCommandOutput`\>
 
-Defined in: [sfn/sfn.ts:92](https://github.com/aligent/microservice-development-utilities/blob/0505887eb00467bf78adacde3766052acbbfb10a/packages/aws-wrappers/src/sfn/sfn.ts#L92)
+Defined in: [sfn/sfn.ts:93](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sfn/sfn.ts#L93)
 
 Stop an in-progress Step Functions execution.
 

--- a/packages/aws-wrappers/src/dynamodb/dynamodb.test.ts
+++ b/packages/aws-wrappers/src/dynamodb/dynamodb.test.ts
@@ -184,6 +184,27 @@ describe('DynamoDBService', () => {
             expect(loggedInput).toEqual({ tables: [TableName] });
         });
 
+        it('batchGet logs the full RequestItems at TRACE level', async () => {
+            ddbMock.on(BatchGetCommand).resolves({});
+            const logger = new Logger();
+            logger.setLogLevel('TRACE');
+            const infoSpy = vi.spyOn(logger, 'info');
+            const service = new DynamoDBService({
+                client: DynamoDBDocumentClient.from(new DynamoDBClient({})),
+                logger,
+            });
+
+            await service.batchGet({
+                RequestItems: { [TableName]: { Keys: [{ pk: 'customer-123' }] } },
+            });
+
+            const [, payload] = infoSpy.mock.calls[0] ?? [];
+            const loggedInput = (payload as { input: object }).input;
+            expect(loggedInput).toHaveProperty('RequestItems', {
+                [TableName]: { Keys: [{ pk: 'customer-123' }] },
+            });
+        });
+
         it('batchWrite logs only the table names at INFO level', async () => {
             ddbMock.on(BatchWriteCommand).resolves({});
             const logger = new Logger();
@@ -204,6 +225,29 @@ describe('DynamoDBService', () => {
             const loggedInput = (payload as { input: object }).input;
             expect(loggedInput).not.toHaveProperty('RequestItems');
             expect(loggedInput).toEqual({ tables: [TableName] });
+        });
+
+        it('batchWrite logs the full RequestItems at TRACE level', async () => {
+            ddbMock.on(BatchWriteCommand).resolves({});
+            const logger = new Logger();
+            logger.setLogLevel('TRACE');
+            const infoSpy = vi.spyOn(logger, 'info');
+            const service = new DynamoDBService({
+                client: DynamoDBDocumentClient.from(new DynamoDBClient({})),
+                logger,
+            });
+
+            await service.batchWrite({
+                RequestItems: {
+                    [TableName]: [{ PutRequest: { Item: { pk: 'a', email: 'pii@example.com' } } }],
+                },
+            });
+
+            const [, payload] = infoSpy.mock.calls[0] ?? [];
+            const loggedInput = (payload as { input: object }).input;
+            expect(loggedInput).toHaveProperty('RequestItems', {
+                [TableName]: [{ PutRequest: { Item: { pk: 'a', email: 'pii@example.com' } } }],
+            });
         });
     });
 

--- a/packages/aws-wrappers/src/dynamodb/dynamodb.ts
+++ b/packages/aws-wrappers/src/dynamodb/dynamodb.ts
@@ -143,8 +143,9 @@ type WithTypedKey<TInput, K extends Record<string, unknown>> = Omit<TInput, 'Key
  * Wrapper around the AWS DynamoDB Document client providing structured
  * Powertools logging and X-Ray tracing by default.
  *
- * At INFO the log lines omit payloads, secret material and PII; the verbose
- * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+ * Where a method's input carries payloads, secret material or PII, the INFO
+ * log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+ * `TRACE`) log full SDK inputs.
  *
  * Items are automatically marshalled / unmarshalled via the document client —
  * callers work with plain TypeScript objects in both directions.

--- a/packages/aws-wrappers/src/dynamodb/dynamodb.ts
+++ b/packages/aws-wrappers/src/dynamodb/dynamodb.ts
@@ -30,7 +30,7 @@ import {
     UpdateCommandOutput,
 } from '@aws-sdk/lib-dynamodb';
 import xray from 'aws-xray-sdk-core';
-import { filterFieldsForLogLevel } from '../util/redact.js';
+import { filterFieldsForLogLevel, shouldLogFullInput } from '../util/redact.js';
 
 const BATCH_WRITE_MAX_ATTEMPTS = 5;
 const BATCH_WRITE_BASE_DELAY_MS = 200;
@@ -317,13 +317,13 @@ export class DynamoDBService {
      * Callers should narrow the result type at the call site.
      */
     async batchGet(input: BatchGetCommandInput): Promise<BatchGetCommandOutput> {
-        // Inline DEBUG check rather than `filterFieldsForLogLevel` because
+        // Inline verbosity check rather than `filterFieldsForLogLevel` because
         // `RequestItems` is a `Record<tableName, KeysAndAttributes>` — the
         // payload (`Keys[]`) lives inside the value, not as a top-level key
         // the helper could pick or drop.
-        const isDebug = this.logger.getLevelName() === 'DEBUG';
+        const logFullInput = shouldLogFullInput(this.logger);
         this.logger.info('Batch getting DynamoDB items', {
-            input: isDebug ? input : { tables: Object.keys(input.RequestItems ?? {}) },
+            input: logFullInput ? input : { tables: Object.keys(input.RequestItems ?? {}) },
         });
         return this.client.send(new BatchGetCommand(input));
     }
@@ -334,13 +334,13 @@ export class DynamoDBService {
      * items remain unprocessed after the final attempt.
      */
     async batchWrite(input: BatchWriteCommandInput): Promise<BatchWriteCommandOutput> {
-        // Inline DEBUG check rather than `filterFieldsForLogLevel` because
+        // Inline verbosity check rather than `filterFieldsForLogLevel` because
         // `RequestItems` is a `Record<tableName, WriteRequest[]>` — the
         // payload (`PutRequest.Item` / `DeleteRequest.Key`) lives inside the
         // value, not as a top-level key the helper could pick or drop.
-        const isDebug = this.logger.getLevelName() === 'DEBUG';
+        const logFullInput = shouldLogFullInput(this.logger);
         this.logger.info('Batch writing DynamoDB items', {
-            input: isDebug ? input : { tables: Object.keys(input.RequestItems ?? {}) },
+            input: logFullInput ? input : { tables: Object.keys(input.RequestItems ?? {}) },
         });
         let current = input;
         for (let attempt = 0; attempt < BATCH_WRITE_MAX_ATTEMPTS; attempt++) {

--- a/packages/aws-wrappers/src/dynamodb/dynamodb.ts
+++ b/packages/aws-wrappers/src/dynamodb/dynamodb.ts
@@ -37,7 +37,6 @@ const BATCH_WRITE_BASE_DELAY_MS = 200;
 
 /**
  * Fields safe to log at INFO. Omits `Key` (may carry customer IDs / tenant IDs).
- * `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full input.
  */
 const GET_ITEM_SAFE_FIELDS: ReadonlyArray<keyof GetCommandInput> = [
     'TableName',
@@ -50,7 +49,6 @@ const GET_ITEM_SAFE_FIELDS: ReadonlyArray<keyof GetCommandInput> = [
 /**
  * Fields safe to log at INFO. Omits `Item` (the payload itself) and
  * `ExpressionAttributeValues` (values bound to ConditionExpression, often PII).
- * `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full input.
  */
 const PUT_ITEM_SAFE_FIELDS: ReadonlyArray<keyof PutCommandInput> = [
     'TableName',
@@ -64,7 +62,6 @@ const PUT_ITEM_SAFE_FIELDS: ReadonlyArray<keyof PutCommandInput> = [
 
 /**
  * Fields safe to log at INFO. Omits `Key` and `ExpressionAttributeValues`.
- * `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full input.
  */
 const UPDATE_ITEM_SAFE_FIELDS: ReadonlyArray<keyof UpdateCommandInput> = [
     'TableName',
@@ -80,7 +77,6 @@ const UPDATE_ITEM_SAFE_FIELDS: ReadonlyArray<keyof UpdateCommandInput> = [
 /**
  * Fields safe to log at INFO. Omits `Key` and `ExpressionAttributeValues`
  * (the latter binds to ConditionExpression and may carry PII).
- * `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full input.
  */
 const DELETE_ITEM_SAFE_FIELDS: ReadonlyArray<keyof DeleteCommandInput> = [
     'TableName',
@@ -95,8 +91,7 @@ const DELETE_ITEM_SAFE_FIELDS: ReadonlyArray<keyof DeleteCommandInput> = [
 /**
  * Fields safe to log at INFO for `query` and `paginateItems`. Omits
  * `ExpressionAttributeValues` (values often carry PII) and `ExclusiveStartKey`
- * (pagination cursor includes Key shape). `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks
- * the full input.
+ * (pagination cursor includes Key shape).
  */
 const QUERY_SAFE_FIELDS: ReadonlyArray<keyof QueryCommandInput> = [
     'TableName',
@@ -115,7 +110,6 @@ const QUERY_SAFE_FIELDS: ReadonlyArray<keyof QueryCommandInput> = [
 /**
  * Fields safe to log at INFO for `scan` and `paginateScan`. Omits
  * `ExpressionAttributeValues` and `ExclusiveStartKey`.
- * `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full input.
  */
 const SCAN_SAFE_FIELDS: ReadonlyArray<keyof ScanCommandInput> = [
     'TableName',
@@ -148,6 +142,9 @@ type WithTypedKey<TInput, K extends Record<string, unknown>> = Omit<TInput, 'Key
 /**
  * Wrapper around the AWS DynamoDB Document client providing structured
  * Powertools logging and X-Ray tracing by default.
+ *
+ * At INFO the log lines omit payloads, secret material and PII; the verbose
+ * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
  *
  * Items are automatically marshalled / unmarshalled via the document client —
  * callers work with plain TypeScript objects in both directions.

--- a/packages/aws-wrappers/src/s3/s3.test.ts
+++ b/packages/aws-wrappers/src/s3/s3.test.ts
@@ -136,6 +136,20 @@ describe('S3Service', () => {
             expect(loggedInput).not.toHaveProperty('keys');
             expect(loggedInput).toMatchObject({ bucket: Bucket, keyCount: 3 });
         });
+
+        it('logs the full key list at TRACE level', async () => {
+            s3Mock.on(DeleteObjectsCommand).resolves({});
+            const logger = new Logger();
+            logger.setLogLevel('TRACE');
+            const infoSpy = vi.spyOn(logger, 'info');
+            const service = new S3Service({ client: new S3Client({}), logger });
+
+            await service.deleteObjects(Bucket, ['k1', 'k2', 'k3']);
+
+            const [, payload] = infoSpy.mock.calls[0] ?? [];
+            const loggedInput = (payload as { input: object }).input;
+            expect(loggedInput).toEqual({ bucket: Bucket, keys: ['k1', 'k2', 'k3'] });
+        });
     });
 
     describe('emptyBucket', () => {

--- a/packages/aws-wrappers/src/s3/s3.ts
+++ b/packages/aws-wrappers/src/s3/s3.ts
@@ -23,7 +23,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import xray from 'aws-xray-sdk-core';
-import { filterFieldsForLogLevel } from '../util/redact.js';
+import { filterFieldsForLogLevel, shouldLogFullInput } from '../util/redact.js';
 
 const DEFAULT_PRESIGNED_URL_EXPIRES_IN_SECONDS = 3600;
 
@@ -276,12 +276,12 @@ export class S3Service {
      * per chunk.
      */
     async deleteObjects(bucket: string, keys: string[]): Promise<DeleteObjectsCommandOutput[]> {
-        // Inline DEBUG check rather than `filterFieldsForLogLevel` because the
+        // Inline verbosity check rather than `filterFieldsForLogLevel` because the
         // safe log shape includes the computed `keyCount`, which isn't a key
         // on any SDK input type.
-        const isDebug = this.logger.getLevelName() === 'DEBUG';
+        const logFullInput = shouldLogFullInput(this.logger);
         this.logger.info('Deleting S3 objects', {
-            input: isDebug ? { bucket, keys } : { bucket, keyCount: keys.length },
+            input: logFullInput ? { bucket, keys } : { bucket, keyCount: keys.length },
         });
         const results: DeleteObjectsCommandOutput[] = [];
         for (let i = 0; i < keys.length; i += DELETE_OBJECTS_BATCH_LIMIT) {

--- a/packages/aws-wrappers/src/s3/s3.ts
+++ b/packages/aws-wrappers/src/s3/s3.ts
@@ -42,14 +42,12 @@ type PutJsonObjectInput<T> = {
 
 /**
  * Fields safe to log at INFO for `putObject`. Omits `Body` (object payload).
- * `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full input.
  */
 const PUT_OBJECT_SAFE_FIELDS: ReadonlyArray<keyof PutObjectInput> = ['Bucket', 'Key'];
 
 /**
  * Fields safe to log at INFO for `putJsonObject`. Omits `Body` (the
  * unserialised JSON payload). `Metadata` is included (operational labels).
- * `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full input.
  */
 const PUT_JSON_OBJECT_SAFE_FIELDS: ReadonlyArray<keyof PutJsonObjectInput<unknown>> = [
     'Bucket',
@@ -60,6 +58,9 @@ const PUT_JSON_OBJECT_SAFE_FIELDS: ReadonlyArray<keyof PutJsonObjectInput<unknow
 /**
  * Wrapper around the AWS S3 client providing structured Powertools logging
  * and X-Ray tracing by default.
+ *
+ * At INFO the log lines omit payloads, secret material and PII; the verbose
+ * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
  *
  * Input shapes are intentionally tight (Bucket/Key/Body only). Callers
  * needing SDK-level options not exposed here (server-side encryption,

--- a/packages/aws-wrappers/src/s3/s3.ts
+++ b/packages/aws-wrappers/src/s3/s3.ts
@@ -59,8 +59,9 @@ const PUT_JSON_OBJECT_SAFE_FIELDS: ReadonlyArray<keyof PutJsonObjectInput<unknow
  * Wrapper around the AWS S3 client providing structured Powertools logging
  * and X-Ray tracing by default.
  *
- * At INFO the log lines omit payloads, secret material and PII; the verbose
- * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+ * Where a method's input carries payloads, secret material or PII, the INFO
+ * log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+ * `TRACE`) log full SDK inputs.
  *
  * Input shapes are intentionally tight (Bucket/Key/Body only). Callers
  * needing SDK-level options not exposed here (server-side encryption,

--- a/packages/aws-wrappers/src/scheduler/scheduler.test.ts
+++ b/packages/aws-wrappers/src/scheduler/scheduler.test.ts
@@ -22,6 +22,9 @@ const target = {
     RoleArn: 'arn:aws:iam::0:role/test',
 };
 
+/** Both levels unlock `Target.Input` — see `shouldLogFullInput` in `util/redact.ts`. */
+const VERBOSE_LEVELS = ['DEBUG', 'TRACE'] as const;
+
 describe('SchedulerService', () => {
     afterEach(() => {
         schedulerMock.reset();
@@ -115,29 +118,10 @@ describe('SchedulerService', () => {
             expect(loggedTarget).toHaveProperty('Arn', target.Arn);
         });
 
-        it('logs Target.Input at DEBUG level', async () => {
+        it.each(VERBOSE_LEVELS)('logs Target.Input at %s level', async level => {
             schedulerMock.on(CreateScheduleCommand).resolves({ ScheduleArn: 'arn-1' });
             const logger = new Logger();
-            logger.setLogLevel('DEBUG');
-            const infoSpy = vi.spyOn(logger, 'info');
-            const service = new SchedulerService({ client: new SchedulerClient({}), logger });
-
-            await service.createSchedule({
-                Name: 's1',
-                ScheduleExpression: 'rate(1 day)',
-                FlexibleTimeWindow: { Mode: 'OFF' },
-                Target: { ...target, Input: 'payload' },
-            });
-
-            const [, payload] = infoSpy.mock.calls[0] ?? [];
-            const loggedTarget = (payload as { input: { Target: object } }).input.Target;
-            expect(loggedTarget).toHaveProperty('Input', 'payload');
-        });
-
-        it('logs Target.Input at TRACE level', async () => {
-            schedulerMock.on(CreateScheduleCommand).resolves({ ScheduleArn: 'arn-1' });
-            const logger = new Logger();
-            logger.setLogLevel('TRACE');
+            logger.setLogLevel(level);
             const infoSpy = vi.spyOn(logger, 'info');
             const service = new SchedulerService({ client: new SchedulerClient({}), logger });
 
@@ -197,10 +181,10 @@ describe('SchedulerService', () => {
             expect(loggedTarget).toHaveProperty('Arn', target.Arn);
         });
 
-        it('logs Target.Input at DEBUG level', async () => {
+        it.each(VERBOSE_LEVELS)('logs Target.Input at %s level', async level => {
             schedulerMock.on(UpdateScheduleCommand).resolves({ ScheduleArn: 'arn-1' });
             const logger = new Logger();
-            logger.setLogLevel('DEBUG');
+            logger.setLogLevel(level);
             const infoSpy = vi.spyOn(logger, 'info');
             const service = new SchedulerService({ client: new SchedulerClient({}), logger });
 

--- a/packages/aws-wrappers/src/scheduler/scheduler.test.ts
+++ b/packages/aws-wrappers/src/scheduler/scheduler.test.ts
@@ -134,6 +134,25 @@ describe('SchedulerService', () => {
             expect(loggedTarget).toHaveProperty('Input', 'payload');
         });
 
+        it('logs Target.Input at TRACE level', async () => {
+            schedulerMock.on(CreateScheduleCommand).resolves({ ScheduleArn: 'arn-1' });
+            const logger = new Logger();
+            logger.setLogLevel('TRACE');
+            const infoSpy = vi.spyOn(logger, 'info');
+            const service = new SchedulerService({ client: new SchedulerClient({}), logger });
+
+            await service.createSchedule({
+                Name: 's1',
+                ScheduleExpression: 'rate(1 day)',
+                FlexibleTimeWindow: { Mode: 'OFF' },
+                Target: { ...target, Input: 'payload' },
+            });
+
+            const [, payload] = infoSpy.mock.calls[0] ?? [];
+            const loggedTarget = (payload as { input: { Target: object } }).input.Target;
+            expect(loggedTarget).toHaveProperty('Input', 'payload');
+        });
+
         it('leaves the input untouched when the Target has no Input', async () => {
             schedulerMock.on(CreateScheduleCommand).resolves({ ScheduleArn: 'arn-1' });
             const logger = new Logger();

--- a/packages/aws-wrappers/src/scheduler/scheduler.ts
+++ b/packages/aws-wrappers/src/scheduler/scheduler.ts
@@ -48,8 +48,9 @@ import { shouldLogFullInput } from '../util/redact.js';
  * bespoke case: keep every top-level field and shallow-strip only
  * `Target.Input`.
  *
- * At `DEBUG` the input is returned unchanged — operators who set
- * `POWERTOOLS_LOG_LEVEL=DEBUG` have opted into seeing payloads and PII.
+ * At the verbose levels — see {@link shouldLogFullInput} — the input is
+ * returned unchanged: operators who asked for that verbosity have opted into
+ * seeing payloads and PII.
  */
 function redactTargetInput<T extends { Target?: Target | undefined }>(
     logger: LoggerInterface,
@@ -64,6 +65,9 @@ function redactTargetInput<T extends { Target?: Target | undefined }>(
 /**
  * Wrapper around the AWS EventBridge Scheduler client providing structured
  * Powertools logging and X-Ray tracing by default.
+ *
+ * At INFO the log lines omit payloads, secret material and PII; the verbose
+ * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
  *
  * Covers CRUD on schedules and their groups. Named `SchedulerService` (not
  * `EventBridgeSchedulerService`) so it doesn't collide with a future wrapper
@@ -90,8 +94,7 @@ export class SchedulerService {
 
     /**
      * Create a new schedule. At INFO the log line omits `Target.Input` (the
-     * target payload, a PII carrier); `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the
-     * full input.
+     * target payload, a PII carrier).
      */
     async createSchedule(input: CreateScheduleCommandInput): Promise<CreateScheduleCommandOutput> {
         this.logger.info('Creating schedule', { input: redactTargetInput(this.logger, input) });
@@ -117,8 +120,7 @@ export class SchedulerService {
      * your behalf: deep-merging a `Target` (with its mutually-exclusive
      * target-type params) has no single correct semantics.
      *
-     * At INFO the log line omits `Target.Input`; `POWERTOOLS_LOG_LEVEL=DEBUG`
-     * unlocks the full input.
+     * At INFO the log line omits `Target.Input`.
      */
     async updateSchedule(input: UpdateScheduleCommandInput): Promise<UpdateScheduleCommandOutput> {
         this.logger.info('Updating schedule', { input: redactTargetInput(this.logger, input) });

--- a/packages/aws-wrappers/src/scheduler/scheduler.ts
+++ b/packages/aws-wrappers/src/scheduler/scheduler.ts
@@ -32,6 +32,7 @@ import {
     UpdateScheduleCommandOutput,
 } from '@aws-sdk/client-scheduler';
 import xray from 'aws-xray-sdk-core';
+import { shouldLogFullInput } from '../util/redact.js';
 
 /**
  * `CreateSchedule` / `UpdateSchedule` inputs carry the payload handed to the
@@ -54,7 +55,7 @@ function redactTargetInput<T extends { Target?: Target | undefined }>(
     logger: LoggerInterface,
     input: T
 ): T {
-    if (logger.getLevelName() === 'DEBUG') return input;
+    if (shouldLogFullInput(logger)) return input;
     if (input.Target?.Input === undefined) return input;
     const { Input: _input, ...safeTarget } = input.Target;
     return { ...input, Target: safeTarget as Target };

--- a/packages/aws-wrappers/src/scheduler/scheduler.ts
+++ b/packages/aws-wrappers/src/scheduler/scheduler.ts
@@ -66,8 +66,9 @@ function redactTargetInput<T extends { Target?: Target | undefined }>(
  * Wrapper around the AWS EventBridge Scheduler client providing structured
  * Powertools logging and X-Ray tracing by default.
  *
- * At INFO the log lines omit payloads, secret material and PII; the verbose
- * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+ * Where a method's input carries payloads, secret material or PII, the INFO
+ * log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+ * `TRACE`) log full SDK inputs.
  *
  * Covers CRUD on schedules and their groups. Named `SchedulerService` (not
  * `EventBridgeSchedulerService`) so it doesn't collide with a future wrapper

--- a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts
+++ b/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts
@@ -61,8 +61,9 @@ const DELETE_SECRET_SAFE_FIELDS: ReadonlyArray<keyof DeleteSecretCommandInput> =
  * Wrapper around the AWS Secrets Manager client providing structured
  * Powertools logging and X-Ray tracing by default.
  *
- * At INFO the log lines omit payloads, secret material and PII; the verbose
- * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+ * Where a method's input carries payloads, secret material or PII, the INFO
+ * log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+ * `TRACE`) log full SDK inputs.
  *
  * Write operations (`createSecret`, `updateSecret`, `putSecretValue`,
  * `deleteSecret`) are exposed for convenience but should be used with care:

--- a/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts
+++ b/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts
@@ -21,8 +21,7 @@ import { filterFieldsForLogLevel } from '../util/redact.js';
 
 /**
  * Fields safe to log at INFO level. Omits `SecretString` and `SecretBinary` —
- * the secret material itself. `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full
- * input.
+ * the secret material itself.
  */
 const CREATE_SECRET_SAFE_FIELDS: ReadonlyArray<keyof CreateSecretCommandInput> = [
     'Name',
@@ -61,6 +60,9 @@ const DELETE_SECRET_SAFE_FIELDS: ReadonlyArray<keyof DeleteSecretCommandInput> =
 /**
  * Wrapper around the AWS Secrets Manager client providing structured
  * Powertools logging and X-Ray tracing by default.
+ *
+ * At INFO the log lines omit payloads, secret material and PII; the verbose
+ * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
  *
  * Write operations (`createSecret`, `updateSecret`, `putSecretValue`,
  * `deleteSecret`) are exposed for convenience but should be used with care:
@@ -112,8 +114,7 @@ export class SecretsManagerService {
 
     /**
      * Create a new secret. At INFO level the log line includes only identity
-     * and non-secret metadata; `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full
-     * input (including `SecretString` / `SecretBinary`).
+     * and non-secret metadata.
      *
      * Prefer IaC (CDK / Terraform) for secret lifecycle — use this for
      * dynamically-issued credentials only.
@@ -127,8 +128,7 @@ export class SecretsManagerService {
 
     /**
      * Update an existing secret's metadata or value. At INFO level the log
-     * line omits `SecretString` / `SecretBinary`; `POWERTOOLS_LOG_LEVEL=DEBUG`
-     * unlocks the full input.
+     * line omits `SecretString` / `SecretBinary`.
      *
      * Prefer IaC (CDK / Terraform) for secret lifecycle — use this for
      * runtime metadata updates only.
@@ -142,8 +142,7 @@ export class SecretsManagerService {
 
     /**
      * Store a new version of a secret's value. At INFO level the log line
-     * omits `SecretString` / `SecretBinary`; `POWERTOOLS_LOG_LEVEL=DEBUG`
-     * unlocks the full input.
+     * omits `SecretString` / `SecretBinary`.
      *
      * Typically used by rotation flows.
      */

--- a/packages/aws-wrappers/src/sfn/sfn.ts
+++ b/packages/aws-wrappers/src/sfn/sfn.ts
@@ -21,7 +21,7 @@ import { filterFieldsForLogLevel } from '../util/redact.js';
 /**
  * Fields safe to log at INFO for `startExecution`. Omits `input` — the SFN
  * execution payload, which routinely carries PII (customer IDs, addresses,
- * order contents, etc.). `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full input.
+ * order contents, etc.).
  */
 const START_EXECUTION_SAFE_FIELDS: ReadonlyArray<keyof StartExecutionCommandInput> = [
     'stateMachineArn',
@@ -32,6 +32,9 @@ const START_EXECUTION_SAFE_FIELDS: ReadonlyArray<keyof StartExecutionCommandInpu
 /**
  * Wrapper around the AWS Step Functions client providing structured
  * Powertools logging and X-Ray tracing by default.
+ *
+ * At INFO the log lines omit payloads, secret material and PII; the verbose
+ * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
  */
 export class StepFunctionsService {
     private readonly client: SFNClient;

--- a/packages/aws-wrappers/src/sfn/sfn.ts
+++ b/packages/aws-wrappers/src/sfn/sfn.ts
@@ -33,8 +33,9 @@ const START_EXECUTION_SAFE_FIELDS: ReadonlyArray<keyof StartExecutionCommandInpu
  * Wrapper around the AWS Step Functions client providing structured
  * Powertools logging and X-Ray tracing by default.
  *
- * At INFO the log lines omit payloads, secret material and PII; the verbose
- * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+ * Where a method's input carries payloads, secret material or PII, the INFO
+ * log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+ * `TRACE`) log full SDK inputs.
  */
 export class StepFunctionsService {
     private readonly client: SFNClient;

--- a/packages/aws-wrappers/src/sns/sns.test.ts
+++ b/packages/aws-wrappers/src/sns/sns.test.ts
@@ -74,6 +74,25 @@ describe('SNSService', () => {
             expect(loggedInput).toMatchObject({ entryCount: 1 });
         });
 
+        it('logs the full entries at TRACE level', async () => {
+            snsMock.on(PublishBatchCommand).resolves({ Successful: [], Failed: [] });
+            const logger = new Logger();
+            logger.setLogLevel('TRACE');
+            const infoSpy = vi.spyOn(logger, 'info');
+            const service = new SNSService({ client: new SNSClient({}), logger });
+
+            await service.publishBatch({
+                TopicArn: 'arn:aws:sns:us-east-1:0:topic',
+                PublishBatchRequestEntries: [{ Id: '1', Message: 'shh' }],
+            });
+
+            const [, payload] = infoSpy.mock.calls[0] ?? [];
+            const loggedInput = (payload as { input: object }).input;
+            expect(loggedInput).toHaveProperty('PublishBatchRequestEntries', [
+                { Id: '1', Message: 'shh' },
+            ]);
+        });
+
         it('returns an empty array when entries are empty or undefined', async () => {
             const service = new SNSService({ client: new SNSClient({}) });
 

--- a/packages/aws-wrappers/src/sns/sns.ts
+++ b/packages/aws-wrappers/src/sns/sns.ts
@@ -11,7 +11,7 @@ import {
     SNSClient,
 } from '@aws-sdk/client-sns';
 import xray from 'aws-xray-sdk-core';
-import { filterFieldsForLogLevel } from '../util/redact.js';
+import { filterFieldsForLogLevel, shouldLogFullInput } from '../util/redact.js';
 import { truncateCodepoints, truncateUtf8 } from '../util/truncate.js';
 
 const PUBLISH_BATCH_LIMIT = 10;
@@ -106,12 +106,12 @@ export class SNSService {
      */
     async publishBatch(input: PublishBatchCommandInput): Promise<PublishBatchCommandOutput[]> {
         const entries: PublishBatchRequestEntry[] = input.PublishBatchRequestEntries ?? [];
-        // Inline DEBUG check rather than `filterFieldsForLogLevel` because the
+        // Inline verbosity check rather than `filterFieldsForLogLevel` because the
         // safe log shape includes the computed `entryCount`, which isn't a key
         // on `PublishBatchCommandInput`.
-        const isDebug = this.logger.getLevelName() === 'DEBUG';
+        const logFullInput = shouldLogFullInput(this.logger);
         this.logger.info('Publishing SNS message batch', {
-            input: isDebug ? input : { TopicArn: input.TopicArn, entryCount: entries.length },
+            input: logFullInput ? input : { TopicArn: input.TopicArn, entryCount: entries.length },
         });
         const results: PublishBatchCommandOutput[] = [];
         for (let i = 0; i < entries.length; i += PUBLISH_BATCH_LIMIT) {

--- a/packages/aws-wrappers/src/sns/sns.ts
+++ b/packages/aws-wrappers/src/sns/sns.ts
@@ -22,7 +22,7 @@ const SNS_SUBJECT_MAX_CHARS = 100;
  * Fields safe to log at INFO level for `publish`. Omits `Message`, `Subject`,
  * `MessageAttributes`, and `PhoneNumber` — payloads, user-visible content
  * (subjects often carry order numbers / customer names), and PII recipient
- * identifiers. `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full input.
+ * identifiers.
  */
 const PUBLISH_SAFE_FIELDS: ReadonlyArray<keyof PublishCommandInput> = [
     'TopicArn',
@@ -35,6 +35,9 @@ const PUBLISH_SAFE_FIELDS: ReadonlyArray<keyof PublishCommandInput> = [
 /**
  * Wrapper around the AWS SNS client providing structured Powertools logging
  * and X-Ray tracing by default.
+ *
+ * At INFO the log lines omit payloads, secret material and PII; the verbose
+ * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
  */
 export class SNSService {
     private readonly client: SNSClient;
@@ -62,8 +65,7 @@ export class SNSService {
      * Publish a single message to an SNS topic.
      *
      * At INFO level the log line includes only routing / dedup metadata; see
-     * `PUBLISH_SAFE_FIELDS` for the list. Setting `POWERTOOLS_LOG_LEVEL=DEBUG`
-     * unlocks the full input.
+     * `PUBLISH_SAFE_FIELDS` for the list.
      *
      * @param input - PublishCommandInput including TopicArn and Message.
      */

--- a/packages/aws-wrappers/src/sns/sns.ts
+++ b/packages/aws-wrappers/src/sns/sns.ts
@@ -36,8 +36,9 @@ const PUBLISH_SAFE_FIELDS: ReadonlyArray<keyof PublishCommandInput> = [
  * Wrapper around the AWS SNS client providing structured Powertools logging
  * and X-Ray tracing by default.
  *
- * At INFO the log lines omit payloads, secret material and PII; the verbose
- * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+ * Where a method's input carries payloads, secret material or PII, the INFO
+ * log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+ * `TRACE`) log full SDK inputs.
  */
 export class SNSService {
     private readonly client: SNSClient;

--- a/packages/aws-wrappers/src/sqs/sqs.test.ts
+++ b/packages/aws-wrappers/src/sqs/sqs.test.ts
@@ -90,6 +90,23 @@ describe('SQSService', () => {
             expect(loggedInput).not.toHaveProperty('Entries');
             expect(loggedInput).toMatchObject({ entryCount: 1 });
         });
+
+        it('logs the full entries at TRACE level', async () => {
+            sqsMock.on(SendMessageBatchCommand).resolves({ Successful: [], Failed: [] });
+            const logger = new Logger();
+            logger.setLogLevel('TRACE');
+            const infoSpy = vi.spyOn(logger, 'info');
+            const service = new SQSService({ client: new SQSClient({}), logger });
+
+            await service.sendMessageBatch({
+                QueueUrl,
+                Entries: [{ Id: '1', MessageBody: 'shh' }],
+            });
+
+            const [, payload] = infoSpy.mock.calls[0] ?? [];
+            const loggedInput = (payload as { input: object }).input;
+            expect(loggedInput).toHaveProperty('Entries', [{ Id: '1', MessageBody: 'shh' }]);
+        });
     });
 
     describe('pass-through commands', () => {
@@ -231,6 +248,23 @@ describe('SQSService', () => {
             const loggedInput = (payload as { input: object }).input;
             expect(loggedInput).not.toHaveProperty('Entries');
             expect(loggedInput).toMatchObject({ entryCount: 1 });
+        });
+
+        it('logs the full entries at TRACE level', async () => {
+            sqsMock.on(DeleteMessageBatchCommand).resolves({ Successful: [], Failed: [] });
+            const logger = new Logger();
+            logger.setLogLevel('TRACE');
+            const infoSpy = vi.spyOn(logger, 'info');
+            const service = new SQSService({ client: new SQSClient({}), logger });
+
+            await service.deleteMessageBatch({
+                QueueUrl,
+                Entries: [{ Id: '1', ReceiptHandle: 'handle' }],
+            });
+
+            const [, payload] = infoSpy.mock.calls[0] ?? [];
+            const loggedInput = (payload as { input: object }).input;
+            expect(loggedInput).toHaveProperty('Entries', [{ Id: '1', ReceiptHandle: 'handle' }]);
         });
     });
 });

--- a/packages/aws-wrappers/src/sqs/sqs.ts
+++ b/packages/aws-wrappers/src/sqs/sqs.ts
@@ -42,8 +42,9 @@ const SEND_MESSAGE_SAFE_FIELDS: ReadonlyArray<keyof SendMessageCommandInput> = [
  * Wrapper around the AWS SQS client providing structured Powertools logging
  * and X-Ray tracing by default.
  *
- * At INFO the log lines omit payloads, secret material and PII; the verbose
- * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+ * Where a method's input carries payloads, secret material or PII, the INFO
+ * log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+ * `TRACE`) log full SDK inputs.
  */
 export class SQSService {
     private readonly client: SQSClient;

--- a/packages/aws-wrappers/src/sqs/sqs.ts
+++ b/packages/aws-wrappers/src/sqs/sqs.ts
@@ -21,7 +21,7 @@ import {
     SQSClient,
 } from '@aws-sdk/client-sqs';
 import xray from 'aws-xray-sdk-core';
-import { filterFieldsForLogLevel } from '../util/redact.js';
+import { filterFieldsForLogLevel, shouldLogFullInput } from '../util/redact.js';
 import { truncateUtf8 } from '../util/truncate.js';
 
 const SQS_BATCH_LIMIT = 10;
@@ -128,12 +128,12 @@ export class SQSService {
         input: SendMessageBatchCommandInput
     ): Promise<SendMessageBatchCommandOutput[]> {
         const entries: SendMessageBatchRequestEntry[] = input.Entries ?? [];
-        // Inline DEBUG check rather than `filterFieldsForLogLevel` because the
+        // Inline verbosity check rather than `filterFieldsForLogLevel` because the
         // safe log shape includes the computed `entryCount`, which isn't a key
         // on `SendMessageBatchCommandInput`.
-        const isDebug = this.logger.getLevelName() === 'DEBUG';
+        const logFullInput = shouldLogFullInput(this.logger);
         this.logger.info('Sending SQS message batch', {
-            input: isDebug ? input : { QueueUrl: input.QueueUrl, entryCount: entries.length },
+            input: logFullInput ? input : { QueueUrl: input.QueueUrl, entryCount: entries.length },
         });
         const results: SendMessageBatchCommandOutput[] = [];
         for (let i = 0; i < entries.length; i += SQS_BATCH_LIMIT) {
@@ -154,12 +154,12 @@ export class SQSService {
         input: DeleteMessageBatchCommandInput
     ): Promise<DeleteMessageBatchCommandOutput[]> {
         const entries: DeleteMessageBatchRequestEntry[] = input.Entries ?? [];
-        // Inline DEBUG check rather than `filterFieldsForLogLevel` because the
+        // Inline verbosity check rather than `filterFieldsForLogLevel` because the
         // safe log shape includes the computed `entryCount`, which isn't a key
         // on `DeleteMessageBatchCommandInput`.
-        const isDebug = this.logger.getLevelName() === 'DEBUG';
+        const logFullInput = shouldLogFullInput(this.logger);
         this.logger.info('Deleting SQS message batch', {
-            input: isDebug ? input : { QueueUrl: input.QueueUrl, entryCount: entries.length },
+            input: logFullInput ? input : { QueueUrl: input.QueueUrl, entryCount: entries.length },
         });
         const results: DeleteMessageBatchCommandOutput[] = [];
         for (let i = 0; i < entries.length; i += SQS_BATCH_LIMIT) {

--- a/packages/aws-wrappers/src/sqs/sqs.ts
+++ b/packages/aws-wrappers/src/sqs/sqs.ts
@@ -30,7 +30,6 @@ const SQS_MESSAGE_BODY_MAX_BYTES = 256 * 1024;
 /**
  * Fields safe to log at INFO level for `sendMessage`. Omits `MessageBody` and
  * `MessageAttributes` — both carry payload content.
- * `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full input.
  */
 const SEND_MESSAGE_SAFE_FIELDS: ReadonlyArray<keyof SendMessageCommandInput> = [
     'QueueUrl',
@@ -42,6 +41,9 @@ const SEND_MESSAGE_SAFE_FIELDS: ReadonlyArray<keyof SendMessageCommandInput> = [
 /**
  * Wrapper around the AWS SQS client providing structured Powertools logging
  * and X-Ray tracing by default.
+ *
+ * At INFO the log lines omit payloads, secret material and PII; the verbose
+ * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
  */
 export class SQSService {
     private readonly client: SQSClient;
@@ -68,8 +70,7 @@ export class SQSService {
      * Send a single message to an SQS queue.
      *
      * At INFO level the log line includes only queue routing / FIFO metadata;
-     * see `SEND_MESSAGE_SAFE_FIELDS`. `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the
-     * full input.
+     * see `SEND_MESSAGE_SAFE_FIELDS`.
      */
     async sendMessage(
         input: SendMessageCommandInput,

--- a/packages/aws-wrappers/src/ssm/ssm.ts
+++ b/packages/aws-wrappers/src/ssm/ssm.ts
@@ -16,8 +16,7 @@ import { filterFieldsForLogLevel } from '../util/redact.js';
 
 /**
  * Fields safe to log at INFO level for `putParameter`. Omits `Value` (the
- * parameter content itself). `POWERTOOLS_LOG_LEVEL=DEBUG` unlocks the full
- * input.
+ * parameter content itself).
  */
 const PUT_PARAMETER_SAFE_FIELDS: ReadonlyArray<keyof PutParameterCommandInput> = [
     'Name',
@@ -37,6 +36,9 @@ const PUT_PARAMETER_SAFE_FIELDS: ReadonlyArray<keyof PutParameterCommandInput> =
  * Powertools logging and X-Ray tracing by default. All read operations enable
  * `WithDecryption` — callers needing plaintext should use `SSMClient`
  * directly.
+ *
+ * At INFO the log lines omit payloads, secret material and PII; the verbose
+ * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
  *
  * Write operations (`putParameter`, `deleteParameter`) are exposed for
  * convenience but should be used with care: parameter lifecycle is usually

--- a/packages/aws-wrappers/src/ssm/ssm.ts
+++ b/packages/aws-wrappers/src/ssm/ssm.ts
@@ -37,8 +37,9 @@ const PUT_PARAMETER_SAFE_FIELDS: ReadonlyArray<keyof PutParameterCommandInput> =
  * `WithDecryption` — callers needing plaintext should use `SSMClient`
  * directly.
  *
- * At INFO the log lines omit payloads, secret material and PII; the verbose
- * levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or `TRACE`) log full SDK inputs.
+ * Where a method's input carries payloads, secret material or PII, the INFO
+ * log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
+ * `TRACE`) log full SDK inputs.
  *
  * Write operations (`putParameter`, `deleteParameter`) are exposed for
  * convenience but should be used with care: parameter lifecycle is usually

--- a/packages/aws-wrappers/src/util/redact.test.ts
+++ b/packages/aws-wrappers/src/util/redact.test.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@aws-lambda-powertools/logger';
+import type { LogLevel } from '@aws-lambda-powertools/logger/types';
 import { describe, expect, it } from 'vitest';
 import { filterFieldsForLogLevel, shouldLogFullInput } from './redact';
 
@@ -6,7 +7,7 @@ import { filterFieldsForLogLevel, shouldLogFullInput } from './redact';
  * Levels must be uppercase — `setLogLevel('trace')` throws, despite Powertools'
  * `LogLevel` type admitting lowercase spellings.
  */
-type Level = 'TRACE' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'CRITICAL' | 'SILENT';
+type Level = Uppercase<LogLevel>;
 
 const buildLogger = (level: Level) => {
     const logger = new Logger();
@@ -15,17 +16,25 @@ const buildLogger = (level: Level) => {
 };
 
 describe('shouldLogFullInput', () => {
-    // Powertools orders TRACE (6) as more verbose than DEBUG (8), so both
-    // unlock. The boundary sits between DEBUG and INFO.
-    const cases: Array<[Level, boolean]> = [
-        ['TRACE', true],
-        ['DEBUG', true],
-        ['INFO', false],
-        ['WARN', false],
-        ['ERROR', false],
-        ['CRITICAL', false],
-        ['SILENT', false],
-    ];
+    /**
+     * Powertools orders TRACE (6) as more verbose than DEBUG (8), so both
+     * unlock. The boundary sits between DEBUG and INFO.
+     *
+     * Typed as a `Record` over every level rather than an array of cases: if
+     * Powertools adds a level, this stops compiling instead of silently
+     * leaving the new level untested.
+     */
+    const unlocksByLevel: Record<Level, boolean> = {
+        TRACE: true,
+        DEBUG: true,
+        INFO: false,
+        WARN: false,
+        ERROR: false,
+        CRITICAL: false,
+        SILENT: false,
+    };
+
+    const cases = Object.entries(unlocksByLevel) as Array<[Level, boolean]>;
 
     it.each(cases)('at %s level returns %s', (level, expected) => {
         expect(shouldLogFullInput(buildLogger(level))).toBe(expected);

--- a/packages/aws-wrappers/src/util/redact.test.ts
+++ b/packages/aws-wrappers/src/util/redact.test.ts
@@ -1,12 +1,36 @@
 import { Logger } from '@aws-lambda-powertools/logger';
 import { describe, expect, it } from 'vitest';
-import { filterFieldsForLogLevel } from './redact';
+import { filterFieldsForLogLevel, shouldLogFullInput } from './redact';
 
-const buildLogger = (level: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR') => {
+/**
+ * Levels must be uppercase — `setLogLevel('trace')` throws, despite Powertools'
+ * `LogLevel` type admitting lowercase spellings.
+ */
+type Level = 'TRACE' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'CRITICAL' | 'SILENT';
+
+const buildLogger = (level: Level) => {
     const logger = new Logger();
     logger.setLogLevel(level);
     return logger;
 };
+
+describe('shouldLogFullInput', () => {
+    // Powertools orders TRACE (6) as more verbose than DEBUG (8), so both
+    // unlock. The boundary sits between DEBUG and INFO.
+    const cases: Array<[Level, boolean]> = [
+        ['TRACE', true],
+        ['DEBUG', true],
+        ['INFO', false],
+        ['WARN', false],
+        ['ERROR', false],
+        ['CRITICAL', false],
+        ['SILENT', false],
+    ];
+
+    it.each(cases)('at %s level returns %s', (level, expected) => {
+        expect(shouldLogFullInput(buildLogger(level))).toBe(expected);
+    });
+});
 
 describe('filterFieldsForLogLevel', () => {
     it('returns only the listed fields when the logger is at INFO level', () => {
@@ -17,7 +41,7 @@ describe('filterFieldsForLogLevel', () => {
         expect(result).toEqual({ TopicArn: 'arn' });
     });
 
-    it('returns the full input when the logger is at DEBUG level', () => {
+    it('returns the full input at DEBUG level', () => {
         const input = { TopicArn: 'arn', Message: 'shh', Subject: 'private' };
 
         const result = filterFieldsForLogLevel(buildLogger('DEBUG'), input, ['TopicArn']);
@@ -25,7 +49,15 @@ describe('filterFieldsForLogLevel', () => {
         expect(result).toEqual(input);
     });
 
-    it('returns the safe subset at WARN level too (only DEBUG unlocks)', () => {
+    it('returns the full input at TRACE level', () => {
+        const input = { TopicArn: 'arn', Message: 'shh', Subject: 'private' };
+
+        const result = filterFieldsForLogLevel(buildLogger('TRACE'), input, ['TopicArn']);
+
+        expect(result).toEqual(input);
+    });
+
+    it('returns the safe subset at WARN level too', () => {
         const input = { TopicArn: 'arn', Message: 'shh' };
 
         const result = filterFieldsForLogLevel(buildLogger('WARN'), input, ['TopicArn']);

--- a/packages/aws-wrappers/src/util/redact.ts
+++ b/packages/aws-wrappers/src/util/redact.ts
@@ -1,4 +1,19 @@
+import { LogLevelThreshold } from '@aws-lambda-powertools/logger';
 import type { LoggerInterface } from '@aws-lambda-powertools/logger/types';
+
+/**
+ * Whether the logger is verbose enough that full SDK inputs — payloads, secret
+ * material and PII — may be written to the log.
+ *
+ * **This is the only place in the package that reads the log level.** Never
+ * compare `logger.getLevelName()` yourself: Powertools orders `TRACE` as *more*
+ * verbose than `DEBUG` (thresholds 6 and 8), so the obvious
+ * `getLevelName() === 'DEBUG'` check silently redacts at the most verbose level
+ * available. Route every disclosure decision through this predicate instead.
+ */
+export function shouldLogFullInput(logger: LoggerInterface): boolean {
+    return LogLevelThreshold[logger.getLevelName()] <= LogLevelThreshold.DEBUG;
+}
 
 /**
  * Return a log-safe projection of `input` based on the logger's configured level.
@@ -21,7 +36,7 @@ export function filterFieldsForLogLevel<T extends object, K extends keyof T>(
     input: T,
     safeFields: readonly K[]
 ): T | Pick<T, K> {
-    if (logger.getLevelName() === 'DEBUG') return input;
+    if (shouldLogFullInput(logger)) return input;
     const out = {} as Pick<T, K>;
     for (const key of safeFields) {
         if (key in input) out[key] = input[key];

--- a/packages/aws-wrappers/src/util/redact.ts
+++ b/packages/aws-wrappers/src/util/redact.ts
@@ -18,10 +18,9 @@ export function shouldLogFullInput(logger: LoggerInterface): boolean {
 /**
  * Return a log-safe projection of `input` based on the logger's configured level.
  *
- * At `DEBUG`, the full input is returned unchanged — operators who set
- * `POWERTOOLS_LOG_LEVEL=DEBUG` (or call `logger.setLogLevel('DEBUG')`) have
- * explicitly opted into seeing everything, including payloads, secret material
- * and PII.
+ * At the verbose levels — see {@link shouldLogFullInput} — the full input is
+ * returned unchanged: operators who asked for that verbosity have explicitly
+ * opted into seeing everything, including payloads, secret material and PII.
  *
  * At any other level, only the fields listed in `safeFields` are included.
  * Missing fields are silently skipped — the result type narrows to


### PR DESCRIPTION
**Description of the proposed changes**

- Every log-redaction decision in `@aligent/aws-wrappers` gated on `logger.getLevelName() === 'DEBUG'`. Powertools orders `TRACE` (threshold 6) as **more** verbose than `DEBUG` (8), so `POWERTOOLS_LOG_LEVEL=TRACE` silently redacted payloads at the most verbose level available — the opposite of what an operator asking for TRACE wants.
- Root cause was duplication: the rule was documented as living in one place but was implemented eight times. Seven were copies made because the shared helper couldn't express their safe shape. Because the exemplar was wrong, every copy inherited the bug.
- Adds `shouldLogFullInput(logger)` in `src/util/redact.ts` as the single authority (`LogLevelThreshold[getLevelName()] <= LogLevelThreshold.DEBUG`) and routes all eight sites through it: `filterFieldsForLogLevel`, `redactTargetInput` (scheduler), and the six inline checks in `s3.ts`, `sns.ts`, `sqs.ts` ×2, `dynamodb.ts` ×2.
- Collapses 22 TSDoc restatements of the unlock mechanism to one per service class. Per-method and per-`SAFE_FIELDS` docs now carry only *what* is omitted and *why* — the genuinely per-method part. `README.md`, `CLAUDE.md` and `docs/` updated to match.

⚠️ **Behaviour change — classified `minor`, not `patch`.** Environments already running at `TRACE` will begin logging full SDK inputs (`SecretString`, SQS/SNS message bodies, DynamoDB items and keys, SFN execution inputs) to CloudWatch. Review any `TRACE`-level deployments before upgrading. A patch could be auto-merged by Renovate with nobody reading the note; the version plan carries the operator-facing warning.

**Other solutions considered (if any)**

- **Keep DEBUG-only and document it as deliberate.** Rejected — "TRACE shows you less than DEBUG" is a permanent footgun that every future reader re-reports as a bug.
- **Decouple disclosure from log level** behind a dedicated flag. Cleanest security story, but it breaks a locked-in package convention and adds a second control surface. Level-driven disclosure stays.
- **A `logSafeInput(logger, full, safe)` helper** to collapse the six inline sites. Rejected: swapping the two positional arguments leaks payloads with no type error, since both are `object`. Bad failure mode for a security-relevant helper.
- **An ESLint rule** banning `getLevelName()` comparisons outside `redact.ts`. Rejected as marginal — the bug spread by copy-paste, so fixing the exemplar removes the mechanism. `grep -rl LogLevelThreshold src/` returning `1` is the checkable invariant instead.

**Notes to reviewers**

- 🛈 Toggl Code: _MI-332: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

Reviewing in commit order is easiest — `0505887` is the behaviour change, `62f85a7` is mechanical doc churn across 8 files plus regenerated `docs/`.

Worth a closer look:

- **`src/util/redact.ts`** — the whole fix is three lines. Everything else follows from it.
- **The six new TRACE unlock tests.** The pre-existing INFO assertions only pin the *redacted* direction, so a site left on the old comparison would have passed the entire suite green. Mutation-tested: reverting `s3.ts` to `getLevelName() === 'DEBUG'` fails exactly the new TRACE test and nothing else.
- **`docs/` links** are stamped with commit `a2bb34f`. That is intentional and correct — `git diff a2bb34f HEAD -- packages/aws-wrappers/src` is empty, so they resolve to the shipped source. Re-running typedoc will show a 70-line diff that is *only* the embedded SHA; it is not drift. (A first attempt did have genuinely wrong links, generated before the TSDoc commit landed — fixed in `e80d53a`.)

Verified at the repo root: `lint`, `check-types`, `test` green. 146 tests, coverage 99.09% statements / 90.13% branch against the 80% gate.

Out of scope, raised separately: `emptyBucket` swallowing per-key `DeleteObjects` errors; SNS/SQS truncation budgeting a single field against a whole-payload cap (and producing invalid JSON under `MessageStructure: 'json'`); `sideEffects: false` plus subpath exports; DynamoDB batch chunking; and a CI gate for the recurring typedoc-regeneration drift.
