### PR TITLE
MI-333: fix aws-wrappers ES5 compile target, and tighten truncation/pagination contracts

### DIFF
--- a/.nx/version-plans/version-plan-1785725972000.md
+++ b/.nx/version-plans/version-plan-1785725972000.md
@@ -10,7 +10,7 @@ The published build now targets ES2022 rather than ES5, so **ESM consumers** can
 
 Also in this release:
 
-- `SNS.publish` and `SQS.sendMessage` no longer state each truncation limit twice, removing a latent path where an oversized payload could be warned about but not truncated, or truncated without a warning. `publish` also stops adding an empty `Subject` to inputs that omitted one.
+- `SNS.publish` and `SQS.sendMessage` no longer state each truncation limit twice. No behaviour change — the two checks were the same computation against the same constant and could not disagree — but the limit now has a single source of truth, and an oversized payload is UTF-8 encoded once instead of twice. `publish` also no longer copies an unset `Subject` through as an explicit `undefined`; the SDK skipped it either way, so this is shape-only.
 - `S3.emptyBucket` documents its contract as **unversioned buckets only**. It paginates `ListObjectsV2`, which never reports noncurrent versions or delete markers, so against a versioned bucket it succeeds and leaves the bucket populated. Behaviour is unchanged; the limitation is now stated.
 - `DynamoDB.paginateItems` / `paginateScan` document that `Limit` is a page size, not a total cap — `{ Limit: 10 }` yields every matching item in pages of 10. `break` out of the loop to bound the read.
 

--- a/.nx/version-plans/version-plan-1785725972000.md
+++ b/.nx/version-plans/version-plan-1785725972000.md
@@ -1,0 +1,17 @@
+---
+aws-wrappers: minor
+---
+
+The published build now targets ES2022 rather than ES5, so **ESM consumers** can tree-shake unused services — importing a single wrapper no longer pulls in every AWS SDK client. Measured against a real Lambda handler importing only `SSMService`: 1.57 MB → 1.10 MB bundled with Vite (−30%), and 2.93 MB → 2.06 MB with esbuild (−30%). The package's own published bundle is roughly half its previous size.
+
+**CJS consumers see no pruning** (−0.8%, which is just the smaller library file). `require` is resolved dynamically, so a CJS entry point cannot be statically tree-shaken — that is a property of the module format, not something this change can address. CJS consumers still get native classes and no `tslib` downlevel helpers.
+
+**Requires a Node 18+ runtime.** The emitted JavaScript changes: classes are emitted natively rather than as ES5 IIFEs, and `async`/`await` no longer downlevels to `tslib` generator helpers. Consumers on older runtimes should stay on 0.3.x.
+
+Also in this release:
+
+- `SNS.publish` and `SQS.sendMessage` no longer state each truncation limit twice, removing a latent path where an oversized payload could be warned about but not truncated, or truncated without a warning. `publish` also stops adding an empty `Subject` to inputs that omitted one.
+- `S3.emptyBucket` documents its contract as **unversioned buckets only**. It paginates `ListObjectsV2`, which never reports noncurrent versions or delete markers, so against a versioned bucket it succeeds and leaves the bucket populated. Behaviour is unchanged; the limitation is now stated.
+- `DynamoDB.paginateItems` / `paginateScan` document that `Limit` is a page size, not a total cap — `{ Limit: 10 }` yields every matching item in pages of 10. `break` out of the loop to bound the read.
+
+Released as a minor rather than a patch because the emitted JavaScript changes, which is consumer-visible.

