### PR TITLE
fix: use the client's fetch for retried requests

### DIFF
--- a/.nx/version-plans/version-plan-retry-client-fetch.md
+++ b/.nx/version-plans/version-plan-retry-client-fetch.md
@@ -1,0 +1,15 @@
+---
+microservice-util-lib: minor
+---
+
+`retryMiddleware` now performs its retries using the fetch the client was created with (`ClientOptions.fetch`) instead of the global `fetch`, falling back to the global only when the client does not configure one. An explicitly configured `fetch` in the retry config still takes precedence.
+
+Previously a fetch injected into `createClient` applied to the initial request but not to any retry, so retries silently bypassed the injected transport. In tests this meant a fetch double saw one call while the retry escaped to the network; in production it meant instrumentation, proxying, or body transformation wired into the client's fetch was skipped on exactly the path that is least exercised. Both the `onResponse` and `onError` (network error) retry paths are fixed.
+
+This covers the fetch function only. `ClientOptions.requestInitExt` is passed by openapi-fetch as the second argument to the initial fetch and is not exposed to middleware, so it remains unavailable to retries — a `dispatcher` set there still applies to the first attempt alone. That limitation is unchanged by this release and is now documented.
+
+Released as a minor rather than a patch because the transport used for retries changes observably for any consumer that configured a client fetch without also passing `fetch` to `retryMiddleware`.
+
+Also in this release:
+
+- The README documents `retryMiddleware`'s ordering constraint. Because openapi-fetch runs `onResponse` once per request in reverse registration order, and the middleware retries inside its own hook, **any middleware registered after `retryMiddleware` is skipped for retried responses**. Response-transforming middleware is the dangerous case: the first attempt is transformed and a retried attempt is not, so the caller receives a body in the wrong shape rather than an error. Reordering does not fully resolve this — placing the transform first makes it run after retry, which leaves `throwOnNotOk` building `HttpResponseError` from untransformed error bodies. The documented workaround is to apply the transform in the fetch handed to the client so every attempt passes through it. This is a documentation change only; the composition behaviour is unchanged.

--- a/packages/microservice-util-lib/README.md
+++ b/packages/microservice-util-lib/README.md
@@ -7,6 +7,34 @@ MicroServices tasks.
 
 Documentation on each function can be found [here](docs/modules.md)
 
+## `retryMiddleware` and middleware ordering
+
+`retryMiddleware` performs its retries inside its own `onResponse`/`onError` hook, so retried responses re-enter the middleware chain at that point rather than at the start. openapi-fetch runs `onResponse` once per request, in reverse registration order.
+
+**Any middleware registered after `retryMiddleware` has its `onResponse` run before the retry happens, and is therefore skipped for retried responses.** Response-transforming middleware is the dangerous case: the first attempt is transformed, a retried attempt is not, and the caller receives a body in the wrong shape rather than an error. The failure only appears on the retry path, which is the least exercised in development.
+
+```ts
+// Broken: xmlToJsonMiddleware transforms the first response, but never a retried one
+client.use(retryMiddleware(), xmlToJsonMiddleware());
+```
+
+Reordering alone does not fully solve this. Registering the transform *before* `retryMiddleware` makes it run *after* retry, which leaves `throwOnNotOk` reading untransformed error bodies when it builds an `HttpResponseError`. If you need both, apply the transform in the fetch you hand to the client so every attempt passes through it:
+
+```ts
+// xmlToJson here is a plain (response: Response) => Promise<Response> transform,
+// not a middleware
+const fetchWithXml: typeof fetch = async (...args) => xmlToJson(await fetch(...args));
+
+const client = createClient({ baseUrl, fetch: fetchWithXml });
+client.use(retryMiddleware());
+```
+
+Retries use the client's configured `fetch` by default, so a fetch injected via `ClientOptions.fetch` applies to every attempt. Pass `fetch` in the retry config only when retries must use a different transport.
+
+Note that this covers the fetch function itself, not `ClientOptions.requestInitExt`. openapi-fetch passes `requestInitExt` as the second argument to the initial fetch only, and does not expose it to middleware, so per-attempt options carried there — an undici `dispatcher` for a proxy or mTLS agent, for example — do not apply to retries. Configure those on the fetch you pass to the client instead.
+
+Retried requests do not re-enter `onRequest`. The original request is cloned, so headers already applied survive, but anything that must be recomputed per attempt — OAuth 1.0a signatures, HMAC-over-body, short-lived bearer tokens — needs the `onRetry` callback, which can return a replacement `Request`.
+
 ## Deprecations
 
 `fetchSsmParams` and `S3Dao` are deprecated in favour of `SSMService` and

--- a/packages/microservice-util-lib/docs/classes/HttpResponseError.md
+++ b/packages/microservice-util-lib/docs/classes/HttpResponseError.md
@@ -6,7 +6,7 @@
 
 # Class: HttpResponseError\<TBody\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:58](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L58)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:58](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L58)
 
 Custom error class for HTTP response errors, similar to Axios Error.
 Provides detailed information about the failed request and response.
@@ -67,7 +67,7 @@ Defined in: node\_modules/typescript/lib/lib.es2022.error.d.ts:26
 
 > `readonly` **isHttpResponseError**: `true` = `true`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:64](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L64)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:64](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L64)
 
 ***
 
@@ -91,7 +91,7 @@ Defined in: node\_modules/typescript/lib/lib.es5.d.ts:1077
 
 > `readonly` **name**: `"HttpResponseError"` = `'HttpResponseError'`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:59](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L59)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:59](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L59)
 
 #### Overrides
 
