### PR TITLE
MI-338: Add lambda-test-utils package for testing API Gateway Lambda handlers

### DIFF
--- a/.nx/version-plans/version-plan-1787876539199.md
+++ b/.nx/version-plans/version-plan-1787876539199.md
@@ -1,0 +1,10 @@
+---
+lambda-test-utils: minor
+---
+
+MI-338: Add lambda-test-utils package for testing API Gateway Lambda handlers
+
+- `buildApiGatewayEvent` builds a valid `APIGatewayProxyEvent` with sensible, deep-mergeable defaults
+- `withJsonBody` sets a JSON-stringified body and `content-type` header
+- `buildLambdaContext` builds a valid Lambda `Context` with sensible defaults
+- `invokeApiGatewayHandler` invokes a handler and returns a parsed `InvokedResponse`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Aligent's TypeScript monorepo for microservice development utilities.
 | `packages/appbuilder-util-lib`   | Adobe App Builder utilities (logging, DB, files, state, auth) |
 | `packages/aws-wrappers`          | Opinionated AWS SDK wrappers with Powertools logging + X-Ray  |
 | `packages/create-workspace`      | CLI scaffolding tool for new Nx workspaces                    |
+| `packages/lambda-test-utils`     | Test utilities for API Gateway-attached Lambda handlers       |
 | `packages/microservice-util-lib` | Core utilities (AWS SDK, OAuth, OpenAPI clients)              |
 | `packages/nx-appbuilder`         | Nx plugin with generators for Adobe App Builder apps          |
 | `packages/nx-cdk`                | Nx plugin with generators for AWS CDK projects                |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Aligent's monorepo for Microservice Development Utilities. For more details abou
 - [App Builder Util Lib](/packages/appbuilder-util-lib/README.md)
 - [AWS Wrappers](/packages/aws-wrappers/README.md)
 - [Create Workspace](/packages/create-workspace/README.md)
+- [Lambda Test Utils](/packages/lambda-test-utils/README.md)
 - [Microservice Util Lib](/packages/microservice-util-lib/README.md)
 - [Nx App Builder](/packages/nx-appbuilder/README.md)
 - [Nx CDK](/packages/nx-cdk/README.md)
@@ -45,6 +46,7 @@ microservice-development-utilities/
 │   ├── appbuilder-util-lib/    # Adobe App Builder utility library
 │   ├── aws-wrappers/           # Opinionated AWS SDK wrappers with logging + X-Ray
 │   ├── create-workspace/       # Workspace scaffolding tool
+│   ├── lambda-test-utils/      # Test utilities for API Gateway Lambda handlers
 │   ├── microservice-util-lib/  # Utility library for microservices
 │   ├── nx-appbuilder/          # Nx plugin with generators for Adobe App Builder apps
 │   ├── nx-cdk/                 # Nx plugin for CDK project generation

--- a/package-lock.json
+++ b/package-lock.json
@@ -308,6 +308,10 @@
       "resolved": "packages/create-workspace",
       "link": true
     },