--- a/packages/aws-wrappers/README.md
+++ b/packages/aws-wrappers/README.md
@@ -71,10 +71,12 @@ const uploadUrl = await s3.getPresignedUrl({
 
 await s3.deleteObject({ Bucket: 'my-bucket', Key: 'file.txt' });
 await s3.deleteObjects('my-bucket', ['key1', 'key2']); // auto-chunked to 1000 keys per request
-await s3.emptyBucket('my-bucket');                     // streams the listing + delegates each page to deleteObjects
+await s3.emptyBucket('my-bucket');                     // unversioned buckets only — see below
 ```
 
 Input shapes are intentionally tight (`Bucket`, `Key`, `Body` and similar). Callers needing SDK-specific options like server-side encryption or tagging should use `S3Client` directly.
+
+`emptyBucket` streams the listing page-by-page and delegates each page to `deleteObjects`, so peak memory stays bounded by one page regardless of bucket size. It empties **unversioned buckets only**: it paginates `ListObjectsV2`, which reports current object versions and never noncurrent versions or delete markers. Against a versioned bucket the call succeeds and leaves the bucket non-empty, because the deletes add delete markers rather than removing data. Emptying a versioned bucket needs `ListObjectVersions` plus per-version deletes — use `S3Client` directly.
 
 ## DynamoDB
 

--- a/packages/aws-wrappers/README.md
+++ b/packages/aws-wrappers/README.md
@@ -140,7 +140,22 @@ for await (const item of ddb.paginateItems<{ pk: string }>({
 for await (const item of ddb.paginateScan<{ pk: string }>({ TableName: 'my-table' })) {
     console.log(item.pk);
 }
+
+// `Limit` is a PAGE SIZE, not a total cap — this walks the whole result set
+// in pages of 10, it does not stop after 10 items. `break` to bound the read.
+const firstTen: Array<{ pk: string }> = [];
+for await (const item of ddb.paginateItems<{ pk: string }>({
+    TableName: 'my-table',
+    KeyConditionExpression: 'pk = :pk',
+    ExpressionAttributeValues: { ':pk': 'abc' },
+    Limit: 10,
+})) {
+    firstTen.push(item);
+    if (firstTen.length === 10) break; // stops immediately — no further requests
+}
 ```
+
+`Limit` on `paginateItems` / `paginateScan` is applied by DynamoDB per request, and both methods walk every page until `LastEvaluatedKey` is exhausted. Passing `Limit: 10` therefore yields *every* matching item in pages of 10, not the first 10. Because both return an `AsyncGenerator`, `break` calls its `return()`, which unwinds the pagination and issues no further requests — that is how you bound the number of items. `Limit` is still the right knob for tuning per-request consumed capacity and page memory; it just doesn't stop the walk.
 
 `batchGet` is **not** generic — its `Responses` field is a multi-table record whose item shapes can differ per table, so no single generic can soundly describe it. Callers should narrow the result type at the call site.
 

--- a/packages/aws-wrappers/README.md
+++ b/packages/aws-wrappers/README.md
@@ -8,6 +8,8 @@ Opinionated AWS SDK wrappers with Powertools logging and X-Ray tracing baked in.
 npm install @aligent/aws-wrappers
 ```
 
+Requires **Node 18 or later**. The package is compiled to ES2022 and ships native `class` declarations, so older runtimes fail at import time with a syntax error rather than degrading gracefully.
+
 ## Conventions
 
 Every wrapper takes the same optional constructor options:

--- a/packages/aws-wrappers/README.md
+++ b/packages/aws-wrappers/README.md
@@ -76,7 +76,7 @@ await s3.emptyBucket('my-bucket');                     // unversioned buckets on
 
 Input shapes are intentionally tight (`Bucket`, `Key`, `Body` and similar). Callers needing SDK-specific options like server-side encryption or tagging should use `S3Client` directly.
 
-`emptyBucket` streams the listing page-by-page and delegates each page to `deleteObjects`, so peak memory stays bounded by one page regardless of bucket size. It empties **unversioned buckets only**: it paginates `ListObjectsV2`, which reports current object versions and never noncurrent versions or delete markers. Against a versioned bucket the call succeeds and leaves the bucket non-empty, because the deletes add delete markers rather than removing data. Emptying a versioned bucket needs `ListObjectVersions` plus per-version deletes — use `S3Client` directly.
+`emptyBucket` streams the listing page-by-page and delegates each page to `deleteObjects`, so peak memory stays bounded by one page regardless of bucket size. It empties **unversioned buckets only**: it paginates `ListObjectsV2`, which reports current object versions and never noncurrent versions or delete markers. Against a versioned bucket the call succeeds and the bucket then *looks* empty to `ListObjectsV2` — but the deletes only added delete markers, so every object version is still stored. You will still be billed for that storage, and `DeleteBucket` will fail with `BucketNotEmpty`. Emptying a versioned bucket needs `ListObjectVersions` plus per-version deletes — use `S3Client` directly.
 
 ## DynamoDB
 

--- a/packages/aws-wrappers/docs/classes/DynamoDBService.md
+++ b/packages/aws-wrappers/docs/classes/DynamoDBService.md
@@ -6,7 +6,7 @@
 
 # Class: DynamoDBService
 
-Defined in: [dynamodb/dynamodb.ts:153](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L153)
+Defined in: [dynamodb/dynamodb.ts:153](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L153)
 
 Wrapper around the AWS DynamoDB Document client providing structured
 Powertools logging and X-Ray tracing by default.
@@ -26,7 +26,7 @@ callers work with plain TypeScript objects in both directions.
 
 > **new DynamoDBService**(`opts?`): `DynamoDBService`
 
-Defined in: [dynamodb/dynamodb.ts:166](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L166)
+Defined in: [dynamodb/dynamodb.ts:166](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L166)
 
 #### Parameters
 
@@ -61,7 +61,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **batchGet**(`input`): `Promise`\<`BatchGetCommandOutput`\>
 
-Defined in: [dynamodb/dynamodb.ts:317](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L317)
+Defined in: [dynamodb/dynamodb.ts:317](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L317)
 
 Batch-get items from one or more DynamoDB tables.
 
@@ -88,7 +88,7 @@ Callers should narrow the result type at the call site.
 
 > **batchWrite**(`input`): `Promise`\<`BatchWriteCommandOutput`\>
 
-Defined in: [dynamodb/dynamodb.ts:334](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L334)
+Defined in: [dynamodb/dynamodb.ts:334](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L334)
 
 Batch-write items to DynamoDB, retrying `UnprocessedItems` with jittered
 exponential backoff. Up to 5 attempts (200ms base delay). Throws when
@@ -112,7 +112,7 @@ items remain unprocessed after the final attempt.
 
 > **deleteItem**\<`K`, `R`\>(`input`): `Promise`\<`Omit`\<`DeleteCommandOutput`, `"Attributes"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:247](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L247)
+Defined in: [dynamodb/dynamodb.ts:247](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L247)
 
 Delete an item from DynamoDB. The `Attributes` field on the response is
 typed as `R` — relevant when `ReturnValues: 'ALL_OLD'` is set.
@@ -149,7 +149,7 @@ Expected shape of the returned `Attributes`.
 
 > **getItem**\<`K`, `R`\>(`input`): `Promise`\<`R` \| `undefined`\>
 
-Defined in: [dynamodb/dynamodb.ts:181](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L181)
+Defined in: [dynamodb/dynamodb.ts:181](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L181)
 
 Get an item from DynamoDB.
 
@@ -187,9 +187,30 @@ The item, or `undefined` if not found.
 
 > **paginateItems**\<`T`\>(`input`): `AsyncGenerator`\<`T`\>
 
-Defined in: [dynamodb/dynamodb.ts:362](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L362)
+Defined in: [dynamodb/dynamodb.ts:384](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L384)
 
 Paginate over Query results, yielding one unmarshalled item at a time.
+
+**`Limit` is a page size, not a total cap.** DynamoDB applies it per
+request, and this method walks every page until `LastEvaluatedKey` is
+exhausted — so `paginateItems({ Limit: 10 })` yields *every* matching
+item, in pages of 10, not the first 10 items.
+
+To bound the number of items, `break` out of the loop. This is an
+`AsyncGenerator`, so `break` calls its `return()`, which unwinds the
+pagination and issues no further requests:
+
+```ts
+const firstTen: Item[] = [];
+for await (const item of ddb.paginateItems<Item>(input)) {
+    firstTen.push(item);
+    if (firstTen.length === 10) break;
+}
+```
+
+`Limit` remains the right knob for tuning per-request consumed capacity
+and page memory — set it deliberately, just don't expect it to stop the
+walk.
 
 #### Type Parameters
 
@@ -217,9 +238,13 @@ Expected shape of each yielded item.
 
 > **paginateScan**\<`T`\>(`input`): `AsyncGenerator`\<`T`\>
 
-Defined in: [dynamodb/dynamodb.ts:379](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L379)
+Defined in: [dynamodb/dynamodb.ts:406](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L406)
 
 Paginate over Scan results, yielding one unmarshalled item at a time.
+
+**`Limit` is a page size, not a total cap** — see `paginateItems` for the
+detail. `break` out of the loop to bound the number of items; `Limit`
+stays the right knob for per-request consumed capacity and page memory.
 
 #### Type Parameters
 
@@ -247,7 +272,7 @@ Expected shape of each yielded item.
 
 > **putItem**\<`T`\>(`input`): `Promise`\<`PutCommandOutput`\>
 
-Defined in: [dynamodb/dynamodb.ts:201](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L201)
+Defined in: [dynamodb/dynamodb.ts:201](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L201)
 
 Put an item into DynamoDB. The caller's `Item` is typed as `T`, which
 the document client marshalls automatically.
@@ -278,7 +303,7 @@ Type of the item being stored.
 
 > **query**\<`T`\>(`input`): `Promise`\<`Omit`\<`QueryCommandOutput`, `"Items"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:270](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L270)
+Defined in: [dynamodb/dynamodb.ts:270](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L270)
 
 Execute a DynamoDB Query. The full `QueryCommandOutput` is returned with
 `Items` typed as `T[]` so callers retain pagination metadata
@@ -310,7 +335,7 @@ Expected shape of each unmarshalled item.
 
 > **scan**\<`T`\>(`input`): `Promise`\<`Omit`\<`ScanCommandOutput`, `"Items"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:299](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L299)
+Defined in: [dynamodb/dynamodb.ts:299](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L299)
 
 Scan a DynamoDB table. The full `ScanCommandOutput` is returned with
 `Items` typed as `T[]` so callers retain pagination metadata.
@@ -354,7 +379,7 @@ Expected shape of each unmarshalled item.
 
 > **updateItem**\<`K`, `R`\>(`input`): `Promise`\<`Omit`\<`UpdateCommandOutput`, `"Attributes"`\> & `object`\>
 
