### PR TITLE
MI-331: Fix path traversal in nx-cdk service generators

### DIFF
--- a/.nx/version-plans/version-plan-nx-cdk-service-name-traversal.md
+++ b/.nx/version-plans/version-plan-nx-cdk-service-name-traversal.md
@@ -1,0 +1,5 @@
+---
+nx-cdk: patch
+---
+
+MI-331: Fix path traversal in the `service` and `remove-service` generators. Neither validated the `name` option before using it to build filesystem paths (`services/${name}`), and Nx's `Tree` does not sandbox `..` segments — a name like `../../etc` could write or delete files outside the `services/` directory, or outside the workspace entirely. Added a shared `assertValidServiceName` runtime guard restricting names to `[a-z0-9-]+`, plus matching `pattern` constraints on both generators' `schema.json` so the CLI prompt rejects an unsafe name up front.

--- a/packages/nx-cdk/src/generators/helpers/utilities.ts
+++ b/packages/nx-cdk/src/generators/helpers/utilities.ts
@@ -332,3 +332,22 @@ export function removeTsConfigReference(tree: Tree, referencePath: string) {
 export function splitInputName(name: string) {
     return name.split('-').map(part => part.charAt(0).toUpperCase() + part.slice(1));
 }
+
+const SAFE_SERVICE_NAME = /^[a-z0-9-]+$/;
+
+/**
+ * Validates that a service name is safe to use when building filesystem
+ * paths. `Tree` does not sandbox `..` segments, so an unvalidated name
+ * (e.g. "../../etc") can escape the services directory during file
+ * generation or deletion.
+ *
+ * @throws {Error} If the name contains anything other than lowercase
+ * alphanumeric characters and dashes.
+ */
+export function assertValidServiceName(name: string): void {
+    if (!SAFE_SERVICE_NAME.test(name)) {
+        throw new Error(
+            `Invalid service name "${name}". Service names must contain only lowercase alphanumeric characters and dashes.`
+        );
+    }
+}

--- a/packages/nx-cdk/src/generators/remove-service/generator.spec.ts
+++ b/packages/nx-cdk/src/generators/remove-service/generator.spec.ts
@@ -197,6 +197,12 @@ describe('remove generator', () => {
         ).rejects.toThrow(/Service "non-existent" does not exist/);
     });
 