+    "node_modules/@aligent/lambda-test-utils": {
+      "resolved": "packages/lambda-test-utils",
+      "link": true
+    },
     "node_modules/@aligent/microservice-util-lib": {
       "resolved": "packages/microservice-util-lib",
       "link": true
@@ -7213,6 +7217,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.162",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.162.tgz",
+      "integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -21574,6 +21584,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "packages/lambda-test-utils": {
+      "name": "@aligent/lambda-test-utils",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/aws-lambda": "^8.10.162"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/microservice-util-lib": {

--- a/packages/lambda-test-utils/CLAUDE.md
+++ b/packages/lambda-test-utils/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md — @aligent/lambda-test-utils
+
+Guidance for Claude Code when working in this package. Read alongside the repo-root `CLAUDE.md`.
+
+## Purpose
+
+API Gateway-attached Lambda handlers tend to get skipped by unit tests because they're treated as integration tests. This package builds a valid `APIGatewayProxyEvent` and Lambda `Context`, invokes the handler under test with them, and hands back a parsed response — so handler authors can assert input/output without standing up a real HTTP layer.
+
+Scope is deliberately narrow: input/output assertions only. Mocking side effects (S3, DynamoDB, etc.) stays the test author's responsibility, outside this harness, and there is no real HTTP-layer emulation (no supertest / local server). See "Out of scope" below.
+
+## Layout
+
+```
+packages/lambda-test-utils/src/
+├── event.ts          # buildApiGatewayEvent, withJsonBody
+├── event.test.ts
+├── context.ts         # buildLambdaContext
+├── context.test.ts
+├── invoke.ts          # invokeApiGatewayHandler, InvokedResponse
+├── invoke.test.ts
+├── util/
+│   ├── deep-merge.ts  # internal-only, not exported from index.ts
+│   └── deep-merge.test.ts
+└── index.ts           # named exports of the public API
+```
+
+One file per exported concept, flat — no service-style subfolders (unlike `aws-wrappers`), since there's a small, fixed set of functions rather than a growing set of per-service wrappers. `util/` holds internal helpers only; nothing in it is re-exported from `index.ts`.
+
+## Build layout
+
+The package is **dual-published** as both CommonJS and ES modules via `@nx/rollup`, following the same pattern as `aws-wrappers` (see `packages/aws-wrappers/CLAUDE.md` under "Build layout" for the full rationale). The short version:
+
+- `rollup.config.mjs` invokes `withNx` twice — once per format — emitting `dist/cjs` and `dist/esm`.
+- Unlike `aws-wrappers`, there is **no `./testing` subpath** — this package has a single entry point (`src/index.ts`), since the whole package *is* test scaffolding; there's no split between production code and a test-only helper.
+- `package.json` `exports` routes ESM consumers to `dist/esm/` and CJS consumers to `dist/cjs/`, each with its own `.d.ts`.
+- `tsconfig.lib.json` / `tsconfig.spec.json` override `module: ESNext` / `moduleResolution: Bundler` / `target: ES2022`, mirroring `aws-wrappers` for the same reasons (rollup is the bundler; ES5 fallback would emit IIFE classes).
+- Relative imports in `src/` use the `.js` extension (e.g. `./util/deep-merge.js`) — required for ESM consumer resolution under Node16/NodeNext. Test files omit it, matching the rest of the repo's test-file convention.
+
+This package is published as a **devDependency** for consuming service projects — it never ships in a Lambda bundle, so bundle size for the package itself isn't a driving concern the way it is for `aws-wrappers`' `./testing` subpath. `@types/aws-lambda` is a regular `dependencies` entry (not `devDependencies`) purely so its ambient types (`Context`, `APIGatewayProxyEvent`, `Handler`) resolve transitively for consumers — it contributes no runtime code.
+
+## Locked-in conventions
+
+### Deep-merge overrides, not shallow replace
+
+`buildApiGatewayEvent` and `buildLambdaContext` both deep-merge `overrides` onto their defaults via `util/deep-merge.ts`, rather than a shallow `{ ...defaults, ...overrides }`. This is load-bearing: `APIGatewayProxyEvent.requestContext` and `Context` both nest several required fields (`requestContext.identity.sourceIp`, etc.), and a shallow merge would let a caller silently drop sibling defaults by overriding one nested field. Plain objects recurse; arrays and primitives are replaced outright — an override completely replaces a default array rather than attempting element-wise merging (see `deepMerge`'s TSDoc).
+
+`deepMerge`'s public signature takes `overrides?: DeepPartial<NoInfer<T>>` rather than `Partial<T>`. The `NoInfer` wrapper is required — without it, TypeScript infers the generic `T` from *both* the `base` and `overrides` parameters, and picks up the looser (fully-optional) shape from `overrides`, defeating the return type. Removing it re-introduces a real type hole; don't "simplify" this away.
+
+### `invokeApiGatewayHandler` supports both handler styles
+
+The `Handler` type from `@types/aws-lambda` allows either a returned `Promise` or a NodeJS-style `callback`. `invokeApiGatewayHandler` races both: it always passes a callback, and separately checks whether the handler's return value is promise-like. Real Lambda handlers only ever use one style, so only one path resolves per call — but the implementation doesn't assume which, since dropping the callback path (or the promise path) would silently break handlers written in the other style.
+
+### `json<T>()` throws on non-JSON bodies
+
+`InvokedResponse.json<T>()` wraps `JSON.parse` failures in a new `Error` with a `cause`, per the acceptance criteria for a "clear error on non-JSON bodies" (MI-338). Don't let a `JSON.parse` `SyntaxError` propagate unwrapped — the message doesn't include the offending body, which is the useful part for a failing test.
+
+## Adding a new builder or assertion helper
+
+1. **Confirm it's still input/output-only.** If the ask involves mocking a side effect (S3, DynamoDB, SQS, etc.) or spinning up a real HTTP layer, that's out of scope for this package — raise it with the user rather than growing the harness. See "Out of scope" below.
+2. **One file per concept**, following the existing flat layout — don't introduce subfolders unless the package outgrows a handful of files.
+3. **Deep-merge, don't shallow-merge**, if the new builder produces a nested object with sensible defaults a caller might want to partially override. Reuse `util/deep-merge.ts` rather than hand-rolling another merge.
+4. **Add a named export to `src/index.ts`.**
+5. **Add tests** covering the default-construction path and any override behaviour. The workspace coverage gate is 80% global; this package currently sits at 100%, so a new export without tests will fail the gate.
+6. **Update the package `README.md`** with a usage example — this package is consumed by other teams writing Lambda tests, so the README is the primary discoverability surface.
+7. **Run** `npx nx run lambda-test-utils:lint --fix`, `:typecheck`, `:test --coverage`.
+
+## Testing notes
+
+- No AWS SDK mocking is needed in this package's own tests — it builds plain data (events, contexts) and invokes plain functions. Tests exercise the builders directly and `invokeApiGatewayHandler` against small inline handler functions (both async and callback-style) defined per test.
+- Cover both completion paths of `invokeApiGatewayHandler` when touching it: a handler that returns a promise, and one that only uses the callback — plus the callback's error branch (`Error`, string, and "completed without a result") and a thrown rejection from an async handler.
+
+## Out of scope
+
+These were explicitly ruled out when the package was designed (MI-338) and should be raised with the user before being added:
+
+- Mocking side effects — S3, DynamoDB, or any other AWS SDK call a handler under test makes. That's the test author's own responsibility, using whatever mocking approach fits their handler (e.g. `aws-sdk-client-mock`).
+- Real HTTP-layer emulation (`supertest`, a local server, or similar) — this package only ever calls the handler function directly.
+- Event/context builders for non-API-Gateway trigger types (SQS, EventBridge, S3, etc.) — nothing in this package currently supports them; adding one is a scope change worth raising explicitly, not an obvious extension of the existing builders.

--- a/packages/lambda-test-utils/README.md
+++ b/packages/lambda-test-utils/README.md
@@ -1,0 +1,76 @@
+# @aligent/lambda-test-utils
+
+Small, dependency-light test utilities for asserting the input/output of API Gateway-attached Lambda handlers without standing up a real HTTP layer.
+
+API Gateway handlers tend to get skipped by unit tests because they're treated as integration tests. This package builds a valid `APIGatewayProxyEvent` and Lambda `Context`, invokes your handler with them, and hands back a parsed response — so you can unit test the handler directly.
+
+Scope is limited to input/output assertions. Mocking side effects (S3, DynamoDB, etc.) stays the test author's responsibility, outside this harness. There's no real HTTP-layer emulation (no supertest / local server).
+
+## Installation
+
+```sh
+npm install --save-dev @aligent/lambda-test-utils
+```
+
+Requires **Node 18 or later**.
+
+## Usage
+
+```ts
+import { invokeApiGatewayHandler, withJsonBody } from '@aligent/lambda-test-utils';
+import { handler } from './create-order';
+
+it('creates an order and returns its id', async () => {
+    const response = await invokeApiGatewayHandler(
+        handler,
+        withJsonBody({ httpMethod: 'POST', path: '/orders' }, { sku: 'ABC-123', quantity: 2 })
+    );
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json<{ orderId: string }>()).toEqual({ orderId: expect.any(String) });
+});
+```
+
+### Building an event directly
+
+```ts
+import { buildApiGatewayEvent } from '@aligent/lambda-test-utils';
+
+const event = buildApiGatewayEvent({
+    httpMethod: 'GET',
+    path: '/orders/123',
+    pathParameters: { orderId: '123' },
+});
+```
+
+`overrides` is deep-merged onto the built-in defaults, so overriding one field of `headers` or `requestContext` doesn't drop the rest of the defaults.
+
+### Building a context directly
+
+```ts
+import { buildLambdaContext } from '@aligent/lambda-test-utils';
+
+const context = buildLambdaContext({ functionName: 'create-order', memoryLimitInMB: '256' });
+```
+
+### `InvokedResponse`
+
+`invokeApiGatewayHandler` resolves an `InvokedResponse`:
+
+```ts
+interface InvokedResponse {
+    statusCode: number;
+    headers: APIGatewayProxyResult['headers'];
+    body: string;
+    json<T>(): T;
+}
+```
+
+`json()` parses `body` as JSON and throws a clear error if the body isn't valid JSON.
+
+## Testing & Linting
+
+```sh
+npm run test
+npm run lint
+```

--- a/packages/lambda-test-utils/docs/functions/buildApiGatewayEvent.md
+++ b/packages/lambda-test-utils/docs/functions/buildApiGatewayEvent.md
@@ -1,0 +1,26 @@
+[**@aligent/lambda-test-utils**](../modules.md)
+
+***
+
+[@aligent/lambda-test-utils](../modules.md) / buildApiGatewayEvent
+
+# Function: buildApiGatewayEvent()
+
+> **buildApiGatewayEvent**(`overrides?`): `APIGatewayProxyEvent`
+
+Defined in: event.ts:48
+
+Builds a valid APIGatewayProxyEvent with sensible defaults for a
+REST API proxy integration. `overrides` is deep-merged onto the defaults,
+so a partial `requestContext` or `headers` override doesn't drop sibling
+default fields.
+
+## Parameters
+
+### overrides?
+
+`Partial`\<`APIGatewayProxyEvent`\>
+
+## Returns
+
+`APIGatewayProxyEvent`

--- a/packages/lambda-test-utils/docs/functions/buildLambdaContext.md
+++ b/packages/lambda-test-utils/docs/functions/buildLambdaContext.md
@@ -1,0 +1,24 @@
+[**@aligent/lambda-test-utils**](../modules.md)
+
+***
+
+[@aligent/lambda-test-utils](../modules.md) / buildLambdaContext
+
+# Function: buildLambdaContext()
+
+> **buildLambdaContext**(`overrides?`): `Context`
+
+Defined in: context.ts:9
+
+Builds a valid Lambda Context with sensible defaults. `overrides`
+is deep-merged onto the defaults.
+
+## Parameters
+
+### overrides?
+
+`Partial`\<`Context`\>
+
+## Returns
+
+`Context`

--- a/packages/lambda-test-utils/docs/functions/invokeApiGatewayHandler.md
+++ b/packages/lambda-test-utils/docs/functions/invokeApiGatewayHandler.md
@@ -1,0 +1,33 @@
+[**@aligent/lambda-test-utils**](../modules.md)
+
+***
+
+[@aligent/lambda-test-utils](../modules.md) / invokeApiGatewayHandler
+
+# Function: invokeApiGatewayHandler()
+
+> **invokeApiGatewayHandler**(`handler`, `eventOverrides?`, `contextOverrides?`): `Promise`\<[`InvokedResponse`](../interfaces/InvokedResponse.md)\>
+
+Defined in: invoke.ts:26
+
+Invokes an API Gateway proxy handler with a built event/context and
+resolves whichever completion path the handler uses — a returned promise
+or the NodeJS-style callback.
+
+## Parameters
+
+### handler
+
+`Handler`\<`APIGatewayProxyEvent`, `APIGatewayProxyResult`\>
+
+### eventOverrides?
+
+`Partial`\<`APIGatewayProxyEvent`\>
+
+### contextOverrides?
+
+`Partial`\<`Context`\>
+
+## Returns
+
+`Promise`\<[`InvokedResponse`](../interfaces/InvokedResponse.md)\>

--- a/packages/lambda-test-utils/docs/functions/withJsonBody.md
+++ b/packages/lambda-test-utils/docs/functions/withJsonBody.md
@@ -1,0 +1,28 @@
+[**@aligent/lambda-test-utils**](../modules.md)
+
+***
+
+[@aligent/lambda-test-utils](../modules.md) / withJsonBody
+
+# Function: withJsonBody()
+
+> **withJsonBody**(`event`, `body`): `Partial`\<`APIGatewayProxyEvent`\>
+
+Defined in: event.ts:73
+
+Sets a JSON-stringified `body` and the matching `content-type` header on
+an event (or partial event overrides destined for [buildApiGatewayEvent](buildApiGatewayEvent.md)).
+
+## Parameters
+
+### event
+
+`Partial`\<`APIGatewayProxyEvent`\>
+
+### body
+
+`unknown`
+
+## Returns
+
+`Partial`\<`APIGatewayProxyEvent`\>

--- a/packages/lambda-test-utils/docs/interfaces/InvokedResponse.md
+++ b/packages/lambda-test-utils/docs/interfaces/InvokedResponse.md
@@ -1,0 +1,59 @@
+[**@aligent/lambda-test-utils**](../modules.md)
+
+***
+
+[@aligent/lambda-test-utils](../modules.md) / InvokedResponse
+
+# Interface: InvokedResponse
+
+Defined in: invoke.ts:6
+
+## Properties
+
+<a id="body"></a>
+
+### body
+
+> **body**: `string`
+
+Defined in: invoke.ts:9
+
+***
+
+<a id="headers"></a>
+
+### headers
+
+> **headers**: \{\[`header`: `string`\]: `string` \| `number` \| `boolean`; \} \| `undefined`
+
+Defined in: invoke.ts:8
+
+***
+
+<a id="statuscode"></a>
+
+### statusCode
+
+> **statusCode**: `number`
+
+Defined in: invoke.ts:7
+
+## Methods
+
+<a id="json"></a>
+
+### json()
+
+> **json**\<`T`\>(): `T`
+
+Defined in: invoke.ts:10
+
+#### Type Parameters
+
+##### T
+
+`T`
+
+#### Returns
+
+`T`

--- a/packages/lambda-test-utils/docs/modules.md
+++ b/packages/lambda-test-utils/docs/modules.md
@@ -1,0 +1,16 @@
+**@aligent/lambda-test-utils**
+
+***
+
+# @aligent/lambda-test-utils
+
+## Interfaces
+
+- [InvokedResponse](interfaces/InvokedResponse.md)
+
+## Functions
+
+- [buildApiGatewayEvent](functions/buildApiGatewayEvent.md)
+- [buildLambdaContext](functions/buildLambdaContext.md)
+- [invokeApiGatewayHandler](functions/invokeApiGatewayHandler.md)
+- [withJsonBody](functions/withJsonBody.md)

--- a/packages/lambda-test-utils/eslint.config.mjs
+++ b/packages/lambda-test-utils/eslint.config.mjs
@@ -1,0 +1,21 @@
+import nxEslintPlugin from '@nx/eslint-plugin';
+import jsonParser from 'jsonc-eslint-parser';
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+    ...baseConfig,
+    {
+        files: ['./package.json'],
+        plugins: { '@nx': nxEslintPlugin },
+        rules: {
+            '@nx/dependency-checks': ['error', { ignoredFiles: ['{projectRoot}/*.{js,cjs,mjs}'] }],
+        },
+        languageOptions: { parser: jsonParser },
+    },
+    {
+        files: ['./package.json', './generators.json'],
+        plugins: { '@nx': nxEslintPlugin },
+        rules: { '@nx/nx-plugin-checks': 'error' },
+        languageOptions: { parser: jsonParser },
+    },
+];

--- a/packages/lambda-test-utils/package.json
+++ b/packages/lambda-test-utils/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@aligent/lambda-test-utils",
+  "version": "0.1.0",
+  "description": "Test utilities for asserting API Gateway Lambda handler input/output without a real HTTP layer",
+  "engines": {
+    "node": ">=18"
+  },
+  "main": "./cjs/index.cjs",
+  "module": "./esm/index.mjs",
+  "types": "./cjs/src/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./esm/src/index.d.ts",
+        "default": "./esm/index.mjs"
+      },
+      "require": {
+        "types": "./cjs/src/index.d.ts",
+        "default": "./cjs/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "cjs",
+    "esm",
+    "README.md",
+    "docs"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aligent/microservice-development-utilities.git",
+    "directory": "packages/lambda-test-utils"
+  },
+  "dependencies": {
+    "@types/aws-lambda": "^8.10.162"
+  },
+  "author": "Aligent",
+  "license": "MIT"
+}

