### PR TITLE
feat: generate clients that retry at the transport

### DIFF
--- a/.nx/version-plans/version-plan-generator-retry-fetch.md
+++ b/.nx/version-plans/version-plan-generator-retry-fetch.md
@@ -1,0 +1,15 @@
+---
+nx-openapi: minor
+---
+
+Generated clients now wire retries into the client's `fetch` via `retryFetch` instead of registering the deprecated `retryMiddleware`, and register `throwOnNotOk()` for non-2xx responses.
+
+Registering retry as middleware meant a retried response re-entered the middleware chain past anything registered after it, so response-transforming middleware silently skipped retried attempts. Wiring it into `fetch` puts retries beneath the chain, so every attempt flows through it.
+
+The generated registration order also changes to `throwOnNotOk(), logMiddleware(...)`. `onResponse` runs in reverse registration order, so previously `retryMiddleware` threw before `logMiddleware` ran and **generated clients never logged a failing response**. With the logger registered after `throwOnNotOk()`, failures are logged and still thrown.
+
+Also in this release:
+
+- Auth middleware insertion no longer anchors on a statement containing `retryMiddleware`. It anchors on the `this.client.use(...)` call itself, and now throws when no such statement is present rather than silently emitting a client with no auth middleware. Keying the anchor to a specific middleware name was what made it fragile: it stopped matching as soon as retry moved out of the chain.
+
+Existing generated clients are untouched — `client.ts` is only scaffolded on first generation and preserved on override.

--- a/packages/nx-openapi/README.md
+++ b/packages/nx-openapi/README.md
@@ -80,8 +80,9 @@ A `types` file that will contain several typescript interfaces depending on the 
 
 A `client` file that will contain boilerplate code to help you get started. The client includes:
 
-- `logMiddleware` for request/response logging
-- `retryMiddleware` for automatic retry with exponential backoff
+- `retryFetch` wrapping the client's fetch, for automatic retry with exponential backoff
+- `throwOnNotOk` to surface non-2xx responses as `HttpResponseError`
+- `logMiddleware` for request/response logging, registered after `throwOnNotOk` so failures are logged before they throw
 - Authentication middleware configured based on the `--authMethod` flag:
   - **api-key**: Configured to fetch credentials from AWS SSM Parameter Store
   - **oauth1.0a**: Configured with HMAC-SHA256 algorithm and placeholder credentials

--- a/packages/nx-openapi/src/generators/client/client-specific-files/client.ts.template
+++ b/packages/nx-openapi/src/generators/client/client-specific-files/client.ts.template
@@ -7,7 +7,8 @@
  */
 import {
     logMiddleware,
-    retryMiddleware,
+    retryFetch,
+    throwOnNotOk,
 } from '@aligent/microservice-util-lib';
 import createClient, { Client, ClientOptions } from 'openapi-fetch';
 import { paths } from './generated-types';
@@ -16,20 +17,27 @@ export class <%= className %> {
     public readonly client: Client<paths, `${string}/${string}`>;
 
     constructor(options: ClientOptions) {
-        this.client = createClient<paths>(options);
+        /**
+         * Retries wrap the client's fetch rather than being registered as middleware,
+         * so every attempt's response flows through the whole middleware chain.
+         * Pass `onRetry` if a request must be rebuilt per attempt, such as re-signing.
+         */
+        this.client = createClient<paths>({
+            ...options,
+            fetch: retryFetch(options.fetch),
+        });
 
         /**
          * The order in which middleware are registered matters.
          * - For requests, onRequest() will be called in the order registered
          * - For responses, onResponse() will be called in reverse order.
+         *
+         * throwOnNotOk() is registered first so that logMiddleware, registered after
+         * it, still sees a failing response before it is thrown to the caller.
          */
-
         this.client.use(
-            logMiddleware('<%= className %>'),
-            retryMiddleware({
-                onRetry: ({ attempt, error }) =>
-                    console.log(`Retrying...${attempt} due to ${String(error)}`),
-            })
+            throwOnNotOk(),
+            logMiddleware('<%= className %>')
         );
     }
 }

--- a/packages/nx-openapi/src/generators/client/generator.spec.ts
+++ b/packages/nx-openapi/src/generators/client/generator.spec.ts
@@ -235,6 +235,44 @@ describe('client generator', () => {
         expect(clientContent).toContain("logMiddleware('Test')");
     });
 