@@ -105,7 +105,7 @@ Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/
 
 > `readonly` **request**: `HttpRequestData`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:63](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L63)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:63](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L63)
 
 ***
 
@@ -115,7 +115,7 @@ Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/
 
 > `readonly` **response**: `HttpResponseData`\<`TBody`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:62](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L62)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:62](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L62)
 
 ***
 
@@ -139,7 +139,7 @@ Defined in: node\_modules/typescript/lib/lib.es5.d.ts:1078
 
 > `readonly` **status**: `number`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:60](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L60)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:60](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L60)
 
 ***
 
@@ -149,7 +149,7 @@ Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/
 
 > `readonly` **statusText**: `string`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:61](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L61)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:61](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L61)
 
 ***
 
@@ -183,7 +183,7 @@ not capture any frames.
 
 > **toJson**(): `object`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:123](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L123)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:123](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L123)
 
 Returns a JSON representation of the error for logging/debugging.
 
@@ -295,7 +295,7 @@ a();
 
 > `static` **create**\<`TBody`\>(`response`, `request`): `Promise`\<`HttpResponseError`\<`TBody`\>\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:88](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L88)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:88](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L88)
 
 Creates an HttpResponseError with pre-read request and response bodies.
 Bodies are read eagerly so they are available for logging/serialization.

--- a/packages/microservice-util-lib/docs/functions/apiKeyAuthMiddleware.md
+++ b/packages/microservice-util-lib/docs/functions/apiKeyAuthMiddleware.md
@@ -8,7 +8,7 @@
 
 > **apiKeyAuthMiddleware**(`config`): `Middleware`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts:37](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts#L37)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts:37](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts#L37)
 
 Creates an openapi-fetch middleware for API key authentication.
 This middleware sets the API key in the specified header for each request.

--- a/packages/microservice-util-lib/docs/functions/basicAuthMiddleware.md
+++ b/packages/microservice-util-lib/docs/functions/basicAuthMiddleware.md
@@ -8,7 +8,7 @@
 
 > **basicAuthMiddleware**(`config`): `Middleware`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts:65](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts#L65)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts:65](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts#L65)
 
 Creates an openapi-fetch middleware for Basic authentication.
 This middleware sets the `Authorization` header with the Basic authentication credentials

--- a/packages/microservice-util-lib/docs/functions/chunkBy.md
+++ b/packages/microservice-util-lib/docs/functions/chunkBy.md
@@ -8,7 +8,7 @@
 
 > **chunkBy**\<`ArrayItem`\>(`source`, `chunkSize`): `ArrayItem`[][]
 
-Defined in: [packages/microservice-util-lib/src/chunk-by/chunk-by.ts:10](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/chunk-by/chunk-by.ts#L10)
+Defined in: [packages/microservice-util-lib/src/chunk-by/chunk-by.ts:10](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/chunk-by/chunk-by.ts#L10)
 
 Split an array into chunks of a certain size
 

--- a/packages/microservice-util-lib/docs/functions/createErrorThrowingClient.md
+++ b/packages/microservice-util-lib/docs/functions/createErrorThrowingClient.md
@@ -8,7 +8,7 @@
 
 > **createErrorThrowingClient**\<`Paths`, `Media`\>(`options`): [`ErrorThrowingClient`](../interfaces/ErrorThrowingClient.md)\<`Paths`, `Media`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:111](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L111)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:111](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L111)
 
 Create an openapi-fetch client and cast it to an ErrorThrowingClient.
 

--- a/packages/microservice-util-lib/docs/functions/fetchSsmParams.md
+++ b/packages/microservice-util-lib/docs/functions/fetchSsmParams.md
@@ -34,7 +34,7 @@ the keys of the parameters to fetch
 
 > **fetchSsmParams**(`param`): `Promise`\<`Parameter` \| `undefined`\>
 
-Defined in: [packages/microservice-util-lib/src/fetch-ssm-params/fetch-ssm-params.ts:15](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/fetch-ssm-params/fetch-ssm-params.ts#L15)
+Defined in: [packages/microservice-util-lib/src/fetch-ssm-params/fetch-ssm-params.ts:15](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/fetch-ssm-params/fetch-ssm-params.ts#L15)
 
 Fetch one SSM parameter
 
@@ -58,7 +58,7 @@ Use `SSMService#getParameter` from `@aligent/aws-wrappers` instead.
 
 > **fetchSsmParams**(...`params`): `Promise`\<(`Parameter` \| `undefined`)[]\>
 
-Defined in: [packages/microservice-util-lib/src/fetch-ssm-params/fetch-ssm-params.ts:22](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/fetch-ssm-params/fetch-ssm-params.ts#L22)
+Defined in: [packages/microservice-util-lib/src/fetch-ssm-params/fetch-ssm-params.ts:22](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/fetch-ssm-params/fetch-ssm-params.ts#L22)
 
 Fetch a list of SSM parameters
 

--- a/packages/microservice-util-lib/docs/functions/getAwsIdFromArn.md
+++ b/packages/microservice-util-lib/docs/functions/getAwsIdFromArn.md
@@ -8,7 +8,7 @@
 
 > **getAwsIdFromArn**(`resourceArn`): `string`
 
-Defined in: [packages/microservice-util-lib/src/get-aws-id-from-arn/get-aws-id-from-arn.ts:11](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/get-aws-id-from-arn/get-aws-id-from-arn.ts#L11)
+Defined in: [packages/microservice-util-lib/src/get-aws-id-from-arn/get-aws-id-from-arn.ts:11](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/get-aws-id-from-arn/get-aws-id-from-arn.ts#L11)
 
 Get the AWS ID from its resource ARN
 

--- a/packages/microservice-util-lib/docs/functions/hasDefinedProperties.md
+++ b/packages/microservice-util-lib/docs/functions/hasDefinedProperties.md
@@ -8,7 +8,7 @@
 
 > **hasDefinedProperties**\<`T`, `K`\>(`obj`, ...`keys`): `obj is SimplifyIntersection<Required<Pick<T, K>> & Omit<T, K>>`
 
-Defined in: [packages/microservice-util-lib/src/has-properties-defined/has-properties-defined.ts:23](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/has-properties-defined/has-properties-defined.ts#L23)
+Defined in: [packages/microservice-util-lib/src/has-properties-defined/has-properties-defined.ts:23](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/has-properties-defined/has-properties-defined.ts#L23)
 
 Ensure that the given properties are defined on the object.
 

--- a/packages/microservice-util-lib/docs/functions/isHttpResponseError.md
+++ b/packages/microservice-util-lib/docs/functions/isHttpResponseError.md
@@ -8,7 +8,7 @@
 
 > **isHttpResponseError**\<`TBody`\>(`error`): `error is HttpResponseError<TBody>`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:157](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L157)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts:157](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/utils/http-response-error.ts#L157)
 
 Type guard to check if an error is an [HttpResponseError](../classes/HttpResponseError.md).
 Useful for narrowing error types in catch blocks.

--- a/packages/microservice-util-lib/docs/functions/logMiddleware.md
+++ b/packages/microservice-util-lib/docs/functions/logMiddleware.md
@@ -8,7 +8,7 @@
 
 > **logMiddleware**(`clientName`, `logLevel?`, `logger?`): `Middleware`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts:57](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts#L57)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts:57](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts#L57)
 
 Creates a logging middleware for openapi-fetch clients.
 

--- a/packages/microservice-util-lib/docs/functions/oAuth10aAuthMiddleware.md
+++ b/packages/microservice-util-lib/docs/functions/oAuth10aAuthMiddleware.md
@@ -8,7 +8,7 @@
 
 > **oAuth10aAuthMiddleware**(`config`): `Middleware`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts:105](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts#L105)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts:105](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts#L105)
 
 Creates an openapi-fetch middleware for OAuth 1.0a authentication.
 This middleware generates OAuth 1.0a parameters and sets the `Authorization` header

--- a/packages/microservice-util-lib/docs/functions/oAuth20AuthMiddleware.md
+++ b/packages/microservice-util-lib/docs/functions/oAuth20AuthMiddleware.md
@@ -8,7 +8,7 @@
 
 > **oAuth20AuthMiddleware**(`options`): `Middleware`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts:136](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts#L136)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts:136](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/authentications.ts#L136)
 
 Creates an openapi-fetch middleware for OAuth 2.0 authentication.
 This middleware sets the `Authorization` header with the OAuth 2.0 token for each request.

--- a/packages/microservice-util-lib/docs/functions/remap.md
+++ b/packages/microservice-util-lib/docs/functions/remap.md
@@ -8,7 +8,7 @@
 
 > **remap**\<`Original`, `MapArray`\>(`object`, `map`): `SimplifyIntersection`\<`ConstructTypeFromProperties`\<`MapArray`, `Original`, `0`\>\>
 
-Defined in: [packages/microservice-util-lib/src/remap/remap.ts:246](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/remap/remap.ts#L246)
+Defined in: [packages/microservice-util-lib/src/remap/remap.ts:246](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/remap/remap.ts#L246)
 
 Map one object's values to another structure
 

--- a/packages/microservice-util-lib/docs/functions/resignOauth10aRequest.md
+++ b/packages/microservice-util-lib/docs/functions/resignOauth10aRequest.md
@@ -8,7 +8,7 @@
 
 > **resignOauth10aRequest**(`request`, `config`): `Promise`\<`Request`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.ts:292](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.ts#L292)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.ts:292](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.ts#L292)
 
 Standalone function that re-signs a `Request` with fresh OAuth 1.0a credentials.
 This function derives all information (URL, method, query params, body)

--- a/packages/microservice-util-lib/docs/functions/retryMiddleware.md
+++ b/packages/microservice-util-lib/docs/functions/retryMiddleware.md
@@ -8,7 +8,7 @@
 
 > **retryMiddleware**(`config?`): `Middleware`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts:186](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts#L186)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts:186](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts#L186)
 
 This middleware implements retry logic with support for:
 - Configurable number of retry attempts

--- a/packages/microservice-util-lib/docs/functions/retryWrapper.md
+++ b/packages/microservice-util-lib/docs/functions/retryWrapper.md
@@ -8,7 +8,7 @@
 
 > **retryWrapper**\<`T`\>(`fn`, `config`): `Promise`\<`T`\>
 
-Defined in: [packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts:78](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts#L78)
+Defined in: [packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts:78](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts#L78)
 
 Retry an async function if it fails
 

--- a/packages/microservice-util-lib/docs/interfaces/ApiKey.md
+++ b/packages/microservice-util-lib/docs/interfaces/ApiKey.md
@@ -6,7 +6,7 @@
 
 # Interface: ApiKey
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:28](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L28)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:28](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L28)
 
 Represents an API key authentication method.
 
@@ -23,7 +23,7 @@ in a specific header. The value can be a static string or a function that return
 
 > **header**: `string`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:29](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L29)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:29](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L29)
 
 The header name where the API key will be set.
 
@@ -35,6 +35,6 @@ The header name where the API key will be set.
 
 > **value**: `Resolvable`\<`string`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:30](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L30)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:30](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L30)
 
 The API key value, or a function returning it.

--- a/packages/microservice-util-lib/docs/interfaces/Basic.md
+++ b/packages/microservice-util-lib/docs/interfaces/Basic.md
@@ -6,7 +6,7 @@
 
 # Interface: Basic
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:42](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L42)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:42](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L42)
 
 Represents basic authentication credentials.
 
@@ -23,6 +23,6 @@ can be provided statically or retrieved dynamically via a function.
 
 > **credentials**: `Resolvable`\<\{ `password`: `string`; `username`: `string`; \}\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:43](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L43)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:43](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L43)
 
 The credentials, or a function returning them.

--- a/packages/microservice-util-lib/docs/interfaces/ErrorThrowingClient.md
+++ b/packages/microservice-util-lib/docs/interfaces/ErrorThrowingClient.md
@@ -6,7 +6,7 @@
 
 # Interface: ErrorThrowingClient\<Paths, Media\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:88](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L88)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:88](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L88)
 
 A Client whose HTTP methods return only the success branch
 ({ data: D; response: Response }), reflecting the runtime contract
@@ -32,7 +32,7 @@ Errors are thrown as HttpResponseError, never returned in the union.
 
 > **DELETE**: `ThrowingClientMethod`\<`Paths`, `"delete"`, `Media`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:92](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L92)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:92](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L92)
 
 ***
 