--- a/packages/lambda-test-utils/project.json
+++ b/packages/lambda-test-utils/project.json
@@ -1,0 +1,50 @@
+{
+    "name": "lambda-test-utils",
+    "$schema": "../../node_modules/nx/schemas/project-schema.json",
+    "projectType": "library",
+    "sourceRoot": "packages/lambda-test-utils/src",
+    "targets": {
+        "build": {
+            "dependsOn": ["package-dist"]
+        },
+        "package-dist": {
+            "dependsOn": ["typedoc"],
+            "executor": "nx:run-commands",
+            "outputs": [
+                "{projectRoot}/dist/package.json",
+                "{projectRoot}/dist/README.md",
+                "{projectRoot}/dist/docs"
+            ],
+            "inputs": [
+                "{projectRoot}/package.json",
+                "{projectRoot}/README.md",
+                "{projectRoot}/docs/**/*"
+            ],
+            "cache": true,
+            "options": {
+                "cwd": "{projectRoot}",
+                "parallel": false,
+                "commands": [
+                    "mkdir -p dist",
+                    "cp package.json dist/package.json",
+                    "cp README.md dist/README.md",
+                    "rm -rf dist/docs && cp -R docs dist/docs"
+                ]
+            }
+        },
+        "typedoc": {
+            "executor": "nx:run-commands",
+            "options": {
+                "cwd": "{projectRoot}",
+                "color": true,
+                "command": "typedoc --options ./typedoc.config.mjs"
+            }
+        },
+        "nx-release-publish": {
+            "options": {
+                "packageRoot": "{projectRoot}/dist"
+            }
+        }
+    },
+    "tags": ["library"]
+}