+    it('should reject a name that attempts to traverse outside the services directory', async () => {
+        await expect(
+            removeGenerator(tree, { name: '../../outside-workspace', forceRemove: true })
+        ).rejects.toThrow(/Invalid service name/);
+    });
+
     it('should proceed when service has no dependents and forceRemove is false', async () => {
         vi.spyOn(devkit, 'createProjectGraphAsync').mockResolvedValue({
             nodes: {},

--- a/packages/nx-cdk/src/generators/remove-service/generator.ts
+++ b/packages/nx-cdk/src/generators/remove-service/generator.ts
@@ -1,6 +1,7 @@
 import { createProjectGraphAsync, formatFiles, Tree, updateJson } from '@nx/devkit';
 import { MAIN_APPLICATION_NAME, SERVICES_FOLDER, SERVICES_SCOPE } from '../constants';
 import {
+    assertValidServiceName,
     removeBundleDependency,
     removeServiceFromMainApplication,
     removeTsConfigReference,
@@ -9,6 +10,8 @@ import { RemoveGeneratorSchema } from './schema';
 
 export async function removeGenerator(tree: Tree, options: RemoveGeneratorSchema) {
     const { name, forceRemove } = options;
+
+    assertValidServiceName(name);
 
     const projectRoot = `${SERVICES_FOLDER}/${name}`;
     const projectName = `${SERVICES_SCOPE}/${name}`;

--- a/packages/nx-cdk/src/generators/remove-service/schema.json
+++ b/packages/nx-cdk/src/generators/remove-service/schema.json
@@ -11,7 +11,9 @@
                 "$source": "argv",
                 "index": 0
             },
-            "x-prompt": "What is the name of the service to remove?"
+            "x-prompt": "What is the name of the service to remove?",
+            "pattern": "^[a-z0-9-]+$",
+            "patternErrorMessage": "Service name must contain only lowercase alphanumeric characters and dashes"
         },
         "forceRemove": {
             "type": "boolean",

--- a/packages/nx-cdk/src/generators/service/generator.spec.ts
+++ b/packages/nx-cdk/src/generators/service/generator.spec.ts
@@ -57,6 +57,12 @@ describe('service generator', () => {
         );
     });
 
+    it('should reject a name that attempts to traverse outside the services directory', async () => {
+        const options: ServiceGeneratorSchema = { name: '../../outside-workspace' };
+
+        await expect(serviceGenerator(tree, options)).rejects.toThrow(/Invalid service name/);
+    });
+
     it('should add the service to application bundleDependencies', async () => {
         const options: ServiceGeneratorSchema = { name: 'test' };
 

--- a/packages/nx-cdk/src/generators/service/generator.ts
+++ b/packages/nx-cdk/src/generators/service/generator.ts
@@ -4,6 +4,7 @@ import { MAIN_APPLICATION_NAME, SERVICES_FOLDER } from '../constants';
 import {
     addBundleDependency,
     addServiceStackToMainApplication,
+    assertValidServiceName,
     constructProjectTsConfigFiles,
     splitInputName,
 } from '../helpers/utilities';
@@ -26,6 +27,8 @@ function addTsConfigReference(tree: Tree, referencePath: string) {
 }
 
 export async function serviceGenerator(tree: Tree, options: ServiceGeneratorSchema) {
+    assertValidServiceName(options.name);
+
     const projectRoot = `${SERVICES_FOLDER}/${options.name}`;
     const nameParts = splitInputName(options.name);
 

--- a/packages/nx-cdk/src/generators/service/schema.json
+++ b/packages/nx-cdk/src/generators/service/schema.json
@@ -12,8 +12,8 @@
                 "index": 0
             },
             "x-prompt": "What is the name of the service?",
-            "pattern": "^(?!.*[Ss]tack|.*[Ss]ervice).*$",
-            "patternErrorMessage": "Service name cannot contain '[Ss]tack' or '[Ss]ervice'"
+            "pattern": "^(?!.*[Ss]tack|.*[Ss]ervice)[a-z0-9-]+$",
+            "patternErrorMessage": "Service name must contain only lowercase alphanumeric characters and dashes, and cannot contain '[Ss]tack' or '[Ss]ervice'"
         },
         "example": {
             "type": "boolean",


### PR DESCRIPTION
---

**Description of the proposed changes**

- Fix path traversal in the `service` and `remove-service` nx-cdk generators. Neither validated the `name` option before using it to build filesystem paths (`services/${name}`), and Nx's `Tree` does not sandbox `..` segments — a name like `../../etc` could write or delete files outside the `services/` directory, or outside the workspace entirely. `remove-service` in particular hands the resulting path straight to `tree.delete()`.
- Added a shared `assertValidServiceName` runtime guard in `helpers/utilities.ts`, restricting names to `[a-z0-9-]+`, called at the top of both generators before any path is constructed.
- Tightened both generators' `schema.json` `pattern` so the CLI's own prompt validation rejects an unsafe name up front (matches the existing convention already used by the `preset` generator).
- Added regression tests to both `generator.spec.ts` files confirming a traversal-style name is rejected.

**Screenshots**

N/A

**Other solutions considered (if any)**

Considered relying on the `schema.json` pattern alone, but that's only enforced by the Nx CLI's ajv validation when run through `nx generate` — it doesn't protect a generator invoked programmatically (as our own test suite does). Added the runtime guard as the actual fix and the schema pattern as a complementary UX-level check.

**Notes to reviewers**

- 🛈 Toggl Code: _MI-331: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