-Defined in: [dynamodb/dynamodb.ts:224](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L224)
+Defined in: [dynamodb/dynamodb.ts:224](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/dynamodb/dynamodb.ts#L224)
 
 Update an item in DynamoDB. The `Attributes` field on the response is
 typed as `R` — the caller should choose `R` to match their

--- a/packages/aws-wrappers/docs/classes/S3Service.md
+++ b/packages/aws-wrappers/docs/classes/S3Service.md
@@ -6,7 +6,7 @@
 
 # Class: S3Service
 
-Defined in: [s3/s3.ts:70](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L70)
+Defined in: [s3/s3.ts:70](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L70)
 
 Wrapper around the AWS S3 client providing structured Powertools logging
 and X-Ray tracing by default.
@@ -27,7 +27,7 @@ tagging, version IDs) should use `S3Client` directly.
 
 > **new S3Service**(`opts?`): `S3Service`
 
-Defined in: [s3/s3.ts:80](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L80)
+Defined in: [s3/s3.ts:80](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L80)
 
 #### Parameters
 
@@ -59,7 +59,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **copyObject**(`input`): `Promise`\<`CopyObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:175](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L175)
+Defined in: [s3/s3.ts:175](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L175)
 
 Copy an object within S3.
 
@@ -81,7 +81,7 @@ Copy an object within S3.
 
 > **deleteObject**(`input`): `Promise`\<`DeleteObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:268](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L268)
+Defined in: [s3/s3.ts:268](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L268)
 
 Delete a single object from S3.
 
@@ -103,7 +103,7 @@ Delete a single object from S3.
 
 > **deleteObjects**(`bucket`, `keys`): `Promise`\<`DeleteObjectsCommandOutput`[]\>
 
-Defined in: [s3/s3.ts:280](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L280)
+Defined in: [s3/s3.ts:280](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L280)
 
 Delete multiple objects from S3, auto-chunking the request into batches
 of 1000 keys (the S3-enforced DeleteObjects limit). Returns one output
@@ -131,11 +131,21 @@ per chunk.
 
 > **emptyBucket**(`bucket`): `Promise`\<`string`[]\>
 
-Defined in: [s3/s3.ts:309](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L309)
+Defined in: [s3/s3.ts:320](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L320)
 
-Delete every object in a bucket. Streams the listing page-by-page and
-delegates each page's deletion to `deleteObjects`, so peak memory stays
-bounded by one page (~1000 keys) regardless of bucket size.
+Delete every object in an **unversioned** bucket. Streams the listing
+page-by-page and delegates each page's deletion to `deleteObjects`, so
+peak memory stays bounded by one page (~1000 keys) regardless of bucket
+size.
+
+**Versioned buckets are out of scope.** This paginates `ListObjectsV2`,
+which reports only current object versions — never noncurrent versions or
+delete markers. Against a versioned bucket the call therefore succeeds and
+the bucket then *looks* empty to `ListObjectsV2`, but the deletes only
+added delete markers: every object version is still stored, still billed,
+and `DeleteBucket` will still fail with `BucketNotEmpty`. Emptying a
+versioned bucket requires `ListObjectVersions` and per-version deletes;
+use `S3Client` directly for that.
 
 #### Parameters
 
@@ -147,7 +157,7 @@ bounded by one page (~1000 keys) regardless of bucket size.
 
 `Promise`\<`string`[]\>
 
-The keys of every deleted object.
+The keys this call issued deletes for.
 
 ***
 
@@ -157,7 +167,7 @@ The keys of every deleted object.
 
 > **getAllObjects**\<`T`\>(`bucket`, `prefix?`): `Promise`\<`T`[]\>
 
-Defined in: [s3/s3.ts:206](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L206)
+Defined in: [s3/s3.ts:206](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L206)
 
 List and JSON-parse every object under a bucket and optional prefix.
 Auto-paginated. Objects without a body are skipped.
@@ -192,7 +202,7 @@ Expected type of each parsed object.
 
 > **getJsonObject**\<`T`\>(`input`): `Promise`\<`T` \| `undefined`\>
 
-Defined in: [s3/s3.ts:153](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L153)
+Defined in: [s3/s3.ts:153](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L153)
 
 Get an object from S3 and parse it as JSON.
 
@@ -228,7 +238,7 @@ If the body is non-empty and not valid JSON.
 
 > **getObject**(`input`): `Promise`\<`GetObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:127](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L127)
+Defined in: [s3/s3.ts:127](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L127)
 
 Get an object from S3.
 
@@ -250,7 +260,7 @@ Get an object from S3.
 
 > **getObjectBody**(`input`): `Promise`\<`string` \| `undefined`\>
 
-Defined in: [s3/s3.ts:139](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L139)
+Defined in: [s3/s3.ts:139](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L139)
 
 Get an object from S3 and return its body as a string.
 
@@ -275,7 +285,7 @@ has no body.
 
 > **getPresignedUrl**(`input`): `Promise`\<`string`\>
 
-Defined in: [s3/s3.ts:244](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L244)
+Defined in: [s3/s3.ts:244](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L244)
 
 Generate a presigned URL that callers can use to GET or PUT an S3 object
 directly, without going through the wrapper. The signing happens against
@@ -329,7 +339,7 @@ The S3 object key.
 
 > **headObject**(`input`): `Promise`\<`HeadObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:165](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L165)
+Defined in: [s3/s3.ts:165](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L165)
 
 Fetch the metadata for an S3 object without downloading its body.
 
@@ -351,7 +361,7 @@ Fetch the metadata for an S3 object without downloading its body.
 
 > **listObjects**(`bucket`, `prefix?`): `Promise`\<`string`[]\>
 
-Defined in: [s3/s3.ts:186](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L186)
+Defined in: [s3/s3.ts:186](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L186)
 
 List object keys under a bucket and optional prefix, auto-paginating
 across all pages.