--- a/packages/lambda-test-utils/rollup.config.mjs
+++ b/packages/lambda-test-utils/rollup.config.mjs
@@ -1,0 +1,19 @@
+import { withNx } from '@nx/rollup/with-nx.js';
+
+const baseOptions = {
+    main: './src/index.ts',
+    tsConfig: './tsconfig.lib.json',
+    compiler: 'tsc',
+    assets: [],
+};
+
+export default [
+    withNx(
+        { ...baseOptions, outputPath: './dist/esm', format: ['esm'] },
+        { output: { entryFileNames: '[name].mjs', chunkFileNames: '[name].mjs' } }
+    ),
+    withNx(
+        { ...baseOptions, outputPath: './dist/cjs', format: ['cjs'] },
+        { output: { entryFileNames: '[name].cjs', chunkFileNames: '[name].cjs' } }
+    ),
+];

--- a/packages/lambda-test-utils/src/context.test.ts
+++ b/packages/lambda-test-utils/src/context.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { buildLambdaContext } from './context';
+
+describe('buildLambdaContext', () => {
+    it('produces a valid context with sensible defaults', () => {
+        const context = buildLambdaContext();
+
+        expect(context.functionName).toBe('test-function');
+        expect(context.functionVersion).toBe('$LATEST');
+        expect(context.getRemainingTimeInMillis()).toBe(3000);
+    });
+
+    it('applies overrides', () => {
+        const context = buildLambdaContext({ functionName: 'my-handler', memoryLimitInMB: '256' });
+
+        expect(context.functionName).toBe('my-handler');
+        expect(context.memoryLimitInMB).toBe('256');
+        expect(context.awsRequestId).toBe('test-aws-request-id');
+    });
+
+    it('allows overriding getRemainingTimeInMillis', () => {
+        const context = buildLambdaContext({ getRemainingTimeInMillis: () => 42 });
+
+        expect(context.getRemainingTimeInMillis()).toBe(42);
+    });
+
+    it('provides no-op legacy completion methods', () => {
+        const context = buildLambdaContext();
+
+        expect(() => context.done()).not.toThrow();
+        expect(() => context.fail('boom')).not.toThrow();
+        expect(() => context.succeed('ok')).not.toThrow();
+    });
+});