+    it('should wire retries into the client fetch rather than the middleware chain', async () => {
+        const options: ClientGeneratorSchema = {
+            name: 'test',
+            schemaPath: `${__dirname}/unit-test-schemas/valid.yaml`,
+            skipValidate: true,
+            override: false,
+            authMethod: 'basic',
+        };
+        await clientGenerator(tree, options);
+
+        const clientContent = tree.read('clients/src/test/client.ts', 'utf-8') ?? '';
+
+        // Retry belongs to the transport: registering it as middleware means retried
+        // responses skip any middleware registered after it.
+        expect(clientContent).toContain('retryFetch(');
+        expect(clientContent).not.toContain('retryMiddleware');
+    });
+
+    it('should register throwOnNotOk so failures are logged before they throw', async () => {
+        const options: ClientGeneratorSchema = {
+            name: 'test',
+            schemaPath: `${__dirname}/unit-test-schemas/valid.yaml`,
+            skipValidate: true,
+            override: false,
+            authMethod: 'basic',
+        };
+        await clientGenerator(tree, options);
+
+        const clientContent = tree.read('clients/src/test/client.ts', 'utf-8') ?? '';
+
+        // onResponse runs in reverse registration order, so logMiddleware must be
+        // registered after throwOnNotOk to observe a failing response before the throw.
+        const throwIndex = clientContent.indexOf('throwOnNotOk()');
+        const logIndex = clientContent.indexOf("logMiddleware('Test')");
+        expect(throwIndex).toBeGreaterThanOrEqual(0);
+        expect(logIndex).toBeGreaterThan(throwIndex);
+    });
+
     it('should add clients to root package.json workspaces', async () => {
         tree.write('package.json', JSON.stringify({ name: 'workspace', workspaces: ['libs/*'] }));
 

--- a/packages/nx-openapi/src/generators/client/helpers/auth-configurations.spec.ts
+++ b/packages/nx-openapi/src/generators/client/helpers/auth-configurations.spec.ts
@@ -2,13 +2,13 @@ import { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { applyAuthMethodConfiguration } from './auth-configurations';
 
-const BASE_CLIENT = `import { logMiddleware, retryMiddleware } from '@aligent/microservice-util-lib';
+const BASE_CLIENT = `import { logMiddleware, throwOnNotOk } from '@aligent/microservice-util-lib';
 export class TestClient {
     public readonly client: any;
     constructor() {
         this.client.use(
-            logMiddleware('test'),
-            retryMiddleware({})
+            throwOnNotOk(),
+            logMiddleware('test')
         );
     }
 }`;
@@ -38,7 +38,7 @@ describe('auth-configurations', () => {
         it('should throw error when class is not found', () => {
             tree.write(
                 'client.ts',
-                `import { retryMiddleware } from '@aligent/microservice-util-lib';
+                `import { throwOnNotOk } from '@aligent/microservice-util-lib';
 export class DifferentClass {}`
             );
 
@@ -50,7 +50,7 @@ export class DifferentClass {}`
         it('should throw error when constructor is not found', () => {
             tree.write(
                 'client.ts',
-                `import { retryMiddleware } from '@aligent/microservice-util-lib';
+                `import { throwOnNotOk } from '@aligent/microservice-util-lib';
 export class TestClient {
     public readonly client: any;
 }`
@@ -68,7 +68,7 @@ export class TestClient {
     public readonly client: any;
     constructor() {
         this.client.use(
-            retryMiddleware({})
+            throwOnNotOk()
         );
     }
 }`
@@ -78,14 +78,39 @@ export class TestClient {
             const content = tree.read('client.ts', 'utf-8');
             expect(content).toContain('basicAuthMiddleware');
             expect(content).not.toContain(
-                "import { retryMiddleware, basicAuthMiddleware } from '@aligent/microservice-util-lib'"
+                "import { throwOnNotOk, basicAuthMiddleware } from '@aligent/microservice-util-lib'"
             );
         });
 
-        it('should not insert middleware when retryMiddleware statement is not found', () => {
+        it('should insert middleware into a client that does not use retryMiddleware', () => {
             tree.write(
                 'client.ts',
-                `import { retryMiddleware } from '@aligent/microservice-util-lib';
+                `import { logMiddleware, throwOnNotOk } from '@aligent/microservice-util-lib';
+export class TestClient {
+    public readonly client: any;
+    constructor() {
+        this.client.use(
+            throwOnNotOk(),
+            logMiddleware('test')
+        );
+    }
+}`
+            );
+
+            applyAuthMethodConfiguration(tree, 'client.ts', 'basic', 'TestClient');
+            const content = tree.read('client.ts', 'utf-8');
+
+            expect(content).toContain('basicAuthMiddleware({');
+            const authIndex = content?.indexOf('basicAuthMiddleware({') ?? -1;
+            const logIndex = content?.indexOf("logMiddleware('test')") ?? -1;
+            expect(authIndex).toBeGreaterThanOrEqual(0);
+            expect(authIndex).toBeLessThan(logIndex);
+        });
+
+        it('should throw when no client.use statement is present to anchor against', () => {
+            tree.write(
+                'client.ts',
+                `import { throwOnNotOk } from '@aligent/microservice-util-lib';
 export class TestClient {
     public readonly client: any;
     constructor() {
@@ -94,9 +119,9 @@ export class TestClient {
 }`
             );
 
-            applyAuthMethodConfiguration(tree, 'client.ts', 'basic', 'TestClient');
-            const content = tree.read('client.ts', 'utf-8');
-            expect(content).not.toContain('basicAuthMiddleware({');
+            expect(() =>
+                applyAuthMethodConfiguration(tree, 'client.ts', 'basic', 'TestClient')
+            ).toThrow('Unable to find a this.client.use(...) statement in class: TestClient');
         });
 
         describe('api-key auth method', () => {
@@ -128,15 +153,15 @@ export class TestClient {
                 expect(content).toContain('credentialPath: string');
             });
 
-            it('should insert apiKeyAuthMiddleware before retryMiddleware', () => {
+            it('should insert apiKeyAuthMiddleware before the middleware registration', () => {
                 tree.write('client.ts', BASE_CLIENT);
 
                 applyAuthMethodConfiguration(tree, 'client.ts', 'api-key', 'TestClient');
                 const content = tree.read('client.ts', 'utf-8');
                 const apiKeyIndex = content!.indexOf('apiKeyAuthMiddleware({');
-                const retryIndex = content!.indexOf('retryMiddleware({');
+                const useIndex = content!.indexOf('this.client.use(\n            throwOnNotOk');
                 expect(apiKeyIndex).toBeGreaterThan(-1);
-                expect(apiKeyIndex).toBeLessThan(retryIndex);
+                expect(apiKeyIndex).toBeLessThan(useIndex);
             });
 
             it('should include X-Api-Key header and fetchSsmParams in middleware config', () => {
@@ -152,11 +177,11 @@ export class TestClient {
             it('should skip adding credential property when client property is missing', () => {
                 tree.write(
                     'client.ts',
-                    `import { retryMiddleware } from '@aligent/microservice-util-lib';
+                    `import { throwOnNotOk } from '@aligent/microservice-util-lib';
 export class TestClient {
     constructor() {
         this.client.use(
-            retryMiddleware({})
+            throwOnNotOk()
         );
     }
 }`
@@ -178,15 +203,15 @@ export class TestClient {
                 expect(content).toContain('basicAuthMiddleware');
             });
 
-            it('should insert basicAuthMiddleware before retryMiddleware', () => {
+            it('should insert basicAuthMiddleware before the middleware registration', () => {
                 tree.write('client.ts', BASE_CLIENT);
 
                 applyAuthMethodConfiguration(tree, 'client.ts', 'basic', 'TestClient');
                 const content = tree.read('client.ts', 'utf-8');
                 const basicIndex = content!.indexOf('basicAuthMiddleware({');
-                const retryIndex = content!.indexOf('retryMiddleware({');
+                const useIndex = content!.indexOf('this.client.use(\n            throwOnNotOk');
                 expect(basicIndex).toBeGreaterThan(-1);
-                expect(basicIndex).toBeLessThan(retryIndex);
+                expect(basicIndex).toBeLessThan(useIndex);
             });
 
             it('should not add class property or constructor parameter', () => {
@@ -218,15 +243,15 @@ export class TestClient {
                 expect(content).toContain('oAuth20AuthMiddleware');
             });
 
-            it('should insert oAuth20AuthMiddleware before retryMiddleware', () => {
+            it('should insert oAuth20AuthMiddleware before the middleware registration', () => {
                 tree.write('client.ts', BASE_CLIENT);
 
                 applyAuthMethodConfiguration(tree, 'client.ts', 'oauth2.0', 'TestClient');
                 const content = tree.read('client.ts', 'utf-8');
                 const oauthIndex = content!.indexOf('oAuth20AuthMiddleware({');
-                const retryIndex = content!.indexOf('retryMiddleware({');
+                const useIndex = content!.indexOf('this.client.use(\n            throwOnNotOk');
                 expect(oauthIndex).toBeGreaterThan(-1);
-                expect(oauthIndex).toBeLessThan(retryIndex);
+                expect(oauthIndex).toBeLessThan(useIndex);
             });
 
             it('should not add class property or constructor parameter', () => {
@@ -256,15 +281,15 @@ export class TestClient {
                 expect(content).toContain('oAuth10aAuthMiddleware');
             });
 
-            it('should insert oAuth10aAuthMiddleware before retryMiddleware', () => {
+            it('should insert oAuth10aAuthMiddleware before the middleware registration', () => {
                 tree.write('client.ts', BASE_CLIENT);
 
                 applyAuthMethodConfiguration(tree, 'client.ts', 'oauth1.0a', 'TestClient');
                 const content = tree.read('client.ts', 'utf-8');
                 const oauthIndex = content!.indexOf('oAuth10aAuthMiddleware({');
-                const retryIndex = content!.indexOf('retryMiddleware({');
+                const useIndex = content!.indexOf('this.client.use(\n            throwOnNotOk');
                 expect(oauthIndex).toBeGreaterThan(-1);
-                expect(oauthIndex).toBeLessThan(retryIndex);
+                expect(oauthIndex).toBeLessThan(useIndex);
             });
 
             it('should not add class property or constructor parameter', () => {

--- a/packages/nx-openapi/src/generators/client/helpers/auth-configurations.ts
+++ b/packages/nx-openapi/src/generators/client/helpers/auth-configurations.ts
@@ -172,17 +172,19 @@ export function applyAuthMethodConfiguration(
             })
         );`;
 
-    // Find the middleware use statement and insert auth before it
+    // Insert auth before the middleware registration. Anchored on the `use()` call
+    // itself rather than on any particular middleware — keying on a middleware name
+    // silently stopped matching when retry moved out of the chain.
     const statements = constructor.getStatements();
-    const retryStatementIndex = statements.findIndex(
-        statement =>
-            /this\.client\.use\(/.test(statement.getText()) &&
-            /retryMiddleware/.test(statement.getText())
+    const useStatementIndex = statements.findIndex(statement =>
+        /this\.client\.use\(/.test(statement.getText())
     );
 
-    if (retryStatementIndex !== -1) {
-        constructor.insertStatements(retryStatementIndex, middlewareCall);
+    if (useStatementIndex === -1) {
+        throw new Error(`Unable to find a this.client.use(...) statement in class: ${className}`);
     }
+
+    constructor.insertStatements(useStatementIndex, middlewareCall);
 
     // Write the modified content back to the tree
     tree.write(filePath, sourceFile.getFullText());


### PR DESCRIPTION
---

**Description of the proposed changes**

- Generated clients now wire retries into the client's `fetch` via **`retryFetch`** instead of registering the deprecated `retryMiddleware`.
- Registering retry as middleware meant a retried response re-entered the middleware chain past anything registered after it, so response-transforming middleware silently skipped retried attempts. Every newly generated client shipped that defect. Wiring it into `fetch` puts retries beneath the chain, so every attempt flows through it.
- **Fixes a pre-existing bug in generated clients:** the emitted order was `use(logMiddleware, retryMiddleware)`. `onResponse` runs in reverse registration order, so `retryMiddleware` threw on non-OK *before* `logMiddleware` ran — meaning **generated clients have never logged a failing response**. The new order is `use(throwOnNotOk(), logMiddleware(...))`, which logs the failure and still throws.
- **Auth-middleware insertion no longer anchors on `retryMiddleware`.** `auth-configurations.ts` located the insertion point by matching a statement containing both `this.client.use(` and `retryMiddleware`; once retry leaves the chain that match fails, `retryStatementIndex === -1`, and insertion silently no-ops — emitting a client with no auth middleware and no error. It now anchors on the `use()` call itself and **throws** when no such statement exists, consistent with the missing-class and missing-constructor errors already in that function.
- Spec fixtures updated to model the shape the generator now emits, plus the `nx-openapi` README and a version plan (minor).

**Other solutions considered (if any)**

- **Anchoring on `logMiddleware` instead** — swaps one name for another and recreates the identical trap against a different middleware that could equally move later.
- **Replacing the AST patching with template-side composition** — immune to the whole anchoring category, but expands this into a generator refactor well beyond the change at hand. The hard error is the cheap guard against the same class of failure.
- Anchoring on `this.client.use(` alone is safe here because `applyAuthMethodConfiguration` runs exactly once per generated client (`generator.ts:121`) against a freshly rendered template containing exactly one `use()` statement. The `retryMiddleware` half of the predicate never added selectivity — only a dependency on a name the generator has no other interest in.

**Notes to reviewers**

- **Draft, and stacked on #255**, which is itself stacked on #252. This PR's base is `feature/retry_fetch_transport`, so the diff shows only the generator commit. GitHub will retarget it automatically as the parents merge.
- **The dependency is release ordering, not CI.** `nx-openapi` does not depend on `microservice-util-lib`, and `client.ts.template` is never compiled, so these 67 tests pass independently of #255. But the emitted client imports `retryFetch` and `throwOnNotOk`, which do not exist until #255 ships — so `microservice-util-lib` must publish first, or in the same release.
- **Existing generated clients are untouched.** `client.ts` is scaffolded on first generation only and preserved on override, so nobody's customised client is rewritten.
- `npm run lint` currently fails on `nx-openapi` with `@nx/dependency-checks` errors about the `@nx/devkit` and `enquirer` version specifiers. **This is pre-existing** — I verified it fails identically on the base branch with these changes stashed — and is out of scope here, but it will likely show red on this PR.
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
