### PR TITLE
MI-331: Fix OAuth 1.0a signature for repeated path params

### DIFF
--- a/.nx/version-plans/version-plan-oauth10a-repeated-path-param.md
+++ b/.nx/version-plans/version-plan-oauth10a-repeated-path-param.md
@@ -1,0 +1,5 @@
+---
+microservice-util-lib: patch
+---
+
+MI-331: Fix `combineUrlAndPathParams` in the OAuth 1.0a signing middleware silently dropping repeated path placeholders. A path template referencing the same param twice (e.g. `/accounts/{id}/orders/{id}`) only had its first occurrence substituted, so the signature base string was built against a URL that was never actually requested — causing the server to reject the request as invalid.

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.test.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.test.ts
@@ -296,18 +296,19 @@ describe('generateOauthParams', () => {
     });
 
     it('resolves every occurrence of a repeated path placeholder in the signed URL', async () => {
-        // A path template that references the same param twice (e.g. a nested
-        // resource shape like /accounts/{id}/orders/{id}/items) must have
-        // *every* occurrence substituted before it's used to build the OAuth
+        // Some multi-store commerce APIs repeat the store code both as a URL
+        // prefix and again within a nested resource segment, e.g.
+        // /{storeCode}/V1/stores/{storeCode}/config. Every occurrence of the
+        // placeholder must be substituted before it's used to build the OAuth
         // signature base string — otherwise the signature is computed for a
         // URL that was never actually requested.
         const request: MiddlewareCallbackParams['request'] = {
             ...baseRequest,
-            url: 'accounts/{id}/orders/{id}',
+            url: '{storeCode}/V1/stores/{storeCode}/config',
             clone: () => ({ ...request }),
         };
         const options: MiddlewareCallbackParams['options'] = { ...baseOptions };
-        const params: MiddlewareCallbackParams['params'] = { path: { id: '123' } };
+        const params: MiddlewareCallbackParams['params'] = { path: { storeCode: 'default' } };
         const config: OAuth10a = {
             algorithm: 'HMAC-SHA1',
             credentials: () => new Promise(res => res(credentialsWithoutToken)),
@@ -330,10 +331,10 @@ describe('generateOauthParams', () => {
         expect(signedBaseString).toBeDefined();
         const decodedBaseString = decodeURIComponent(signedBaseString ?? '');
 
-        // Both occurrences of `{id}` must be resolved, matching the URL that
-        // is actually requested.
-        expect(decodedBaseString).toContain('accounts/123/orders/123');
-        expect(decodedBaseString).not.toContain('{id}');
+        // Both occurrences of `{storeCode}` must be resolved, matching the
+        // URL that is actually requested.
+        expect(decodedBaseString).toContain('default/V1/stores/default/config');
+        expect(decodedBaseString).not.toContain('{storeCode}');
     });
 
     it('generate correct HMAC-SHA256 signature to simple GET request with query parameters that contains space character', async () => {

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.test.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.test.ts
@@ -295,6 +295,47 @@ describe('generateOauthParams', () => {
         expect(result).toEqual(expected);
     });
 
+    it('resolves every occurrence of a repeated path placeholder in the signed URL', async () => {
+        // A path template that references the same param twice (e.g. a nested
+        // resource shape like /accounts/{id}/orders/{id}/items) must have
+        // *every* occurrence substituted before it's used to build the OAuth
+        // signature base string — otherwise the signature is computed for a
+        // URL that was never actually requested.
+        const request: MiddlewareCallbackParams['request'] = {
+            ...baseRequest,
+            url: 'accounts/{id}/orders/{id}',
+            clone: () => ({ ...request }),
+        };
+        const options: MiddlewareCallbackParams['options'] = { ...baseOptions };
+        const params: MiddlewareCallbackParams['params'] = { path: { id: '123' } };
+        const config: OAuth10a = {
+            algorithm: 'HMAC-SHA1',
+            credentials: () => new Promise(res => res(credentialsWithoutToken)),
+        };
+
+        let signedBaseString: string | undefined;
+        const originalCreateHmac = crypto.createHmac;
+        vi.spyOn(crypto, 'createHmac').mockImplementation((algorithm, key) => {
+            const hmac = originalCreateHmac(algorithm, key);
+            const originalUpdate = hmac.update.bind(hmac);
+            hmac.update = ((data: crypto.BinaryLike) => {
+                signedBaseString = data.toString();
+                return originalUpdate(data);
+            }) as typeof hmac.update;
+            return hmac;
+        });
+
+        await generateOauthParams(request, options, params, config);
+
+        expect(signedBaseString).toBeDefined();
+        const decodedBaseString = decodeURIComponent(signedBaseString ?? '');
+
+        // Both occurrences of `{id}` must be resolved, matching the URL that
+        // is actually requested.
+        expect(decodedBaseString).toContain('accounts/123/orders/123');
+        expect(decodedBaseString).not.toContain('{id}');
+    });
+
     it('generate correct HMAC-SHA256 signature to simple GET request with query parameters that contains space character', async () => {
         const request: MiddlewareCallbackParams['request'] = { ...baseRequest };
         const options: MiddlewareCallbackParams['options'] = { ...baseOptions };

--- a/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.ts
+++ b/packages/microservice-util-lib/src/openapi-fetch-middlewares/oauth10a/oauth10a.ts
@@ -105,7 +105,7 @@ function combineUrlAndPathParams(url: string, pathParams?: Record<string, unknow
     }
 
     for (const [key, value] of Object.entries(pathParams)) {
-        url = url.replace(`{${key}}`, String(value));
+        url = url.replaceAll(`{${key}}`, String(value));
     }
 
     return url;


### PR DESCRIPTION
---

**Description of the proposed changes**

- Fix `combineUrlAndPathParams` in the OAuth 1.0a signing middleware: it used a non-global `String.replace`, so a path template referencing the same param twice (e.g. `/accounts/{id}/orders/{id}`) only had its first occurrence substituted before being used to build the signature base string. The unresolved placeholder was signed as literal text, producing a signature for a URL that was never actually requested — causing the server to reject the request.
- Switched to `replaceAll` so every occurrence is resolved.
- Added a regression test (`oauth10a.test.ts`) that captures the actual string fed into the HMAC and asserts both path param occurrences are substituted.

**Screenshots**

N/A

**Other solutions considered (if any)**

N/A — straightforward one-line fix, verified with a red/green TDD cycle.

**Notes to reviewers**

- 🛈 Toggl Code: _MI-331: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