--- a/packages/lambda-test-utils/src/context.ts
+++ b/packages/lambda-test-utils/src/context.ts
@@ -1,0 +1,26 @@
+import type { Context } from 'aws-lambda';
+
+import { deepMerge } from './util/deep-merge.js';
+
+/**
+ * Builds a valid Lambda {@link Context} with sensible defaults. `overrides`
+ * is deep-merged onto the defaults.
+ */
+export function buildLambdaContext(overrides?: Partial<Context>): Context {
+    const defaults: Context = {
+        callbackWaitsForEmptyEventLoop: true,
+        functionName: 'test-function',
+        functionVersion: '$LATEST',
+        invokedFunctionArn: 'arn:aws:lambda:ap-southeast-2:123456789012:function:test-function',
+        memoryLimitInMB: '128',
+        awsRequestId: 'test-aws-request-id',
+        logGroupName: '/aws/lambda/test-function',
+        logStreamName: 'test-log-stream',
+        getRemainingTimeInMillis: () => 3000,
+        done: () => undefined,
+        fail: () => undefined,
+        succeed: () => undefined,
+    };
+
+    return deepMerge(defaults, overrides);
+}

--- a/packages/lambda-test-utils/src/event.test.ts
+++ b/packages/lambda-test-utils/src/event.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { buildApiGatewayEvent, withJsonBody } from './event';
+
+describe('buildApiGatewayEvent', () => {
+    it('produces a valid event with sensible defaults', () => {
+        const event = buildApiGatewayEvent();
+
+        expect(event).toMatchObject({
+            httpMethod: 'GET',
+            path: '/',
+            resource: '/',
+            body: null,
+            isBase64Encoded: false,
+            headers: {},
+            pathParameters: null,
+            queryStringParameters: null,
+        });
+        expect(event.requestContext.accountId).toBe('123456789012');
+        expect(event.requestContext.identity.sourceIp).toBe('127.0.0.1');
+    });
+
+    it('applies top-level overrides', () => {
+        const event = buildApiGatewayEvent({ httpMethod: 'POST', path: '/orders' });
+
+        expect(event.httpMethod).toBe('POST');
+        expect(event.path).toBe('/orders');
+        expect(event.resource).toBe('/');
+    });
+
+    it('merges pathParameters onto the null default', () => {
+        const event = buildApiGatewayEvent({ pathParameters: { id: '123' } });
+
+        expect(event.pathParameters).toEqual({ id: '123' });
+    });
+});
+
+describe('withJsonBody', () => {
+    it('stringifies the body and sets the content-type header', () => {
+        const result = withJsonBody({}, { hello: 'world' });
+
+        expect(result.body).toBe(JSON.stringify({ hello: 'world' }));
+        expect(result.headers).toEqual({ 'content-type': 'application/json' });
+    });
+
+    it('preserves existing headers on the event', () => {
+        const result = withJsonBody(
+            { headers: { authorization: 'Bearer test' } },
+            { hello: 'world' }
+        );
+
+        expect(result.headers).toEqual({
+            authorization: 'Bearer test',
+            'content-type': 'application/json',
+        });
+    });
+
+    it('composes with buildApiGatewayEvent', () => {
+        const event = buildApiGatewayEvent(
+            withJsonBody({ httpMethod: 'POST' }, { hello: 'world' })
+        );
+
+        expect(event.httpMethod).toBe('POST');
+        expect(event.body).toBe(JSON.stringify({ hello: 'world' }));
+        expect(event.headers['content-type']).toBe('application/json');
+    });
+});