@@ -42,7 +42,7 @@ Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwi
 
 > **GET**: `ThrowingClientMethod`\<`Paths`, `"get"`, `Media`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:89](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L89)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:89](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L89)
 
 ***
 
@@ -52,7 +52,7 @@ Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwi
 
 > **HEAD**: `ThrowingClientMethod`\<`Paths`, `"head"`, `Media`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:94](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L94)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:94](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L94)
 
 ***
 
@@ -62,7 +62,7 @@ Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwi
 
 > **OPTIONS**: `ThrowingClientMethod`\<`Paths`, `"options"`, `Media`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:93](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L93)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:93](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L93)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwi
 
 > **PATCH**: `ThrowingClientMethod`\<`Paths`, `"patch"`, `Media`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:95](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L95)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:95](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L95)
 
 ***
 
@@ -82,7 +82,7 @@ Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwi
 
 > **POST**: `ThrowingClientMethod`\<`Paths`, `"post"`, `Media`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:91](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L91)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:91](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L91)
 
 ***
 
@@ -92,7 +92,7 @@ Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwi
 
 > **PUT**: `ThrowingClientMethod`\<`Paths`, `"put"`, `Media`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:90](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L90)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:90](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L90)
 
 ***
 
@@ -102,7 +102,7 @@ Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwi
 
 > **TRACE**: `ThrowingClientMethod`\<`Paths`, `"trace"`, `Media`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:96](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L96)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:96](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L96)
 
 ## Methods
 