@@ -378,7 +388,7 @@ across all pages.
 
 > **putJsonObject**\<`T`\>(`input`): `Promise`\<`PutObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:110](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L110)
+Defined in: [s3/s3.ts:110](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L110)
 
 Serialise a value to JSON and store it as an S3 object.
 
@@ -412,7 +422,7 @@ Type of the value being stored.
 
 > **putObject**(`input`): `Promise`\<`PutObjectCommandOutput`\>
 
-Defined in: [s3/s3.ts:94](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/s3/s3.ts#L94)
+Defined in: [s3/s3.ts:94](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/s3/s3.ts#L94)
 
 Put an object into S3.
 

--- a/packages/aws-wrappers/docs/classes/SNSService.md
+++ b/packages/aws-wrappers/docs/classes/SNSService.md
@@ -6,7 +6,7 @@
 
 # Class: SNSService
 
-Defined in: [sns/sns.ts:43](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sns/sns.ts#L43)
+Defined in: [sns/sns.ts:43](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sns/sns.ts#L43)
 
 Wrapper around the AWS SNS client providing structured Powertools logging
 and X-Ray tracing by default.
@@ -23,7 +23,7 @@ log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
 
 > **new SNSService**(`opts?`): `SNSService`
 
-Defined in: [sns/sns.ts:59](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sns/sns.ts#L59)
+Defined in: [sns/sns.ts:59](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sns/sns.ts#L59)
 
 #### Parameters
 
@@ -65,7 +65,7 @@ its own `truncate` option.
 
 > **publish**(`input`, `opts?`): `Promise`\<`PublishCommandOutput`\>
 
-Defined in: [sns/sns.ts:73](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sns/sns.ts#L73)
+Defined in: [sns/sns.ts:73](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sns/sns.ts#L73)
 
 Publish a single message to an SNS topic.
 
@@ -98,7 +98,7 @@ PublishCommandInput including TopicArn and Message.
 
 > **publishBatch**(`input`): `Promise`\<`PublishBatchCommandOutput`[]\>
 
-Defined in: [sns/sns.ts:110](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sns/sns.ts#L110)
+Defined in: [sns/sns.ts:125](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sns/sns.ts#L125)
 
 Publish a batch of messages to an SNS topic. The SNS API caps
 PublishBatch at 10 entries per request, so this method auto-chunks

--- a/packages/aws-wrappers/docs/classes/SQSService.md
+++ b/packages/aws-wrappers/docs/classes/SQSService.md
@@ -6,7 +6,7 @@
 
 # Class: SQSService
 
-Defined in: [sqs/sqs.ts:49](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L49)
+Defined in: [sqs/sqs.ts:49](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sqs/sqs.ts#L49)
 
 Wrapper around the AWS SQS client providing structured Powertools logging
 and X-Ray tracing by default.
@@ -23,7 +23,7 @@ log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
 
 > **new SQSService**(`opts?`): `SQSService`
 
-Defined in: [sqs/sqs.ts:64](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L64)
+Defined in: [sqs/sqs.ts:64](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sqs/sqs.ts#L64)
 
 #### Parameters
 
@@ -64,7 +64,7 @@ option.
 
 > **deleteMessage**(`input`): `Promise`\<`DeleteMessageCommandOutput`\>
 
-Defined in: [sqs/sqs.ts:119](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L119)
+Defined in: [sqs/sqs.ts:128](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sqs/sqs.ts#L128)
 
 Delete a single message from an SQS queue.
 
@@ -86,7 +86,7 @@ Delete a single message from an SQS queue.
 
 > **deleteMessageBatch**(`input`): `Promise`\<`DeleteMessageBatchCommandOutput`[]\>
 
-Defined in: [sqs/sqs.ts:155](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L155)
+Defined in: [sqs/sqs.ts:164](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sqs/sqs.ts#L164)
 
 Delete a batch of messages from an SQS queue. The SQS API caps
 DeleteMessageBatch at 10 entries per request, so this method auto-chunks
@@ -110,7 +110,7 @@ the caller's entries and sends one request per chunk.
 
 > **receiveMessages**(`input`): `Promise`\<`Message`[]\>
 
-Defined in: [sqs/sqs.ts:110](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L110)
+Defined in: [sqs/sqs.ts:119](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sqs/sqs.ts#L119)
 
 Receive messages from an SQS queue. Returns an empty array when no
 messages are available. No automatic deletion is performed — visibility
@@ -136,7 +136,7 @@ The `Messages` array from the response, or `[]` if absent.
 
 > **sendMessage**(`input`, `opts?`): `Promise`\<`SendMessageCommandOutput`\>
 
-Defined in: [sqs/sqs.ts:76](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L76)
+Defined in: [sqs/sqs.ts:76](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sqs/sqs.ts#L76)
 
 Send a single message to an SQS queue.
 
@@ -167,7 +167,7 @@ see `SEND_MESSAGE_SAFE_FIELDS`.
 
 > **sendMessageBatch**(`input`): `Promise`\<`SendMessageBatchCommandOutput`[]\>
 
-Defined in: [sqs/sqs.ts:129](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sqs/sqs.ts#L129)
+Defined in: [sqs/sqs.ts:138](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sqs/sqs.ts#L138)
 
 Send a batch of messages to an SQS queue. The SQS API caps
 SendMessageBatch at 10 entries per request, so this method auto-chunks

--- a/packages/aws-wrappers/docs/classes/SSMService.md
+++ b/packages/aws-wrappers/docs/classes/SSMService.md
@@ -6,7 +6,7 @@
 
 # Class: SSMService
 
-Defined in: [ssm/ssm.ts:50](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L50)
+Defined in: [ssm/ssm.ts:50](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/ssm/ssm.ts#L50)
 
 Wrapper around the AWS SSM Parameter Store client providing structured
 Powertools logging and X-Ray tracing by default. All read operations enable
@@ -31,7 +31,7 @@ mutate within the application.
 
 > **new SSMService**(`opts?`): `SSMService`
 
-Defined in: [ssm/ssm.ts:60](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L60)
+Defined in: [ssm/ssm.ts:60](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/ssm/ssm.ts#L60)
 
 #### Parameters
 
@@ -63,7 +63,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **deleteParameter**(`name`): `Promise`\<`void`\>
 
-Defined in: [ssm/ssm.ts:139](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L139)
+Defined in: [ssm/ssm.ts:139](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/ssm/ssm.ts#L139)
 
 Delete an SSM parameter by name.
 
@@ -88,7 +88,7 @@ runtime cleanup only.
 
 > **getParameter**(`name`): `Promise`\<`string` \| `undefined`\>
 
-Defined in: [ssm/ssm.ts:71](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L71)
+Defined in: [ssm/ssm.ts:71](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/ssm/ssm.ts#L71)
 
 Fetch a single SSM parameter's value.
 
@@ -115,7 +115,7 @@ value set.
 
 > **getParameters**\<`K`\>(`aliases`): `Promise`\<`Record`\<`K`, `string` \| `undefined`\>\>
 
-Defined in: [ssm/ssm.ts:98](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L98)
+Defined in: [ssm/ssm.ts:98](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/ssm/ssm.ts#L98)
 
 Fetch multiple SSM parameters in a single request. Callers supply an
 alias-to-path record, and the returned record is keyed by the same
@@ -160,7 +160,7 @@ no value.
 
 > **getParametersByPath**(`path`, `opts?`): `Promise`\<`Parameter`[]\>
 
-Defined in: [ssm/ssm.ts:155](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L155)
+Defined in: [ssm/ssm.ts:155](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/ssm/ssm.ts#L155)
 
 Fetch all parameters under an SSM hierarchy path, auto-paginating across
 all pages. `Recursive` defaults to `true` (overriding the AWS SDK
@@ -199,7 +199,7 @@ The full `Parameter` objects (including `Version`,
 
 > **putParameter**(`input`): `Promise`\<`PutParameterCommandOutput`\>
 
-Defined in: [ssm/ssm.ts:126](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/ssm/ssm.ts#L126)
+Defined in: [ssm/ssm.ts:126](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/ssm/ssm.ts#L126)
 
 Create or update an SSM parameter. The log line omits `Value` to avoid
 leaking secret material.

--- a/packages/aws-wrappers/docs/classes/SchedulerService.md
+++ b/packages/aws-wrappers/docs/classes/SchedulerService.md
@@ -6,7 +6,7 @@
 
 # Class: SchedulerService
 
-Defined in: [scheduler/scheduler.ts:81](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L81)
+Defined in: [scheduler/scheduler.ts:81](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/scheduler/scheduler.ts#L81)
 
 Wrapper around the AWS EventBridge Scheduler client providing structured
 Powertools logging and X-Ray tracing by default.
@@ -31,7 +31,7 @@ intent (`{ Mode: 'OFF' }` for a fixed-time schedule).
 
 > **new SchedulerService**(`opts?`): `SchedulerService`
 
-Defined in: [scheduler/scheduler.ts:91](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L91)
+Defined in: [scheduler/scheduler.ts:91](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/scheduler/scheduler.ts#L91)
 
 #### Parameters
 
@@ -63,7 +63,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **createSchedule**(`input`): `Promise`\<`CreateScheduleCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:100](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L100)
+Defined in: [scheduler/scheduler.ts:100](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/scheduler/scheduler.ts#L100)
 
 Create a new schedule. At INFO the log line omits `Target.Input` (the
 target payload, a PII carrier).
@@ -86,7 +86,7 @@ target payload, a PII carrier).
 
 > **createScheduleGroup**(`input`): `Promise`\<`CreateScheduleGroupCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:158](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L158)
+Defined in: [scheduler/scheduler.ts:158](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/scheduler/scheduler.ts#L158)
 
 Create a new schedule group. Groups are containers for schedules and are
 typically IaC-managed; use this for dynamically-provisioned groups only.
@@ -109,7 +109,7 @@ typically IaC-managed; use this for dynamically-provisioned groups only.
 
 > **deleteSchedule**(`input`): `Promise`\<`DeleteScheduleCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:134](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L134)