--- a/packages/lambda-test-utils/src/event.ts
+++ b/packages/lambda-test-utils/src/event.ts
@@ -1,0 +1,85 @@
+import type {
+    APIGatewayEventIdentity,
+    APIGatewayEventRequestContextWithAuthorizer,
+    APIGatewayProxyEvent,
+} from 'aws-lambda';
+
+import { deepMerge } from './util/deep-merge.js';
+
+const DEFAULT_IDENTITY: APIGatewayEventIdentity = {
+    accessKey: null,
+    accountId: null,
+    apiKey: null,
+    apiKeyId: null,
+    caller: null,
+    clientCert: null,
+    cognitoAuthenticationProvider: null,
+    cognitoAuthenticationType: null,
+    cognitoIdentityId: null,
+    cognitoIdentityPoolId: null,
+    principalOrgId: null,
+    sourceIp: '127.0.0.1',
+    user: null,
+    userAgent: 'lambda-test-utils',
+    userArn: null,
+};
+
+const DEFAULT_REQUEST_CONTEXT: APIGatewayEventRequestContextWithAuthorizer<null> = {
+    accountId: '123456789012',
+    apiId: 'test-api-id',
+    authorizer: null,
+    protocol: 'HTTP/1.1',
+    httpMethod: 'GET',
+    identity: DEFAULT_IDENTITY,
+    path: '/',
+    stage: 'test',
+    requestId: 'test-request-id',
+    requestTimeEpoch: 0,
+    resourceId: 'test-resource-id',
+    resourcePath: '/',
+};
+
+/**
+ * Builds a valid {@link APIGatewayProxyEvent} with sensible defaults for a
+ * REST API proxy integration. `overrides` is deep-merged onto the defaults,
+ * so a partial `requestContext` or `headers` override doesn't drop sibling
+ * default fields.
+ */
+export function buildApiGatewayEvent(
+    overrides?: Partial<APIGatewayProxyEvent>
+): APIGatewayProxyEvent {
+    const defaults: APIGatewayProxyEvent = {
+        body: null,
+        headers: {},
+        multiValueHeaders: {},
+        httpMethod: 'GET',
+        isBase64Encoded: false,
+        path: '/',
+        pathParameters: null,
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        stageVariables: null,
+        requestContext: DEFAULT_REQUEST_CONTEXT,
+        resource: '/',
+    };
+
+    return deepMerge(defaults, overrides);
+}
+
+/**
+ * Sets a JSON-stringified `body` and the matching `content-type` header on
+ * an event (or partial event overrides destined for {@link buildApiGatewayEvent}).
+ */
+export function withJsonBody(
+    event: Partial<APIGatewayProxyEvent>,
+    body: unknown
+): Partial<APIGatewayProxyEvent> {
+    return {
+        ...event,
+        body: JSON.stringify(body),
+        headers: {
+            ...event.headers,
+            'content-type': 'application/json',
+        },
+    };
+}

--- a/packages/lambda-test-utils/src/index.ts
+++ b/packages/lambda-test-utils/src/index.ts
@@ -1,0 +1,4 @@
+export { buildLambdaContext } from './context.js';
+export { buildApiGatewayEvent, withJsonBody } from './event.js';
+export { invokeApiGatewayHandler } from './invoke.js';
+export type { InvokedResponse } from './invoke.js';