@@ -112,7 +112,7 @@ Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwi
 
 > **eject**(...`middleware`): `void`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:98](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L98)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:98](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L98)
 
 #### Parameters
 
@@ -132,7 +132,7 @@ Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwi
 
 > **use**(...`middleware`): `void`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:97](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L97)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts:97](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/throwing-client.ts#L97)
 
 #### Parameters
 

--- a/packages/microservice-util-lib/docs/interfaces/Logger.md
+++ b/packages/microservice-util-lib/docs/interfaces/Logger.md
@@ -6,7 +6,7 @@
 
 # Interface: Logger
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts:7](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts#L7)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts:7](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts#L7)
 
 Logger interface to support various logging implementations
 (console, winston, pino, bunyan, etc.)
@@ -19,7 +19,7 @@ Logger interface to support various logging implementations
 
 > `optional` **debug**(`message`, ...`args`): `void`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts:9](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts#L9)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts:9](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts#L9)
 
 #### Parameters
 
@@ -43,7 +43,7 @@ Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts
 
 > **info**(`message`, ...`args`): `void`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts:8](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts#L8)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts:8](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts#L8)
 
 #### Parameters
 

--- a/packages/microservice-util-lib/docs/interfaces/OAuth10a.md
+++ b/packages/microservice-util-lib/docs/interfaces/OAuth10a.md
@@ -6,7 +6,7 @@
 
 # Interface: OAuth10a
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:61](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L61)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:61](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L61)
 
 Represents OAuth 1.0a authentication credentials.
 
@@ -24,7 +24,7 @@ It also supports optional parameters like body hash inclusion, realm, callback, 
 
 > **algorithm**: `"HMAC-SHA1"` \| `"HMAC-SHA256"`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:62](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L62)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:62](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L62)
 
 The signing algorithm to use.
 
@@ -36,7 +36,7 @@ The signing algorithm to use.
 
 > `optional` **callback?**: `string`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:71](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L71)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:71](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L71)
 
 The callback URL for OAuth 1.0a.
 
@@ -48,7 +48,7 @@ The callback URL for OAuth 1.0a.
 
 > **credentials**: `Resolvable`\<\{ `consumerKey`: `string`; `consumerSecret`: `string`; `token?`: `string`; `tokenSecret`: `string`; \}\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:63](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L63)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:63](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L63)
 
 The OAuth 1.0a credentials, or a function returning them.
 