+Defined in: [scheduler/scheduler.ts:134](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/scheduler/scheduler.ts#L134)
 
 Delete a schedule.
 
@@ -131,7 +131,7 @@ Delete a schedule.
 
 > **deleteScheduleGroup**(`input`): `Promise`\<`DeleteScheduleGroupCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:180](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L180)
+Defined in: [scheduler/scheduler.ts:180](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/scheduler/scheduler.ts#L180)
 
 Delete a schedule group. Deleting a group also deletes every schedule it
 contains, asynchronously — the API has no `UpdateScheduleGroup`, so this
@@ -155,7 +155,7 @@ is the only mutating group operation besides create.
 
 > **getSchedule**(`input`): `Promise`\<`GetScheduleCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:108](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L108)
+Defined in: [scheduler/scheduler.ts:108](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/scheduler/scheduler.ts#L108)
 
 Fetch a schedule's full configuration.
 
@@ -177,7 +177,7 @@ Fetch a schedule's full configuration.
 
 > **getScheduleGroup**(`input`): `Promise`\<`GetScheduleGroupCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:168](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L168)
+Defined in: [scheduler/scheduler.ts:168](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/scheduler/scheduler.ts#L168)
 
 Fetch a schedule group's configuration.
 
@@ -199,7 +199,7 @@ Fetch a schedule group's configuration.
 
 > **listScheduleGroups**(`input?`): `Promise`\<`ScheduleGroupSummary`[]\>
 
-Defined in: [scheduler/scheduler.ts:191](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L191)
+Defined in: [scheduler/scheduler.ts:191](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/scheduler/scheduler.ts#L191)
 
 List schedule groups, auto-paginating across all pages. Bounded in
 practice by the account's group count and the `NamePrefix` filter.
@@ -222,7 +222,7 @@ practice by the account's group count and the `NamePrefix` filter.
 
 > **listSchedules**(`input?`): `Promise`\<`ScheduleSummary`[]\>
 
-Defined in: [scheduler/scheduler.ts:144](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L144)
+Defined in: [scheduler/scheduler.ts:144](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/scheduler/scheduler.ts#L144)
 
 List schedules, auto-paginating across all pages. Bounded in practice by
 the account's schedule count and the `GroupName` / `NamePrefix` / `State`
@@ -246,7 +246,7 @@ filters, so the flat-array shape is safe.
 
 > **updateSchedule**(`input`): `Promise`\<`UpdateScheduleCommandOutput`\>
 
-Defined in: [scheduler/scheduler.ts:126](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/scheduler/scheduler.ts#L126)
+Defined in: [scheduler/scheduler.ts:126](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/scheduler/scheduler.ts#L126)
 
 Update an existing schedule.
 

--- a/packages/aws-wrappers/docs/classes/SecretsManagerService.md
+++ b/packages/aws-wrappers/docs/classes/SecretsManagerService.md
@@ -6,7 +6,7 @@
 
 # Class: SecretsManagerService
 
-Defined in: [secrets-manager/secrets-manager.ts:75](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L75)
+Defined in: [secrets-manager/secrets-manager.ts:75](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L75)
 
 Wrapper around the AWS Secrets Manager client providing structured
 Powertools logging and X-Ray tracing by default.
@@ -30,7 +30,7 @@ mutable values.
 
 > **new SecretsManagerService**(`opts?`): `SecretsManagerService`
 
-Defined in: [secrets-manager/secrets-manager.ts:86](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L86)
+Defined in: [secrets-manager/secrets-manager.ts:86](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L86)
 
 #### Parameters
 
@@ -63,7 +63,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **createSecret**(`input`): `Promise`\<`CreateSecretCommandOutput`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:123](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L123)
+Defined in: [secrets-manager/secrets-manager.ts:123](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L123)
 
 Create a new secret. At INFO level the log line includes only identity
 and non-secret metadata.
@@ -89,7 +89,7 @@ dynamically-issued credentials only.
 
 > **deleteSecret**(`input`): `Promise`\<`DeleteSecretCommandOutput`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:163](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L163)
+Defined in: [secrets-manager/secrets-manager.ts:163](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L163)
 
 Delete a secret. Pass `ForceDeleteWithoutRecovery: true` to bypass the
 default 7-30 day recovery window (irreversible).
@@ -114,7 +114,7 @@ Prefer IaC (CDK / Terraform) for secret lifecycle.
 
 > **getJsonSecret**\<`T`\>(`secretId`): `Promise`\<`T`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:110](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L110)
+Defined in: [secrets-manager/secrets-manager.ts:110](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L110)
 
 Fetch a secret and parse it as JSON.
 
@@ -152,7 +152,7 @@ If the secret has no `SecretString` or the value is not valid JSON.
 
 > **getSecret**(`secretId`): `Promise`\<`string`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:98](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L98)
+Defined in: [secrets-manager/secrets-manager.ts:98](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L98)
 
 Fetch a secret's string value from Secrets Manager.
 
@@ -183,7 +183,7 @@ stores binary data).
 
 > **putSecretValue**(`input`): `Promise`\<`PutSecretValueCommandOutput`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:150](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L150)
+Defined in: [secrets-manager/secrets-manager.ts:150](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L150)
 
 Store a new version of a secret's value. At INFO level the log line
 omits `SecretString` / `SecretBinary`.
@@ -208,7 +208,7 @@ Typically used by rotation flows.
 
 > **updateSecret**(`input`): `Promise`\<`UpdateSecretCommandOutput`\>
 
-Defined in: [secrets-manager/secrets-manager.ts:137](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L137)
+Defined in: [secrets-manager/secrets-manager.ts:137](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/secrets-manager/secrets-manager.ts#L137)
 
 Update an existing secret's metadata or value. At INFO level the log
 line omits `SecretString` / `SecretBinary`.

--- a/packages/aws-wrappers/docs/classes/StepFunctionsService.md
+++ b/packages/aws-wrappers/docs/classes/StepFunctionsService.md
@@ -6,7 +6,7 @@
 
 # Class: StepFunctionsService
 
-Defined in: [sfn/sfn.ts:40](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sfn/sfn.ts#L40)
+Defined in: [sfn/sfn.ts:40](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sfn/sfn.ts#L40)
 
 Wrapper around the AWS Step Functions client providing structured
 Powertools logging and X-Ray tracing by default.
@@ -23,7 +23,7 @@ log line omits them; the verbose levels (`POWERTOOLS_LOG_LEVEL=DEBUG` or
 
 > **new StepFunctionsService**(`opts?`): `StepFunctionsService`
 
-Defined in: [sfn/sfn.ts:50](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sfn/sfn.ts#L50)
+Defined in: [sfn/sfn.ts:50](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sfn/sfn.ts#L50)
 
 #### Parameters
 
@@ -55,7 +55,7 @@ which picks up `POWERTOOLS_SERVICE_NAME` from the environment.
 
 > **describeExecution**(`input`): `Promise`\<`DescribeExecutionCommandOutput`\>
 
-Defined in: [sfn/sfn.ts:83](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sfn/sfn.ts#L83)
+Defined in: [sfn/sfn.ts:83](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sfn/sfn.ts#L83)
 
 Describe an existing Step Functions execution.
 
@@ -77,7 +77,7 @@ Describe an existing Step Functions execution.
 
 > **listExecutions**(`input`): `Promise`\<`ExecutionListItem`[]\>
 
-Defined in: [sfn/sfn.ts:60](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sfn/sfn.ts#L60)
+Defined in: [sfn/sfn.ts:60](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sfn/sfn.ts#L60)
 
 List all executions for a state machine, auto-paginating across all
 pages. Typically bounded by `statusFilter` and state-machine retention,
@@ -101,7 +101,7 @@ so the flat-array shape is safe in practice.
 
 > **startExecution**(`input`): `Promise`\<`StartExecutionCommandOutput`\>
 
-Defined in: [sfn/sfn.ts:73](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sfn/sfn.ts#L73)
+Defined in: [sfn/sfn.ts:73](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sfn/sfn.ts#L73)
 
 Start a new Step Functions execution.
 
@@ -123,7 +123,7 @@ Start a new Step Functions execution.
 
 > **stopExecution**(`input`): `Promise`\<`StopExecutionCommandOutput`\>
 
-Defined in: [sfn/sfn.ts:93](https://github.com/aligent/microservice-development-utilities/blob/a2bb34fea27b6af8b52791a3302aefd2b6af331f/packages/aws-wrappers/src/sfn/sfn.ts#L93)
+Defined in: [sfn/sfn.ts:93](https://github.com/aligent/microservice-development-utilities/blob/fd6cf9d0c7112a3e2feb0c83a6bedebeddcf46ed/packages/aws-wrappers/src/sfn/sfn.ts#L93)
 
 Stop an in-progress Step Functions execution.
 

--- a/packages/aws-wrappers/package.json
+++ b/packages/aws-wrappers/package.json
@@ -2,6 +2,9 @@
   "name": "@aligent/aws-wrappers",
   "version": "0.3.0",
   "description": "Opinionated AWS SDK wrappers with Powertools logging and X-Ray tracing",
+  "engines": {
+    "node": ">=18"
+  },
   "main": "./cjs/index.cjs",
   "module": "./esm/index.mjs",
   "types": "./cjs/src/index.d.ts",

--- a/packages/aws-wrappers/src/dynamodb/dynamodb.test.ts
+++ b/packages/aws-wrappers/src/dynamodb/dynamodb.test.ts
@@ -400,6 +400,33 @@ describe('DynamoDBService', () => {
 
             expect(items.map(i => i.pk)).toEqual(['1', '2', '3']);
         });
+
+        // `break` is the documented way to bound a read — `Limit` is a page
+        // size, not a total cap. Lock in that breaking really does stop the
+        // walk rather than draining the remaining pages in the background.
+        it('stops requesting pages when the caller breaks out of the loop', async () => {
+            ddbMock
+                .on(QueryCommand)
+                .resolvesOnce({
+                    Items: [{ pk: '1' }, { pk: '2' }],
+                    LastEvaluatedKey: { pk: '2' },
+                })
+                .resolves({ Items: [{ pk: '3' }] });
+            const service = buildService();
+
+            const items: Array<{ pk: string }> = [];
+            for await (const item of service.paginateItems<{ pk: string }>({
+                TableName,
+                KeyConditionExpression: 'pk = :pk',
+                ExpressionAttributeValues: { ':pk': 'x' },
+            })) {
+                items.push(item);
+                break;
+            }
+
+            expect(items.map(i => i.pk)).toEqual(['1']);
+            expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(1);
+        });
     });
 
     describe('paginateScan', () => {

--- a/packages/aws-wrappers/src/dynamodb/dynamodb.ts
+++ b/packages/aws-wrappers/src/dynamodb/dynamodb.ts
@@ -357,6 +357,28 @@ export class DynamoDBService {
 
     /**
      * Paginate over Query results, yielding one unmarshalled item at a time.
+     *
+     * **`Limit` is a page size, not a total cap.** DynamoDB applies it per
+     * request, and this method walks every page until `LastEvaluatedKey` is
+     * exhausted — so `paginateItems({ Limit: 10 })` yields *every* matching
+     * item, in pages of 10, not the first 10 items.
+     *
+     * To bound the number of items, `break` out of the loop. This is an
+     * `AsyncGenerator`, so `break` calls its `return()`, which unwinds the
+     * pagination and issues no further requests:
+     *
+     * ```ts
+     * const firstTen: Item[] = [];
+     * for await (const item of ddb.paginateItems<Item>(input)) {
+     *     firstTen.push(item);
+     *     if (firstTen.length === 10) break;
+     * }
+     * ```
+     *
+     * `Limit` remains the right knob for tuning per-request consumed capacity
+     * and page memory — set it deliberately, just don't expect it to stop the
+     * walk.
+     *
      * @template T - Expected shape of each yielded item.
      */
     async *paginateItems<T extends Record<string, unknown> = Record<string, unknown>>(
@@ -374,6 +396,11 @@ export class DynamoDBService {
 
     /**
      * Paginate over Scan results, yielding one unmarshalled item at a time.
+     *
+     * **`Limit` is a page size, not a total cap** — see `paginateItems` for the
+     * detail. `break` out of the loop to bound the number of items; `Limit`
+     * stays the right knob for per-request consumed capacity and page memory.
+     *
      * @template T - Expected shape of each yielded item.
      */
     async *paginateScan<T extends Record<string, unknown> = Record<string, unknown>>(

--- a/packages/aws-wrappers/src/s3/s3.ts
+++ b/packages/aws-wrappers/src/s3/s3.ts
@@ -301,10 +301,20 @@ export class S3Service {
     }
 
     /**
-     * Delete every object in a bucket. Streams the listing page-by-page and
-     * delegates each page's deletion to `deleteObjects`, so peak memory stays
-     * bounded by one page (~1000 keys) regardless of bucket size.
-     * @returns The keys of every deleted object.
+     * Delete every object in an **unversioned** bucket. Streams the listing
+     * page-by-page and delegates each page's deletion to `deleteObjects`, so
+     * peak memory stays bounded by one page (~1000 keys) regardless of bucket
+     * size.
+     *
+     * **Versioned buckets are out of scope.** This paginates `ListObjectsV2`,
+     * which reports only current object versions — never noncurrent versions or
+     * delete markers. Against a versioned bucket the call therefore succeeds,
+     * reports the keys it deleted, and leaves the bucket non-empty: the deletes
+     * add delete markers rather than removing data. Emptying a versioned bucket
+     * requires `ListObjectVersions` and per-version deletes; use `S3Client`
+     * directly for that.
+     *
+     * @returns The keys this call issued deletes for.
      */
     async emptyBucket(bucket: string): Promise<string[]> {
         this.logger.info('Emptying S3 bucket', { input: { bucket } });

--- a/packages/aws-wrappers/src/s3/s3.ts
+++ b/packages/aws-wrappers/src/s3/s3.ts
@@ -308,11 +308,12 @@ export class S3Service {
      *
      * **Versioned buckets are out of scope.** This paginates `ListObjectsV2`,
      * which reports only current object versions — never noncurrent versions or
-     * delete markers. Against a versioned bucket the call therefore succeeds,
-     * reports the keys it deleted, and leaves the bucket non-empty: the deletes
-     * add delete markers rather than removing data. Emptying a versioned bucket
-     * requires `ListObjectVersions` and per-version deletes; use `S3Client`
-     * directly for that.
+     * delete markers. Against a versioned bucket the call therefore succeeds and
+     * the bucket then *looks* empty to `ListObjectsV2`, but the deletes only
+     * added delete markers: every object version is still stored, still billed,
+     * and `DeleteBucket` will still fail with `BucketNotEmpty`. Emptying a
+     * versioned bucket requires `ListObjectVersions` and per-version deletes;
+     * use `S3Client` directly for that.
      *
      * @returns The keys this call issued deletes for.
      */

--- a/packages/aws-wrappers/src/sns/sns.test.ts
+++ b/packages/aws-wrappers/src/sns/sns.test.ts
@@ -123,6 +123,17 @@ describe('SNSService', () => {
             expect(snsMock.commandCalls(PublishCommand)).toHaveLength(1);
         });
 
+        it('passes a within-limit input through unchanged when truncation is enabled', async () => {
+            snsMock.on(PublishCommand).resolves({ MessageId: 'mid' });
+            const service = new SNSService({ client: new SNSClient({}), truncate: true });
+            const input = { TopicArn: 'arn:aws:sns:us-east-1:0:topic', Message: 'hi' };
+
+            await service.publish(input);
+
+            const sent = snsMock.commandCalls(PublishCommand)[0]?.args[0].input;
+            expect(sent).toStrictEqual(input);
+        });
+
         it('truncates oversized Message when the instance opts in to truncation', async () => {
             snsMock.on(PublishCommand).resolves({ MessageId: 'mid' });
             const service = new SNSService({ client: new SNSClient({}), truncate: true });

--- a/packages/aws-wrappers/src/sns/sns.ts
+++ b/packages/aws-wrappers/src/sns/sns.ts
@@ -82,22 +82,37 @@ export class SNSService {
         return this.client.send(new PublishCommand(effective));
     }
 
+    /**
+     * The truncation helpers return the input unchanged when it already fits, so
+     * a `!==` comparison against their result is what decides whether a field
+     * was modified. Don't reintroduce a size guard here: that would state each
+     * limit twice, encode the string to a `Buffer` twice, and let the two
+     * expressions drift into warning without truncating (or the reverse).
+     */
     private applyTruncation(input: PublishCommandInput): PublishCommandInput {
         const truncated: string[] = [];
-        let Message = input.Message;
-        if (Message !== undefined && Buffer.byteLength(Message, 'utf8') > SNS_MESSAGE_MAX_BYTES) {
-            Message = truncateUtf8(Message, SNS_MESSAGE_MAX_BYTES);
-            truncated.push('Message');
+        const out = { ...input };
+
+        if (out.Message !== undefined) {
+            const next = truncateUtf8(out.Message, SNS_MESSAGE_MAX_BYTES);
+            if (next !== out.Message) {
+                out.Message = next;
+                truncated.push('Message');
+            }
         }
-        let Subject = input.Subject;
-        if (Subject !== undefined && Array.from(Subject).length > SNS_SUBJECT_MAX_CHARS) {
-            Subject = truncateCodepoints(Subject, SNS_SUBJECT_MAX_CHARS);
-            truncated.push('Subject');
+
+        if (out.Subject !== undefined) {
+            const next = truncateCodepoints(out.Subject, SNS_SUBJECT_MAX_CHARS);
+            if (next !== out.Subject) {
+                out.Subject = next;
+                truncated.push('Subject');
+            }
         }
+
         if (truncated.length > 0) {
             this.logger.warn('Truncated SNS publish input', { fields: truncated });
         }
-        return { ...input, Message, Subject };
+        return out;
     }
 
     /**

--- a/packages/aws-wrappers/src/sqs/sqs.test.ts
+++ b/packages/aws-wrappers/src/sqs/sqs.test.ts
@@ -119,6 +119,24 @@ describe('SQSService', () => {
             expect(sqsMock.commandCalls(SendMessageCommand)).toHaveLength(1);
         });
 
+        it('leaves a MessageBody at exactly the limit untruncated and unwarned', async () => {
+            sqsMock.on(SendMessageCommand).resolves({ MessageId: 'mid' });
+            const logger = new Logger();
+            const warnSpy = vi.spyOn(logger, 'warn');
+            const service = new SQSService({
+                client: new SQSClient({}),
+                logger,
+                truncate: true,
+            });
+            const input = { QueueUrl, MessageBody: 'x'.repeat(262_144) };
+
+            await service.sendMessage(input);
+
+            const sent = sqsMock.commandCalls(SendMessageCommand)[0]?.args[0].input;
+            expect(sent).toStrictEqual(input);
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
         it('truncates oversized MessageBody when the instance opts in to truncation', async () => {
             sqsMock.on(SendMessageCommand).resolves({ MessageId: 'mid' });
             const service = new SQSService({ client: new SQSClient({}), truncate: true });

--- a/packages/aws-wrappers/src/sqs/sqs.ts
+++ b/packages/aws-wrappers/src/sqs/sqs.ts
@@ -85,20 +85,29 @@ export class SQSService {
         return this.client.send(new SendMessageCommand(effective));
     }
 
+    /**
+     * `truncateUtf8` returns the input unchanged when it already fits, so a
+     * `!==` comparison against its result is what decides whether the body was
+     * modified. Don't reintroduce a size guard here: that would state the limit
+     * twice, encode the string to a `Buffer` twice, and let the two expressions
+     * drift into warning without truncating (or the reverse).
+     */
     private applyTruncation(input: SendMessageCommandInput): SendMessageCommandInput {
         const truncated: string[] = [];
-        let MessageBody = input.MessageBody;
-        if (
-            MessageBody !== undefined &&
-            Buffer.byteLength(MessageBody, 'utf8') > SQS_MESSAGE_BODY_MAX_BYTES
-        ) {
-            MessageBody = truncateUtf8(MessageBody, SQS_MESSAGE_BODY_MAX_BYTES);
-            truncated.push('MessageBody');
+        const out = { ...input };
+
+        if (out.MessageBody !== undefined) {
+            const next = truncateUtf8(out.MessageBody, SQS_MESSAGE_BODY_MAX_BYTES);
+            if (next !== out.MessageBody) {
+                out.MessageBody = next;
+                truncated.push('MessageBody');
+            }
         }
+
         if (truncated.length > 0) {
             this.logger.warn('Truncated SQS sendMessage input', { fields: truncated });
         }
-        return { ...input, MessageBody };
+        return out;
     }
 
     /**

--- a/packages/aws-wrappers/tsconfig.lib.json
+++ b/packages/aws-wrappers/tsconfig.lib.json
@@ -6,6 +6,12 @@
         "outDir": "dist",
         "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
         "types": ["node"],
+        // `target` must be explicit here. The base config sets `module: Node16`,
+        // which implies `target: es2022`; overriding `module` below drops that
+        // implication, and TypeScript falls back to its ES5 default. ES5 emits
+        // classes as IIFEs, which bundlers cannot prove pure — so consumers
+        // retain every service class and every AWS SDK client it imports.
+        "target": "ES2022",
         "module": "ESNext",
         "moduleResolution": "Bundler",
         "checkJs": false

--- a/packages/aws-wrappers/tsconfig.spec.json
+++ b/packages/aws-wrappers/tsconfig.spec.json
@@ -2,6 +2,10 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "outDir": "./out-tsc/vitest",
+        // Mirrors `tsconfig.lib.json` — see the comment there. Overriding
+        // `module` drops the implied `target: es2022`, and a divergent target
+        // between lib and spec means a divergent `useDefineForClassFields`.
+        "target": "ES2022",
         "module": "ESNext",
         "moduleResolution": "Bundler",
         "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]


### PR DESCRIPTION
**Description of the proposed changes**

- **`packages/aws-wrappers` compiled to ES5**, so every service class emitted as a top-level IIFE (`var S3Service = /** @class */ (function () { … }())`). A bundler cannot prove a function call is pure, so consumers retained all eight service classes and every AWS SDK client they import. `async`/`await` also downlevelled to `tslib` generator state machines on a package that only runs on Node 20+.
- **Root cause:** the shared base sets `module: Node16`, which *implies* `target: es2022`. This package overrides `module: ESNext` for the rollup pipeline — documented in `packages/aws-wrappers/CLAUDE.md` — and that override silently drops the implication, falling back to TypeScript's ES5 default. No package in the repo sets `target` explicitly, so nothing caught it. Fixed by setting `target: ES2022` explicitly, with a comment recording the mechanism, mirrored into `tsconfig.spec.json` so lib and spec don't diverge on `useDefineForClassFields`.
- **`applyTruncation` (SNS + SQS)** stated each size limit twice — once in a guard deciding whether to warn, once inside `truncateUtf8`/`truncateCodepoints`. Now derives "did we truncate" from the helper's return value: one source of truth, one UTF-8 encode instead of two.
- **`emptyBucket`** documents its contract as unversioned buckets only. It paginates `ListObjectsV2`, which never reports noncurrent versions or delete markers.
- **`paginateItems` / `paginateScan`** document that `Limit` is a page size, not a total cap, with a `break` test pinning the lazy-generator contract.

⚠️ **Consumer-visible emit change — classified `minor`.** Requires Node 18+, now declared in `engines`. The pruning win is **ESM-only**; CJS consumers see no improvement because `require` cannot be statically tree-shaken.

**Measured** — real tarballs packed from `dist/`, `npm install`ed into a throwaway consumer project, real Lambda handlers bundled:

| Path | ES5 | ES2022 | Change |
| --- | --- | --- | --- |
| Vite, handler importing only `SSMService` | 1,568,828 B | 1,102,145 B | **−29.7%** |
| Vite, handler importing `S3Service` + `DynamoDBService` | 1,569,945 B | 1,221,618 B | **−22.2%** |
| esbuild, ESM entry | 2,928,139 B | 2,059,674 B | **−29.7%** |
| esbuild, **CJS entry** | 2,967,347 B | 2,943,165 B | −0.8% |
| `dist/esm/index.mjs` itself | 103,447 B | 58,042 B | **−43.9%** |

The clearest evidence is the ES5 baseline: two handlers importing **completely different services** came out 1.1 KB apart (1,568,828 vs 1,569,945). Nothing was being pruned at all. At ES2022 they diverge by what they actually use, and `s3-request-presigner` is retained only in the handler using `S3Service`.

Post-fix, an `SSMService`-only bundle contains no reference to `@aws-sdk/client-{s3,sqs,sns,sfn,scheduler,secrets-manager}` or `s3-request-presigner` — 7 of 9 pruned. `client-dynamodb` and `lib-dynamodb` remain: `lib-dynamodb` ships no `sideEffects: false` of its own, so subpath exports are the only fix for that pair.

`dist/esm/index.mjs` after the change: 8 native `class` declarations, 0 IIFEs, 0 `tslib` helpers.

**Other solutions considered (if any)**

- **`"sideEffects": false`.** This was the original headline of the ticket. It is a **measured no-op** — byte-identical bundles with and without it — because the blocker was never module-level side effects, it was the unprovable-pure IIFE. Deliberately excluded rather than shipped as a field nobody could later justify.
- **Fixing `target` in the shared `@aligent/ts-code-standards` base.** The durable fix, and close to a no-op for this monorepo since all six unaffected packages already resolve to `es2022`. Deferred because it is a different repo — tracked with `vite-plugin-handler`'s identical defect in #245.
- **`GetBucketVersioning` detection in `emptyBucket`.** Rejected: needs an IAM action no deployed consumer's role grants, so every existing caller would start failing with `AccessDenied` — worse than the bug.
- **A `maxItems` option on the paginators.** Rejected: they return `AsyncGenerator`, so `break` already gives callers item-level control.

**Related issues**

- Related to #245 — **not closed by this PR.** `packages/vite-plugin-handler` carries the identical ES5 defect (same `module: ESNext` override, same dropped `target` implication) and is deliberately out of scope here. #245 also tracks the upstream `@aligent/ts-code-standards` one-liner that would stop this recurring in any future package.
- No GitHub issue is closed by this PR; the work is tracked in Jira as MI-333.

**Notes to reviewers**

- 🛈 Toggl Code: _MI-333: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

Commit order is the easiest read — `ad99e3a` is the whole behaviour change in two config files; the rest is contract documentation.

Worth a closer look:

- **`tsconfig.lib.json`** — the comment is the deliverable as much as the setting. Without it the next `module` override silently regresses to ES5 again.
- **`applyTruncation`** — please sanity-check the `!==` predicate. Both helpers return the identity `str` when the value fits, so it cannot false-positive; the at-limit SQS test pins that, and mutating the guard to warn unconditionally fails it.
- **`docs/` links are stamped with `fd6cf9d`**, not HEAD. That is correct — `git diff fd6cf9d HEAD -- packages/aws-wrappers/src` is empty, so they resolve to the shipped source. Re-running typedoc will show a SHA-only diff; that is not drift.

A review round found two overstated claims in this branch, both since corrected in `fd6cf9d`: the version plan described the truncation refactor as fixing a latent warn-without-truncate path (it did not — the two checks were the same computation against the same constant, verified across empty, at-limit, astral-plane and lone-surrogate inputs), and `emptyBucket`'s docs said the bucket is "left non-empty" when it in fact *looks* empty to `ListObjectsV2` while remaining stored and billed.

Repo-root `lint`, `check-types` and `test` green: 149 tests, 99.1% statements / 90.13% branch against the 80% gate.

Out of scope, tracked separately: `emptyBucket`/`deleteObjects` swallowing per-key `Errors[]` and the `Deleted[].DeleteMarker` signal; per-service subpath exports; SNS/SQS whole-payload truncation budget and the `MessageStructure: 'json'` bug; DynamoDB batch chunking; a CI docs-drift gate; and `vite-plugin-handler`'s identical ES5 defect (#245).