--- a/packages/lambda-test-utils/src/invoke.test.ts
+++ b/packages/lambda-test-utils/src/invoke.test.ts
@@ -1,0 +1,109 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, Handler } from 'aws-lambda';
+import { describe, expect, it } from 'vitest';
+import { invokeApiGatewayHandler } from './invoke';
+
+describe('invokeApiGatewayHandler', () => {
+    it('resolves an InvokedResponse for an async handler', async () => {
+        const handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult> = async event => ({
+            statusCode: 200,
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ receivedPath: event.path }),
+        });
+
+        const response = await invokeApiGatewayHandler(handler, { path: '/orders/1' });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.headers).toEqual({ 'content-type': 'application/json' });
+        expect(response.json<{ receivedPath: string }>()).toEqual({ receivedPath: '/orders/1' });
+    });
+
+    it('resolves an InvokedResponse for a callback-style handler', async () => {
+        const handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult> = (
+            _event,
+            _context,
+            callback
+        ) => {
+            callback(null, { statusCode: 201, body: 'created' });
+        };
+
+        const response = await invokeApiGatewayHandler(handler);
+
+        expect(response.statusCode).toBe(201);
+        expect(response.body).toBe('created');
+    });
+
+    it('rejects when the handler calls back with an error', async () => {
+        const handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult> = (
+            _event,
+            _context,
+            callback
+        ) => {
+            callback(new Error('boom'));
+        };
+
+        await expect(invokeApiGatewayHandler(handler)).rejects.toThrow('boom');
+    });
+
+    it('rejects when the handler calls back with a string error', async () => {
+        const handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult> = (
+            _event,
+            _context,
+            callback
+        ) => {
+            callback('boom');
+        };
+
+        await expect(invokeApiGatewayHandler(handler)).rejects.toThrow('boom');
+    });
+
+    it('rejects when the handler calls back without a result', async () => {
+        const handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult> = (
+            _event,
+            _context,
+            callback
+        ) => {
+            callback(null);
+        };
+
+        await expect(invokeApiGatewayHandler(handler)).rejects.toThrow(
+            'Lambda handler completed without a result'
+        );
+    });
+
+    it('rejects when an async handler throws', async () => {
+        const handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult> = async () => {
+            throw new Error('handler failed');
+        };
+
+        await expect(invokeApiGatewayHandler(handler)).rejects.toThrow('handler failed');
+    });
+
+    it('passes context overrides through to the handler', async () => {
+        const handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult> = async (
+            _event,
+            context
+        ) => ({
+            statusCode: 200,
+            body: context.functionName,
+        });
+
+        const response = await invokeApiGatewayHandler(handler, undefined, {
+            functionName: 'my-handler',
+        });
+
+        expect(response.body).toBe('my-handler');
+    });
+
+    describe('json()', () => {
+        it('throws a clear error on a non-JSON body', async () => {
+            const handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult> = async () => ({
+                statusCode: 200,
+                body: 'not json',
+            });
+
+            const response = await invokeApiGatewayHandler(handler);
+
+            expect(() => response.json()).toThrow('Response body is not valid JSON: not json');
+        });
+    });
+});

--- a/packages/lambda-test-utils/src/invoke.ts
+++ b/packages/lambda-test-utils/src/invoke.ts
@@ -1,0 +1,64 @@
+import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context, Handler } from 'aws-lambda';
+
+import { buildLambdaContext } from './context.js';
+import { buildApiGatewayEvent } from './event.js';
+
+export interface InvokedResponse {
+    statusCode: number;
+    headers: APIGatewayProxyResult['headers'];
+    body: string;
+    json<T>(): T;
+}
+
+function isPromiseLike<T>(value: unknown): value is Promise<T> {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        typeof (value as { then?: unknown }).then === 'function'
+    );
+}
+
+/**
+ * Invokes an API Gateway proxy handler with a built event/context and
+ * resolves whichever completion path the handler uses — a returned promise
+ * or the NodeJS-style callback.
+ */
+export async function invokeApiGatewayHandler(
+    handler: Handler<APIGatewayProxyEvent, APIGatewayProxyResult>,
+    eventOverrides?: Partial<APIGatewayProxyEvent>,
+    contextOverrides?: Partial<Context>
+): Promise<InvokedResponse> {
+    const event = buildApiGatewayEvent(eventOverrides);
+    const context = buildLambdaContext(contextOverrides);
+
+    const result = await new Promise<APIGatewayProxyResult>((resolve, reject) => {
+        const returned = handler(event, context, (error, callbackResult) => {
+            if (error) {
+                reject(error instanceof Error ? error : new Error(String(error)));
+                return;
+            }
+            if (callbackResult === undefined) {
+                reject(new Error('Lambda handler completed without a result'));
+                return;
+            }
+            resolve(callbackResult);
+        });
+
+        if (isPromiseLike<APIGatewayProxyResult>(returned)) {
+            returned.then(resolve, reject);
+        }
+    });
+
+    return {
+        statusCode: result.statusCode,
+        headers: result.headers,
+        body: result.body,
+        json<T>(): T {
+            try {
+                return JSON.parse(result.body) as T;
+            } catch (cause) {
+                throw new Error(`Response body is not valid JSON: ${result.body}`, { cause });
+            }
+        },
+    };
+}

--- a/packages/lambda-test-utils/src/util/deep-merge.test.ts
+++ b/packages/lambda-test-utils/src/util/deep-merge.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { deepMerge } from './deep-merge';
+
+describe('deepMerge', () => {
+    it('returns the base unchanged when no overrides are given', () => {
+        const base = { a: 1, b: { c: 2 } };
+
+        expect(deepMerge(base)).toEqual(base);
+    });
+
+    it('replaces primitive fields', () => {
+        expect(deepMerge({ a: 1, b: 2 }, { a: 5 })).toEqual({ a: 5, b: 2 });
+    });
+
+    it('recurses into nested plain objects instead of replacing them', () => {
+        const base = {
+            requestContext: { httpMethod: 'GET', path: '/', identity: { sourceIp: '127.0.0.1' } },
+        };
+
+        const result = deepMerge(base, { requestContext: { httpMethod: 'POST' } });
+
+        expect(result).toEqual({
+            requestContext: { httpMethod: 'POST', path: '/', identity: { sourceIp: '127.0.0.1' } },
+        });
+    });
+
+    it('replaces arrays outright rather than merging them', () => {
+        expect(deepMerge({ items: [1, 2, 3] }, { items: [9] })).toEqual({ items: [9] });
+    });
+
+    it('replaces a base object with null when the override is null', () => {
+        expect(deepMerge<{ a: { b: number } | null }>({ a: { b: 1 } }, { a: null })).toEqual({
+            a: null,
+        });
+    });
+});