@@ -60,7 +60,7 @@ The OAuth 1.0a credentials, or a function returning them.
 
 > `optional` **includeBodyHash?**: `boolean` \| `"auto"`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:69](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L69)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:69](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L69)
 
 Whether to include a body hash in the signature. Defaults to 'auto'.
 
@@ -72,7 +72,7 @@ Whether to include a body hash in the signature. Defaults to 'auto'.
 
 > `optional` **realm?**: `string`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:70](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L70)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:70](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L70)
 
 The realm parameter for the Authorization header.
 
@@ -84,6 +84,6 @@ The realm parameter for the Authorization header.
 
 > `optional` **verifier?**: `string`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:72](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L72)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:72](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L72)
 
 The verifier for OAuth 1.0a.

--- a/packages/microservice-util-lib/docs/interfaces/OAuth20.md
+++ b/packages/microservice-util-lib/docs/interfaces/OAuth20.md
@@ -6,7 +6,7 @@
 
 # Interface: OAuth20
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:86](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L86)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:86](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L86)
 
 Represents OAuth 2.0 authentication credentials.
 
@@ -24,7 +24,7 @@ It also supports an optional token type (e.g., 'Bearer').
 
 > **token**: `Resolvable`\<`string`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:87](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L87)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:87](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L87)
 
 The access token, or a function returning it.
 
@@ -36,6 +36,6 @@ The access token, or a function returning it.
 
 > `optional` **tokenType?**: `string`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:88](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L88)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts:88](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/authentications.ts#L88)
 
 The type of the token (e.g., 'Bearer'). Defaults to 'Bearer' if not specified.

--- a/packages/microservice-util-lib/docs/interfaces/RetryConfig.md
+++ b/packages/microservice-util-lib/docs/interfaces/RetryConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: RetryConfig
 
-Defined in: [packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts:2](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts#L2)
+Defined in: [packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts:2](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts#L2)
 
 Configuration for the retryWrapper
 
@@ -18,7 +18,7 @@ Configuration for the retryWrapper
 
 > `optional` **backoffAmount?**: `number`
 
-Defined in: [packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts:17](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts#L17)
+Defined in: [packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts:17](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts#L17)
 
 The amount to increase the delay by each retry (in ms)
 
@@ -36,7 +36,7 @@ The amount to increase the delay by each retry (in ms)
 
 > `optional` **delay?**: `number`
 
-Defined in: [packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts:12](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts#L12)
+Defined in: [packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts:12](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts#L12)
 
 The base delay between retries (in ms)
 
@@ -54,7 +54,7 @@ The base delay between retries (in ms)
 
 > `optional` **onRetry?**: (`retries`, `error`, `config`) => `void`
 
-Defined in: [packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts:24](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts#L24)
+Defined in: [packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts:24](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts#L24)
 
 A callback to run before each retry
 
@@ -90,7 +90,7 @@ the configuration supplied to the retryWrapper
 
 > `optional` **retries?**: `number`
 
-Defined in: [packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts:7](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts#L7)
+Defined in: [packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts:7](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/retry-wrapper/retry-wrapper.ts#L7)
 
 The number of retries to attempt after the first run
 

--- a/packages/microservice-util-lib/docs/interfaces/RetryMiddlewareConfig.md
+++ b/packages/microservice-util-lib/docs/interfaces/RetryMiddlewareConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: RetryMiddlewareConfig
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:96](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L96)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:101](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L101)
 
 Configuration for the retry middleware.
 
@@ -26,7 +26,7 @@ This interface provides options to configure retry behavior, including:
 
 > `optional` **baseDelay?**: `number`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:100](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L100)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:105](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L105)
 
 Base delay in milliseconds for built-in delay strategies.
 
@@ -38,10 +38,15 @@ Base delay in milliseconds for built-in delay strategies.
 
 > `optional` **fetch?**: (`input`, `init?`) => `Promise`\<`Response`\>
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:107](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L107)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:112](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L112)
 
-Custom fetch function to use for retries. Defaults to the global fetch function.
-- Useful for testing or using a custom fetch implementation.
+Custom fetch function to use for retries.
+- Defaults to the fetch the client was created with (`ClientOptions.fetch`), falling back to
+  the global fetch when the client does not configure one. Only set this when retries must use
+  a different transport to the initial request.
+- Note this covers the fetch function only. `ClientOptions.requestInitExt` is passed by
+  openapi-fetch to the initial fetch alone and is not exposed to middleware, so options
+  carried there do not apply to retries.
 
 #### Parameters
 
@@ -65,7 +70,7 @@ Custom fetch function to use for retries. Defaults to the global fetch function.
 
 > `optional` **idempotentOnly?**: `boolean`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:105](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L105)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:110](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L110)
 
 Whether to retry only when the HTTP method is idempotent.
 - Defaults to `true`, retrying only on GET, HEAD, OPTIONS, PUT, or DELETE methods.
@@ -78,7 +83,7 @@ Whether to retry only when the HTTP method is idempotent.
 
 > `optional` **maxDelay?**: `number`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:101](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L101)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:106](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L106)
 
 Maximum delay in milliseconds between retry attempts.
 
@@ -90,7 +95,7 @@ Maximum delay in milliseconds between retry attempts.
 
 > `optional` **onRetry?**: `OnRetryFn`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:103](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L103)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:108](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L108)
 
 Callback executed before each retry attempt (not the initial request).
 - If it returns a `Request`, that request replaces the current one for the retry.
