### PR TITLE
MI-337: Update root nx.json for new create-workspaces

### DIFF
--- a/.nx/version-plans/version-plan-1787795600241.md
+++ b/.nx/version-plans/version-plan-1787795600241.md
@@ -1,0 +1,7 @@
+---
+nx-cdk: patch
+---
+
+fix for root nx json in new create-workspace
+
+- Swapped CDK DependsOn `params: 'forward' -> params: 'ignore'`

--- a/packages/nx-cdk/src/generators/helpers/configs/nxJson.ts
+++ b/packages/nx-cdk/src/generators/helpers/configs/nxJson.ts
@@ -44,7 +44,7 @@ export const NX_JSON: NxJsonConfiguration = {
             outputs: ['{projectRoot}/out-tsc'],
         },
         cdk: {
-            dependsOn: [{ target: 'build', params: 'forward', projects: `${SERVICES_SCOPE}/*` }],
+            dependsOn: [{ target: 'build', params: 'ignore', projects: `${SERVICES_SCOPE}/*` }],
         },
     },
 } as const;


### PR DESCRIPTION
**Description of the proposed changes**
Currently after creating a brand new workspace with `npx @aligent/create-workspace` and then generating a new service. The service wont deploy to playground.
There are errors about unknown options being passed in from `"pg:deploy": "nx run application:cdk -- deploy --method=direct --require-approval never --profile playground"`

**Notes to reviewers**
I wasnt able to get Verdaccio running locally to test this change to the package.

- 🛈 Toggl Code: _MI-337: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