--- a/packages/lambda-test-utils/src/util/deep-merge.ts
+++ b/packages/lambda-test-utils/src/util/deep-merge.ts
@@ -1,0 +1,34 @@
+type PlainObject = Record<string, unknown>;
+
+type DeepPartial<T> = T extends readonly unknown[]
+    ? T
+    : T extends object
+      ? { [K in keyof T]?: DeepPartial<T[K]> }
+      : T;
+
+function isPlainObject(value: unknown): value is PlainObject {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Merges `overrides` onto `base`, recursing into nested plain objects
+ * (e.g. `requestContext`, `identity`) so a partial override doesn't wipe
+ * sibling defaults. Arrays and primitives are replaced outright.
+ */
+export function deepMerge<T>(base: T, overrides?: DeepPartial<NoInfer<T>>): T {
+    if (!overrides) {
+        return base;
+    }
+
+    const result: PlainObject = { ...(base as PlainObject) };
+
+    for (const [key, overrideValue] of Object.entries(overrides as PlainObject)) {
+        const baseValue = result[key];
+        result[key] =
+            isPlainObject(baseValue) && isPlainObject(overrideValue)
+                ? deepMerge(baseValue, overrideValue)
+                : overrideValue;
+    }
+
+    return result as T;
+}

--- a/packages/lambda-test-utils/tsconfig.json
+++ b/packages/lambda-test-utils/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "extends": "@aligent/ts-code-standards/tsconfigs-base",
+    "compilerOptions": {
+        "composite": true,
+        "declaration": true
+    },
+    "files": [],
+    "include": [],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
+        }
+    ]
+}

--- a/packages/lambda-test-utils/tsconfig.lib.json
+++ b/packages/lambda-test-utils/tsconfig.lib.json
@@ -1,0 +1,20 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "rootDir": "src",
+        "outDir": "dist",
+        "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+        "types": ["node"],
+        // `target` must be explicit here. The base config sets `module: Node16`,
+        // which implies `target: es2022`; overriding `module` below drops that
+        // implication, and TypeScript falls back to its ES5 default. ES5 emits
+        // classes as IIFEs, which bundlers cannot prove pure.
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "checkJs": false
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["vitest.config.mjs", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/lambda-test-utils/tsconfig.spec.json
+++ b/packages/lambda-test-utils/tsconfig.spec.json
@@ -1,0 +1,17 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./out-tsc/vitest",
+        // Mirrors `tsconfig.lib.json` — see the comment there.
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "types": ["vitest/globals", "vitest/importMeta", "vite/client", "node", "vitest"]
+    },
+    "include": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        }
+    ]
+}

--- a/packages/lambda-test-utils/typedoc.config.mjs
+++ b/packages/lambda-test-utils/typedoc.config.mjs
@@ -1,0 +1,13 @@
+/** @type {Partial<import('typedoc').TypeDocOptions>} */
+const config = {
+    plugin: ['typedoc-plugin-markdown'],
+    entryPoints: ['./src/index.ts'],
+    out: 'docs',
+    readme: 'none',
+    githubPages: false,
+    // The 2 configs below comes from typedoc-plugin-markdown
+    entryFileName: 'modules.md',
+    useHTMLAnchors: true,
+};
+
+export default config;

--- a/packages/lambda-test-utils/vitest.config.mjs
+++ b/packages/lambda-test-utils/vitest.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { vitestBaseConfig } from '../../vitest.config.base.mjs';
+
+export default mergeConfig(
+    vitestBaseConfig,
+    defineConfig({
+        cacheDir: '../../node_modules/.vitest/lambda-test-utils',
+    })
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,9 @@
         },
         {
             "path": "./packages/vite-plugin-handler"
+        },
+        {
+            "path": "./packages/lambda-test-utils"
         }
     ]
 }


### PR DESCRIPTION
---

**Description of the proposed changes**

- New `packages/lambda-test-utils` package, scaffolded via `nx g @tools/generators:package` and built on the `aws-wrappers` dual CJS/ESM rollup pattern
- `buildApiGatewayEvent` builds a valid `APIGatewayProxyEvent` with sensible, deep-mergeable defaults
- `withJsonBody` sets a JSON-stringified body and `content-type` header
- `buildLambdaContext` builds a valid Lambda `Context` with sensible defaults
- `invokeApiGatewayHandler` invokes a handler (async or callback-style) and returns a parsed `InvokedResponse` (`{ statusCode, headers, body, json<T>() }`)
- Unit tests for all exported functions (100% coverage)
- README with a worked example
- Version plan added

**Other solutions considered (if any)**

- N/A

**Notes to reviewers**

- 🛈 Toggl Code: _MI-338: Code Review_
- 🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
- The nx-cdk service generator update (devDependency + example handler test scaffold) is intentionally out of scope here, per the ticket's own note that it can be split into a separate ticket.