@@ -105,7 +110,7 @@ Callback executed before each retry attempt (not the initial request).
 
 > `optional` **retries?**: `number`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:97](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L97)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:102](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L102)
 
 The maximum number of retry attempts.
 
@@ -117,7 +122,7 @@ The maximum number of retry attempts.
 
 > `optional` **retryCondition?**: `RetryConditionFn`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:98](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L98)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:103](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L103)
 
 Custom function to determine if a request should be retried.
 - Defaults to retrying on 5xx, 429, 408 errors and network errors.
@@ -130,7 +135,7 @@ Custom function to determine if a request should be retried.
 
 > `optional` **retryDelay?**: `RetryDelayFn` \| `"exponential"` \| `"linear"`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:99](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L99)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:104](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L104)
 
 Strategy for calculating delay between retries.
      - 'exponential': Exponential backoff (100ms * 2^attemptNumber)
@@ -145,7 +150,7 @@ Strategy for calculating delay between retries.
 
 > `optional` **retryOn?**: `number`[]
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:104](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L104)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:109](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L109)
 
 Array of HTTP status codes that should trigger a retry.
 - Defaults to 5xx, 429, and 408 errors.
@@ -158,7 +163,7 @@ Array of HTTP status codes that should trigger a retry.
 
 > `optional` **shouldResetTimeout?**: `boolean`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:102](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L102)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:107](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L107)
 
 Whether to reset the timeout between retries.
 
@@ -170,7 +175,7 @@ Whether to reset the timeout between retries.
 
 > `optional` **throwOnNotOk?**: `boolean`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:106](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L106)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts:111](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts#L111)
 
 Whether to throw an `HttpResponseError` when the final response has a non-OK status (i.e. not 2xx).
 - Defaults to `true` for backward compatibility.

--- a/packages/microservice-util-lib/docs/interfaces/S3Dao.md
+++ b/packages/microservice-util-lib/docs/interfaces/S3Dao.md
@@ -6,7 +6,7 @@
 
 # ~~Interface: S3Dao~~
 
-Defined in: [packages/microservice-util-lib/src/s3/s3.ts:30](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/s3/s3.ts#L30)
+Defined in: [packages/microservice-util-lib/src/s3/s3.ts:30](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/s3/s3.ts#L30)
 
 A data access object for an S3 bucket
 
@@ -36,7 +36,7 @@ const data = await s3.getJsonObject({ Bucket: 'my-bucket', Key: key });
 
 > **deleteData**(`objectDetails`): `Promise`\<`DeleteObjectCommandOutput`\>
 
-Defined in: [packages/microservice-util-lib/src/s3/s3.ts:127](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/s3/s3.ts#L127)
+Defined in: [packages/microservice-util-lib/src/s3/s3.ts:127](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/s3/s3.ts#L127)
 
 Delete an object from the S3 bucket
 
@@ -64,7 +64,7 @@ Use `S3Service#deleteObject` from `@aligent/aws-wrappers` instead.
 
 > **fetchChunks**\<`T`\>(`chunks`): `AsyncGenerator`\<\{ `chunk`: `T`; `s3Object`: `GetObjectCommandInput` \| `undefined`; \}, `Awaited`\<`T`\>, `unknown`\>
 
-Defined in: [packages/microservice-util-lib/src/s3/s3.ts:107](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/s3/s3.ts#L107)
+Defined in: [packages/microservice-util-lib/src/s3/s3.ts:107](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/s3/s3.ts#L107)
 
 Generator to fetch chunked data, chunk by chunk
 
@@ -99,7 +99,7 @@ chunks yourself with `S3Service#getJsonObject`.
 
 > **fetchData**\<`T`\>(`objectDetails`): `Promise`\<`T`\>
 
-Defined in: [packages/microservice-util-lib/src/s3/s3.ts:90](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/s3/s3.ts#L90)
+Defined in: [packages/microservice-util-lib/src/s3/s3.ts:90](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/s3/s3.ts#L90)
 
 Fetch an object from the S3 bucket
 
@@ -135,7 +135,7 @@ Use `S3Service#getJsonObject` from `@aligent/aws-wrappers` instead.
 
 > **storeChunked**\<`T`\>(`data`, `chunkSize`): `Promise`\<`GetObjectCommandInput`[]\>
 
-Defined in: [packages/microservice-util-lib/src/s3/s3.ts:79](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/s3/s3.ts#L79)
+Defined in: [packages/microservice-util-lib/src/s3/s3.ts:79](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/s3/s3.ts#L79)
 
 Store an array of object as individual chunks in S3
 
@@ -178,7 +178,7 @@ No direct equivalent in `@aligent/aws-wrappers` — compose
 
 > **storeData**\<`T`\>(`data`, `name?`): `Promise`\<`GetObjectCommandInput`\>
 
-Defined in: [packages/microservice-util-lib/src/s3/s3.ts:51](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/s3/s3.ts#L51)
+Defined in: [packages/microservice-util-lib/src/s3/s3.ts:51](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/s3/s3.ts#L51)
 
 Store data in an S3 bucket
 

--- a/packages/microservice-util-lib/docs/type-aliases/LogLevel.md
+++ b/packages/microservice-util-lib/docs/type-aliases/LogLevel.md
@@ -8,4 +8,4 @@
 
 > **LogLevel** = `"INFO"` \| `"DEBUG"`
 
-Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts:12](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts#L12)
+Defined in: [packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts:12](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/openapi-fetch-middlewares/log.ts#L12)

--- a/packages/microservice-util-lib/docs/type-aliases/ObjectMap.md
+++ b/packages/microservice-util-lib/docs/type-aliases/ObjectMap.md
@@ -8,6 +8,6 @@
 
 > **ObjectMap** = `ReadonlyArray`\<readonly \[`string`, `string`, (...`args`) => `any`?\]\>
 
-Defined in: [packages/microservice-util-lib/src/remap/remap.ts:70](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/remap/remap.ts#L70)
+Defined in: [packages/microservice-util-lib/src/remap/remap.ts:70](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/remap/remap.ts#L70)
 
 A list of keys to keys, with an optional transformer function

--- a/packages/microservice-util-lib/docs/type-aliases/Remap.md
+++ b/packages/microservice-util-lib/docs/type-aliases/Remap.md
@@ -8,7 +8,7 @@
 
 > **Remap**\<`MapArray`, `Original`\> = `SimplifyIntersection`\<`ConstructTypeFromProperties`\<`MapArray`, `Original`\>\>
 
-Defined in: [packages/microservice-util-lib/src/remap/remap.ts:208](https://github.com/aligent/microservice-development-utilities/blob/abc9d337f3d99af75f0aee53a8dae4dfd3173b99/packages/microservice-util-lib/src/remap/remap.ts#L208)
+Defined in: [packages/microservice-util-lib/src/remap/remap.ts:208](https://github.com/aligent/microservice-development-utilities/blob/2924feaebbc12f9d81d6c8e146827daf51044cc9/packages/microservice-util-lib/src/remap/remap.ts#L208)
 
 ## Type Parameters
 

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.test.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.test.ts
@@ -1024,6 +1024,100 @@ describe('retry middleware', () => {
         });
     });
 
+    describe('fetch resolution', () => {
+        it('should retry using the client fetch when no fetch is configured', async () => {
+            mockFetch
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({ error: 'Server Error' }), {
+                        status: 500,
+                        headers: { 'Content-Type': 'application/json' },
+                    })
+                )
+                .mockResolvedValueOnce(
+                    new Response(JSON.stringify({ message: 'success' }), {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    })
+                );
+            // Rejects rather than calling through, so a regression fails the assertion
+            // below instead of escaping to the network.
+            const globalFetch = vi
+                .spyOn(globalThis, 'fetch')
+                .mockRejectedValue(new Error('global fetch must not be used for retries'));
+
+            const client = createClient<paths>({
+                baseUrl: 'https://api.example.com',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(retryMiddleware({ retries: 2, baseDelay: 10 }));
+
+            const { data } = await client.GET('/test');
+
+            expect(data).toEqual({ message: 'success' });
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+            expect(globalFetch).not.toHaveBeenCalled();
+        });
+
+        it('should prefer an explicitly configured fetch over the client fetch', async () => {
+            const retryFetch = vi.fn().mockResolvedValue(
+                new Response(JSON.stringify({ message: 'from retry fetch' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+            mockFetch.mockResolvedValue(
+                new Response(JSON.stringify({ error: 'Server Error' }), {
+                    status: 500,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+
+            const client = createClient<paths>({
+                baseUrl: 'https://api.example.com',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(
+                retryMiddleware({
+                    retries: 2,
+                    baseDelay: 10,
+                    fetch: retryFetch as typeof fetch,
+                })
+            );
+
+            const { data } = await client.GET('/test');
+
+            expect(data).toEqual({ message: 'from retry fetch' });
+            expect(retryFetch).toHaveBeenCalledTimes(1);
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        it('should retry network errors using the client fetch when no fetch is configured', async () => {
+            mockFetch.mockRejectedValueOnce(new TypeError('fetch failed')).mockResolvedValueOnce(
+                new Response(JSON.stringify({ message: 'success' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                })
+            );
+            // Rejects rather than calling through, so a regression fails the assertion
+            // below instead of escaping to the network.
+            const globalFetch = vi
+                .spyOn(globalThis, 'fetch')
+                .mockRejectedValue(new Error('global fetch must not be used for retries'));
+
+            const client = createClient<paths>({
+                baseUrl: 'https://api.example.com',
+                fetch: mockFetch as typeof fetch,
+            });
+            client.use(retryMiddleware({ retries: 2, baseDelay: 10 }));
+
+            const { data } = await client.GET('/test');
+
+            expect(data).toEqual({ message: 'success' });
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+            expect(globalFetch).not.toHaveBeenCalled();
+        });
+    });
+
     it('should throw error when final response is not ok after exhausting retries', async () => {
         mockFetch.mockResolvedValue(
             new Response(JSON.stringify({ error: 'Internal Server Error' }), {

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/retry.ts
@@ -184,52 +184,55 @@ async function throwErrorIfNotOkResponse(
  * });
  */
 function retryMiddleware(config?: RetryConfig): Middleware {
-    const normalisedConfig: NormalisedConfig = {
+    const normalisedConfig: Omit<NormalisedConfig, 'fetch'> = {
         ...config,
         retries: config?.retries ?? 3,
         retryCondition: config?.retryCondition ?? defaultRetryCondition,
         retryDelay: getRetryDelayFn(config),
         idempotentOnly: config?.idempotentOnly ?? true,
-        fetch: config?.fetch ?? fetch,
         throwOnNotOk: config?.throwOnNotOk ?? true,
     };
 
+    // Resolved per request so retries reuse the client's transport rather than the global
+    // fetch, which would otherwise bypass any fetch injected via `ClientOptions.fetch`.
+    const withFetch = (clientFetch: typeof fetch): NormalisedConfig => ({
+        ...normalisedConfig,
+        fetch: config?.fetch ?? clientFetch,
+    });
+
     return {
-        async onResponse({ request, response }) {
+        async onResponse({ request, response, options }) {
+            const resolvedConfig = withFetch(options.fetch);
             const context = { attempt: 1, request, response, error: null };
 
             // If retryOn is specified, only use that list
             if (config?.retryOn && config.retryOn.length > 0) {
                 if (!shouldRetryOnStatus(response.status, config.retryOn)) {
-                    await throwErrorIfNotOkResponse(
-                        response,
-                        request,
-                        normalisedConfig.throwOnNotOk
-                    );
+                    await throwErrorIfNotOkResponse(response, request, resolvedConfig.throwOnNotOk);
                     return response;
                 }
 
-                return await performRetries(normalisedConfig, context);
+                return await performRetries(resolvedConfig, context);
             }
 
             // Otherwise, check if we should retry based on retry condition
-            const shouldRetry = await normalisedConfig.retryCondition(
+            const shouldRetry = await resolvedConfig.retryCondition(
                 context,
-                normalisedConfig.idempotentOnly
+                resolvedConfig.idempotentOnly
             );
             if (!shouldRetry) {
-                await throwErrorIfNotOkResponse(response, request, normalisedConfig.throwOnNotOk);
+                await throwErrorIfNotOkResponse(response, request, resolvedConfig.throwOnNotOk);
                 return response;
             }
 
-            return await performRetries(normalisedConfig, context);
+            return await performRetries(resolvedConfig, context);
         },
-        async onError({ request, error }) {
+        async onError({ request, error, options }) {
             if (!isNetworkError(error)) {
                 throw error;
             }
 
-            return await performRetries(normalisedConfig, {
+            return await performRetries(withFetch(options.fetch), {
                 attempt: 1,
                 request,
                 response: null,

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/types/retry.ts
@@ -90,8 +90,13 @@ export type OnRetryFn = (context: RetryContext) => Request | void | Promise<Requ
  * - Set to `false` to return the response as-is, which allows downstream middlewares
  *   (e.g. logging middleware) to inspect the response before the caller handles the error.
  * @property {typeof fetch} [fetch]
- * - Custom fetch function to use for retries. Defaults to the global fetch function.
- * - Useful for testing or using a custom fetch implementation.
+ * - Custom fetch function to use for retries.
+ * - Defaults to the fetch the client was created with (`ClientOptions.fetch`), falling back to
+ *   the global fetch when the client does not configure one. Only set this when retries must use
+ *   a different transport to the initial request.
+ * - Note this covers the fetch function only. `ClientOptions.requestInitExt` is passed by
+ *   openapi-fetch to the initial fetch alone and is not exposed to middleware, so options
+ *   carried there do not apply to retries.
  */
 export interface RetryConfig {
     retries?: number;


### PR DESCRIPTION
---

**Description of the proposed changes**

- `retryMiddleware` now performs its retries using the fetch the client was created with (`ClientOptions.fetch`), falling back to the global fetch only when the client does not configure one. An explicitly configured `fetch` in the retry config still takes precedence.
- Previously `config?.fetch ?? fetch` was bound when the middleware was constructed, so a fetch injected into `createClient` applied to the initial request but not to any retry. In tests a fetch double saw one call while the retry escaped to the network; in production, instrumentation or proxying wired into the client's fetch was skipped on the retry path. Both the `onResponse` and `onError` (network error) paths are fixed.
- `options.fetch` turned out to be reachable from inside a middleware — openapi-fetch freezes the client's resolved options into the middleware callback params — so this needed no API change.
- Documents `retryMiddleware`'s ordering constraint in the package README. openapi-fetch runs `onResponse` once per request in reverse registration order, so **any middleware registered after `retryMiddleware` is skipped for retried responses**. Response-transforming middleware is the dangerous case: attempt 1 is transformed, a retry is not, and the caller gets a body in the wrong shape rather than an error. This caused a production Lambda failure in the Accent Group AP21 integration.
- Regression tests cover both retry paths, plus the precedence of an explicit `fetch`.
- Version plan added (minor). Typedoc regenerated.

**Other solutions considered (if any)**

- **Reordering the middleware** does not resolve the skipped-transform problem. Registering the transform *before* `retryMiddleware` makes it run *after* retry, which leaves `throwErrorIfNotOkResponse` building `HttpResponseError` from untransformed error bodies — one silent shape bug traded for another. The README documents the fetch-wrapper workaround instead.
- **Moving retry beneath the chain entirely** (a `retryFetch(fetch, config)` for `ClientOptions.fetch`) is the structurally correct fix and removes the ordering trap rather than documenting it. That is a breaking change to the recommended wiring and is scoped separately — see `packages/microservice-util-lib/prd/retry-transport-redesign.md` on a follow-up branch.

**Notes to reviewers**

- The `docs/` diff is large but almost entirely commit-SHA churn in typedoc permalinks, matching the precedent in 97f11c8. The only substantive doc change is `RetryMiddlewareConfig.md`.
- Two limitations are documented rather than fixed, both deliberate. The response-chain skip itself is unchanged — this PR fixes the transport and documents the ordering trap. And `ClientOptions.requestInitExt` still reaches only the initial request: openapi-fetch does not expose it to middleware, so it cannot be forwarded from here.
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
